### PR TITLE
Finish remaining Dependabot bumps (checkout + frontend patches)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -40,7 +40,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -25,7 +25,7 @@ jobs:
   simulation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # No pip cache: this job's combined key would never be shared with the
       # per-component workflows, so it would only store duplicate wheels.
       - uses: actions/setup-python@v6

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -22,7 +22,7 @@ jobs:
       run:
         working-directory: worker
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1070,9 +1070,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.69.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.1.tgz",
-			"integrity": "sha512-+nz8Fx/cElzb2ZPHC+6Ll3y3NEVIe4Na75PeplLlyTmd1dBXAjz2KR14y1ZgNjb2ThfAYzulu+PFy1UE3RCUzA==",
+			"version": "2.69.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.69.2.tgz",
+			"integrity": "sha512-CMdPDbYjRwRu4KXTxBVMuOpFPCt1i/v0ANennotec+K9Cmb2e3w2yYzJiC6Vh/WSvm9Khi5sJMZa0rJPqfHlDw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2718,9 +2718,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.9.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
-			"integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
+			"version": "3.9.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
+			"integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3131,9 +3131,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.7.1",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.1.tgz",
-			"integrity": "sha512-FGUOmAqxXdN/H9Zm8slrqO7SLtFisXRB7rfOsHNJ3MLTD2po/+Stg8XyErkpumPHbuUiYTcqrEIzxpVWKTLqtg==",
+			"version": "4.7.2",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.7.2.tgz",
+			"integrity": "sha512-GoS4XJdGswlq0rIT1vtFLzJY1bvHtY37McY9H9Gkm1Ggw/ICdZYn8J/Z8Yi0BEL0i3R4+jtaWVePjyppMlij/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3353,16 +3353,16 @@
 			"optional": true
 		},
 		"node_modules/vite": {
-			"version": "8.1.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
-			"integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
+			"version": "8.1.4",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
+			"integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"lightningcss": "^1.32.0",
-				"picomatch": "^4.0.4",
+				"picomatch": "^4.0.5",
 				"postcss": "^8.5.16",
-				"rolldown": "~1.1.3",
+				"rolldown": "~1.1.4",
 				"tinyglobby": "^0.2.17"
 			},
 			"bin": {

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -172,7 +172,9 @@ export function starredGenerations(): Generation[] {
 
 export async function loadStarredGenerations(): Promise<void> {
 	const inHistory = new Set(studio.history.map((generation) => generation.id));
-	const existingById = new Map(studio.starredExtras.map((generation) => [generation.id, generation]));
+	const existingById = new Map(
+		studio.starredExtras.map((generation) => [generation.id, generation])
+	);
 	const outsideHistory = studio.starredIds.filter((id) => !inHistory.has(id));
 	const alreadyLoaded = outsideHistory.flatMap((id) => {
 		const generation = existingById.get(id);


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v7 (setup-node and setup-python already merged via #62/#63)
- Lockfile patches: prettier 3.9.5, @sveltejs/kit 2.69.2, svelte-check 4.7.2, vite 8.1.4
- Format `studio.svelte.ts` — this was the actual CI failure on Dependabot PRs #64 and #66–#69 (lint, not the bumps themselves)

## Why not merge the open Dependabot PRs?
Their CI runs are red because **main** has an unformatted `studio.svelte.ts`. Merging #62/#63 did not fix that. This PR bundles the remaining bumps in one merge-ready commit.

After merging, close #64, #66, #67, #68, #69. Leave #65 (TypeScript 7) open.

## Test plan
- [x] `npm run lint` passes locally
- [x] `npm run check` passes locally
- [ ] CI frontend workflow green on this PR

Made with [Cursor](https://cursor.com)