### PR TITLE
Job execution watchdog for stuck running jobs

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -280,7 +280,13 @@ async def sweep_stalled_jobs() -> None:
         live_progress.pop(job_id, None)
         last_progress_at.pop(job_id, None)
         entry.worker.job_busy = False
-        await requeue_or_fail(job_id, f"no progress for {stall:.0f}s")
+        try:
+            await requeue_or_fail(job_id, f"no progress for {stall:.0f}s")
+        except Exception:
+            # De-tracked above; hand the job to the lost_jobs conduit so the
+            # next dispatch step retries the requeue instead of stranding it.
+            lost_jobs.append(job_id)
+            raise
 
 
 async def dispatch_step() -> None:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -280,7 +280,7 @@ async def sweep_stalled_jobs() -> None:
         live_progress.pop(job_id, None)
         last_progress_at.pop(job_id, None)
         entry.worker.job_busy = False
-        await requeue_or_fail(job_id, "no progress")
+        await requeue_or_fail(job_id, f"no progress for {stall:.0f}s")
 
 
 async def dispatch_step() -> None:
@@ -362,9 +362,12 @@ async def dispatch(job_id: uuid.UUID) -> bool:
 
 async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     job_id = uuid.UUID(control["job_id"])
+    # Only the worker recorded for the attempt may speak for the job: after a
+    # stall requeue the old worker may still be connected and reporting.
+    current = inflight.get(job_id)
+    if current is None or current.worker is not worker:
+        return  # stale report from a previous incarnation or attempt
     if control["type"] == "job_progress":
-        if job_id not in inflight:
-            return
         live_progress[job_id] = float(control.get("progress") or 0.0)
         last_progress_at[job_id] = time.monotonic()
         publish(job_id, {"state": "running", "progress": control.get("progress")})
@@ -373,7 +376,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     live_progress.pop(job_id, None)
     last_progress_at.pop(job_id, None)
     if entry is None:
-        return  # stale report from a previous incarnation
+        return  # finished concurrently
     worker.job_busy = False
     if db.session_factory is None:
         logger.warning("job %s finished on the worker but the database is unavailable",

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -12,6 +12,7 @@ import asyncio
 import heapq
 import json
 import logging
+import time
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -27,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import db, realtime, registry
 from app.auth import current_user
 from app.manifests import validate_params
+from app.settings import get_settings
 from app.storage import get_storage
 from app.tables import Asset, Job, User
 
@@ -84,6 +86,8 @@ def storage_key_in_flight(key: str) -> bool:
 # Latest reported denoising fraction per running job. Transient by design:
 # the job row is the source of truth for state, progress is display only.
 live_progress: dict[uuid.UUID, float] = {}
+# Monotonic timestamp of the last dispatch or job_progress for each inflight job.
+last_progress_at: dict[uuid.UUID, float] = {}
 
 # SSE subscribers per job; events are transient, the job row is the truth.
 subscribers: dict[uuid.UUID, list[asyncio.Queue]] = {}
@@ -137,6 +141,7 @@ async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
             "model_id": job.model_id,
             "params": job.params,
             "state": job.state,
+            "attempt": job.attempt,
             "progress": live_progress.get(job.id) if job.state == "running" else None,
             "gpu_ms": job.gpu_ms,
             "created_at": job.created_at.isoformat(),
@@ -259,11 +264,31 @@ async def dispatch_loop() -> None:
             logger.exception("dispatch step failed")
 
 
+async def sweep_stalled_jobs() -> None:
+    """Requeue or fail jobs whose worker stopped reporting progress (issue #61)."""
+    now = time.monotonic()
+    stall = get_settings().job_stall_seconds
+    for job_id in list(inflight):
+        entry = inflight.pop(job_id, None)
+        if entry is None:
+            continue
+        # Missing stamp means unsweepable; treat as stalled (issue #61).
+        last = last_progress_at.get(job_id, 0.0)
+        if now - last < stall:
+            inflight[job_id] = entry
+            continue
+        live_progress.pop(job_id, None)
+        last_progress_at.pop(job_id, None)
+        entry.worker.job_busy = False
+        await requeue_or_fail(job_id, "no progress")
+
+
 async def dispatch_step() -> None:
     if db.session_factory is None:
         return
     while lost_jobs:
         await requeue_or_fail(lost_jobs.pop(0), "worker disconnected")
+    await sweep_stalled_jobs()
     while True:
         job_id = await queues.pop(JOB_QUEUE)
         if job_id is None:
@@ -311,6 +336,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
         # disconnect handler finds the inflight entry and requeues the job.
         worker.job_busy = True
         inflight[job.id] = InFlight(worker=worker, storage_key=storage_key, user_id=job.user_id)
+        last_progress_at[job_id] = time.monotonic()
         job.state = "running"
         try:
             await worker.ws.send_json({
@@ -325,6 +351,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
                 del realtime.workers[worker.id]  # what the reaper would conclude
             if inflight.pop(job.id, None) is None:
                 return True  # the disconnect handler beat us to it and requeued
+            last_progress_at.pop(job.id, None)
             worker.job_busy = False
             return False  # session rolls back, the job stays queued
         await session.commit()
@@ -339,10 +366,12 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         if job_id not in inflight:
             return
         live_progress[job_id] = float(control.get("progress") or 0.0)
+        last_progress_at[job_id] = time.monotonic()
         publish(job_id, {"state": "running", "progress": control.get("progress")})
         return
     entry = inflight.pop(job_id, None)
     live_progress.pop(job_id, None)
+    last_progress_at.pop(job_id, None)
     if entry is None:
         return  # stale report from a previous incarnation
     worker.job_busy = False
@@ -416,6 +445,7 @@ def on_worker_lost(worker: realtime.Worker) -> None:
         if entry.worker is worker:
             del inflight[job_id]
             live_progress.pop(job_id, None)
+            last_progress_at.pop(job_id, None)
             lost_jobs.append(job_id)
 
 

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -30,6 +30,9 @@ class Settings(BaseSettings):
 
     benchmark_api: bool = False  # expose /api/v1/benchmark/* for scripts/benchmark.py
 
+    # Requeue or fail running jobs with no dispatch/progress for this long (issue #61).
+    job_stall_seconds: float = 600.0
+
     @property
     def auth_methods(self) -> list[str]:
         if self.auth_mode == "none":

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -148,6 +148,32 @@ async def _seed_recover_jobs() -> tuple[uuid.UUID, uuid.UUID]:
     return queued_id, running_id
 
 
+def poll_until_attempt(client, job_id, attempt: int, timeout=5.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        job = client.get(f"/api/v1/generations/{job_id}").json()
+        if job.get("attempt") == attempt:
+            return job
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} never reached attempt {attempt}")
+
+
+@pytest.mark.db
+def test_stalled_job_requeues_once(monkeypatch):
+    monkeypatch.setenv("JOB_STALL_SECONDS", "0.05")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-stall")
+            job_id = client.post("/api/v1/generations",
+                                 json={"model_id": "sd-test",
+                                       "params": {"prompt": "stall"}}).json()["job_id"]
+            assert worker.receive_json()["job_id"] == job_id
+            # Worker stays connected but sends no progress; stall requeues once.
+            poll_until_attempt(client, job_id, 2, timeout=3.0)
+
+
 @pytest.mark.db
 def test_recover_requeues_running_and_dispatches_queued():
     async def prepare() -> tuple[uuid.UUID, uuid.UUID]:

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -170,8 +170,12 @@ def test_stalled_job_requeues_once(monkeypatch):
                                  json={"model_id": "sd-test",
                                        "params": {"prompt": "stall"}}).json()["job_id"]
             assert worker.receive_json()["job_id"] == job_id
-            # Worker stays connected but sends no progress; stall requeues once.
+            # Worker stays connected but sends no progress; stall requeues once
+            # and the retry is dispatched back to the same connected worker.
             poll_until_attempt(client, job_id, 2, timeout=3.0)
+            redispatch = worker.receive_json()
+            assert redispatch["type"] == "dispatch_job"
+            assert redispatch["job_id"] == job_id
 
 
 @pytest.mark.db

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -25,6 +25,7 @@ QUOTA_SERVICE_URL    = ""                        # empty: unlimited default impl
 FLEET_TOKEN_KEY      = ...                       # verifies worker tokens; self-host uses a static shared secret
 EMAIL_BACKEND        = none | smtp | ses
 PUBLIC_URL           = https://app.potocolom.com
+JOB_STALL_SECONDS    = 600                      # requeue or fail running jobs with no progress
 ```
 
 The frontend learns everything it needs at runtime:

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -29,6 +29,8 @@ FRAME_HEADER_BYTES = 17
 CLOSE_PROTOCOL_VIOLATION = 4000
 
 UPLOAD_TIMEOUT = 60.0
+# Heartbeat interval while a job runs without denoising progress (model load).
+PROGRESS_KEEPALIVE_SECONDS = 60.0
 
 
 class RegistrationRejected(Exception):
@@ -98,8 +100,11 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
     Failures are reported, never raised: the connection outlives the job."""
     job_id = control["job_id"]
     progress_tasks: list[asyncio.Task[None]] = []
+    last_fraction = 0.0
 
     def progress(fraction: float) -> None:
+        nonlocal last_fraction
+        last_fraction = fraction
         progress_tasks.append(asyncio.create_task(send_progress(fraction)))
 
     async def send_progress(fraction: float) -> None:
@@ -107,6 +112,17 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
             await ws.send(json.dumps({"type": "job_progress", "job_id": job_id,
                                       "progress": round(fraction, 4)}))
 
+    async def progress_keepalive() -> None:
+        while True:
+            try:
+                await asyncio.sleep(PROGRESS_KEEPALIVE_SECONDS)
+                await send_progress(last_fraction)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("job %s progress keepalive failed", job_id)
+
+    keepalive_task = asyncio.create_task(progress_keepalive())
     try:
         params = manifest.with_defaults(control.get("params") or {})
         result = await engine.generate(manifest, params, progress)
@@ -129,6 +145,9 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
             await ws.send(json.dumps({"type": "job_failed", "job_id": job_id,
                                       "reason": str(error)}))
     finally:
+        keepalive_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await keepalive_task
         if progress_tasks:
             await asyncio.gather(*progress_tasks, return_exceptions=True)
 


### PR DESCRIPTION
## Summary
- Track last `job_progress` time per inflight job in memory
- Sweep stalled jobs from `dispatch_step` and call existing `requeue_or_fail`
- Generous 10-minute stall threshold to tolerate on-demand model loads

Closes #61

## Test plan
- [x] `test_stalled_job_requeues_once` - silent worker triggers requeue
- [x] `make verify` with database available