### PR TITLE
Add a landing site mode for API-less deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ benchmark-publish: ## minify results.json into frontend static assets
 WAITLIST_URL ?= /api/waitlist
 PAGES_PROJECT ?= potocolom
 
-site-build: ## build the frontend with the waitlist endpoint baked in
-	cd frontend && PUBLIC_WAITLIST_URL=$(WAITLIST_URL) npm run build
+site-build: ## build the frontend in landing mode with the waitlist endpoint baked in
+	cd frontend && PUBLIC_WAITLIST_URL=$(WAITLIST_URL) PUBLIC_SITE_MODE=landing npm run build
 
 site-deploy: site-build ## build and deploy the site to Cloudflare Pages
 	cd frontend && npx wrangler pages deploy build --project-name $(PAGES_PROJECT)

--- a/frontend/.env
+++ b/frontend/.env
@@ -2,3 +2,6 @@
 # Real environments override these (actual env vars take precedence over .env).
 # Empty means the waitlist section does not render.
 PUBLIC_WAITLIST_URL=""
+# Empty renders the real studio at /app; "landing" swaps in the static
+# canvas preview for API-less deployments (the marketing site).
+PUBLIC_SITE_MODE=""

--- a/frontend/src/lib/components/studio-preview.svelte
+++ b/frontend/src/lib/components/studio-preview.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import LatentCanvas from '$lib/components/LatentCanvas.svelte';
+	import type { LatentCanvasApi } from '$lib/latent-canvas-scene';
+	import { t } from '$lib/i18n.svelte';
+
+	let leftPanelEl = $state<HTMLDivElement | null>(null);
+	let rightPanelEl = $state<HTMLDivElement | null>(null);
+	let leftCanvasApi = $state<LatentCanvasApi | null>(null);
+	let rightCanvasApi = $state<LatentCanvasApi | null>(null);
+
+	function syncPreviewCursor(event: PointerEvent) {
+		if (!leftPanelEl || !rightPanelEl) return;
+
+		const leftRect = leftPanelEl.getBoundingClientRect();
+		const rightRect = rightPanelEl.getBoundingClientRect();
+
+		leftCanvasApi?.setCursor(event.clientX - leftRect.left, event.clientY - leftRect.top);
+		rightCanvasApi?.setCursor(event.clientX - rightRect.left, event.clientY - rightRect.top);
+	}
+
+	function clearPreviewCursor() {
+		leftCanvasApi?.setCursor(null, null);
+		rightCanvasApi?.setCursor(null, null);
+	}
+</script>
+
+<div
+	class="grid h-full min-h-0 flex-1 cursor-crosshair grid-cols-1 gap-4 md:grid-cols-2"
+	role="presentation"
+	onpointermove={syncPreviewCursor}
+	onpointerleave={clearPreviewCursor}
+>
+	<div
+		bind:this={leftPanelEl}
+		class="border-border/60 relative min-h-0 overflow-hidden rounded-xl border bg-[#070b14]"
+	>
+		<LatentCanvas animate followCursor seed={42} onAttach={(api) => (leftCanvasApi = api)} />
+		<span
+			class="text-foreground/60 bg-background/55 pointer-events-none absolute inset-x-3 bottom-3 rounded-full px-3 py-1 text-center text-[0.65rem] tracking-[0.14em] uppercase backdrop-blur-sm"
+		>
+			{t('app.canvas_hint')}
+		</span>
+	</div>
+	<div
+		bind:this={rightPanelEl}
+		class="border-border/60 relative min-h-0 overflow-hidden rounded-xl border bg-[#070b14]"
+	>
+		<LatentCanvas animate followCursor seed={137} onAttach={(api) => (rightCanvasApi = api)} />
+		<span
+			class="text-foreground/60 bg-background/55 pointer-events-none absolute inset-x-3 bottom-3 rounded-full px-3 py-1 text-center text-[0.65rem] tracking-[0.14em] uppercase backdrop-blur-sm"
+		>
+			{t('app.result_hint')}
+		</span>
+	</div>
+</div>
+<p
+	class="text-foreground/70 pointer-events-none absolute inset-x-6 bottom-5 text-center text-sm leading-relaxed"
+>
+	{t('app.draw_placeholder')}
+</p>

--- a/frontend/src/routes/app/+page.svelte
+++ b/frontend/src/routes/app/+page.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
+	import { PUBLIC_SITE_MODE } from '$env/static/public';
 	import AppSidebar from '$lib/components/app-sidebar.svelte';
 	import GeneratePanel from '$lib/components/generate-panel.svelte';
 	import SiteHeader from '$lib/components/site-header.svelte';
+	import StudioPreview from '$lib/components/studio-preview.svelte';
 	import { t } from '$lib/i18n.svelte';
 	import * as Sidebar from '$lib/components/ui/sidebar';
+
+	// The marketing site (Cloudflare Pages) is a static build with no API
+	// behind it: PUBLIC_SITE_MODE=landing shows the canvas preview instead
+	// of the studio. Product builds leave the variable empty.
+	const landing = PUBLIC_SITE_MODE === 'landing';
 </script>
 
 <svelte:head>
@@ -17,7 +24,11 @@
 			<AppSidebar />
 			<Sidebar.Inset class="min-h-0 overflow-hidden">
 				<div class="relative flex h-full min-h-0 flex-col p-4">
-					<GeneratePanel />
+					{#if landing}
+						<StudioPreview />
+					{:else}
+						<GeneratePanel />
+					{/if}
 				</div>
 			</Sidebar.Inset>
 		</div>


### PR DESCRIPTION
# Description

The marketing site on Cloudflare Pages was building from the shadcn-redesign branch, which no longer exists after the stack merge, freezing production. This PR lets the site build from main: a PUBLIC_SITE_MODE=landing build swaps /app from the real studio to the static canvas preview, which is what the live site shows today.

# Functionality

- frontend/src/lib/components/studio-preview.svelte: the dual LatentCanvas placeholder extracted from the pre-M2 /app page, unchanged markup.
- /app branches on the flag at build time ($env/static/public, same mechanism as PUBLIC_WAITLIST_URL); product builds leave it empty and render the studio.
- make site-build bakes PUBLIC_SITE_MODE=landing alongside the waitlist URL.
- frontend/.env carries the empty default so unconfigured builds keep the studio.

# Details

Verified with headless Chrome against vite preview: the landing build renders the canvas placeholder strings and no studio, the default build renders the Generate panel. svelte-check 0 errors, prettier clean.

After merging, the Cloudflare dashboard needs two changes: production branch set to main with PUBLIC_SITE_MODE=landing and PUBLIC_WAITLIST_URL=/api/waitlist in the build environment, and preview builds restricted to pull requests. make site-deploy keeps working for manual direct uploads.