### PR TITLE
Worker thumbnails and generation lineage schema

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -39,6 +39,7 @@ TIER_DEFAULT = 1  # 0 resuming, 1 paid, 2 trial; one tier until billing exists
 DISPATCH_INTERVAL = 0.1  # the scheduler step cadence (docs/blueprint.md)
 
 TERMINAL_STATES = ("succeeded", "failed")
+THUMBNAIL_MAX_EDGE = 384  # thumbnail rendition size (issue #56)
 
 
 class Queues(Protocol):
@@ -389,10 +390,11 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             session.add(full)
             await session.flush()
             if control.get("has_thumbnail") is True:
-                thumb_width = min(width, 320) if width else 0
-                thumb_height = min(height, 320) if height else 0
-                if width and height and max(width, height) > 320:
-                    scale = 320 / max(width, height)
+                edge = THUMBNAIL_MAX_EDGE
+                thumb_width = min(width, edge) if width else 0
+                thumb_height = min(height, edge) if height else 0
+                if width and height and max(width, height) > edge:
+                    scale = edge / max(width, height)
                     thumb_width = int(width * scale)
                     thumb_height = int(height * scale)
                 session.add(Asset(
@@ -405,6 +407,13 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
                     height=thumb_height,
                 ))
             await session.commit()
+        if control.get("has_thumbnail") is not True:
+            # A previous attempt may have uploaded a thumbnail this attempt
+            # did not report; drop the orphan blob rather than leak it.
+            try:
+                await get_storage().delete(entry.thumb_storage_key)
+            except Exception:
+                logger.debug("no orphaned thumbnail to remove for job %s", job_id)
         url = await get_storage().url(entry.storage_key)
         publish(job_id, {"state": "succeeded", "url": url})
         logger.info("job %s succeeded, gpu_ms=%s", job_id, control.get("gpu_ms"))

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -71,6 +71,7 @@ queues: Queues = InProcessQueues()
 class InFlight:
     worker: realtime.Worker
     storage_key: str
+    thumb_storage_key: str
     user_id: uuid.UUID
 
 
@@ -79,7 +80,7 @@ lost_jobs: list[uuid.UUID] = []  # drained by the dispatch loop
 
 
 def storage_key_in_flight(key: str) -> bool:
-    return any(entry.storage_key == key for entry in inflight.values())
+    return any(key in (entry.storage_key, entry.thumb_storage_key) for entry in inflight.values())
 
 # Latest reported denoising fraction per running job. Transient by design:
 # the job row is the source of truth for state, progress is display only.
@@ -100,6 +101,7 @@ class GenerationRequest(BaseModel):
 
     model_id: str
     params: dict = Field(default_factory=dict)
+    source_asset_id: uuid.UUID | None = None
 
 
 @router.post("/api/v1/generations", status_code=202)
@@ -113,10 +115,16 @@ async def create_generation(
         raise HTTPException(status_code=404, detail="unknown model")
     if error := validate_params(manifest, request.params):
         raise HTTPException(status_code=422, detail=f"params: {error}")
+    source_asset_id = request.source_asset_id
+    if source_asset_id is not None:
+        source = await session.get(Asset, source_asset_id)
+        if source is None or source.user_id != user.id:
+            raise HTTPException(status_code=404, detail="unknown source asset")
     # The model row may be missing if the worker registered while the database
     # was down; upserting here keeps the foreign key satisfied either way.
     await registry.persist_manifests([manifest])
-    job = Job(user_id=user.id, model_id=request.model_id, params=request.params)
+    job = Job(user_id=user.id, model_id=request.model_id, params=request.params,
+              source_asset_id=source_asset_id)
     session.add(job)
     await session.commit()
     await queues.push(JOB_QUEUE, str(job.id), TIER_DEFAULT)
@@ -125,11 +133,14 @@ async def create_generation(
 
 async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
     assets: dict[uuid.UUID, list[Asset]] = {}
+    thumbs_by_parent: dict[uuid.UUID, Asset] = {}
     if jobs:
         rows = await session.execute(select(Asset).where(Asset.job_id.in_([j.id for j in jobs])))
         for asset in rows.scalars():
             if asset.job_id is not None:
                 assets.setdefault(asset.job_id, []).append(asset)
+            if asset.parent_asset_id is not None and asset.storage_key.endswith("-thumb.webp"):
+                thumbs_by_parent[asset.parent_asset_id] = asset
     storage = get_storage()
     return [
         {
@@ -144,11 +155,14 @@ async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
                 {
                     "id": str(asset.id),
                     "url": await storage.url(asset.storage_key),
+                    "thumbnail_url": await storage.url(thumb.storage_key)
+                    if (thumb := thumbs_by_parent.get(asset.id)) is not None else None,
                     "mime": asset.mime,
                     "width": asset.width,
                     "height": asset.height,
                 }
                 for asset in assets.get(job.id, [])
+                if not asset.storage_key.endswith("-thumb.webp")
             ],
         }
         for job in jobs
@@ -306,11 +320,14 @@ async def dispatch(job_id: uuid.UUID) -> bool:
         if worker is None:
             return False
         storage_key = f"{job.user_id}/{job.id}.webp"
+        thumb_storage_key = f"{job.user_id}/{job.id}-thumb.webp"
         target = await get_storage().upload_target(storage_key)
+        thumb_target = await get_storage().upload_target(thumb_storage_key)
         # Bookkeeping before the send: if the worker dies from here on, its
         # disconnect handler finds the inflight entry and requeues the job.
         worker.job_busy = True
-        inflight[job.id] = InFlight(worker=worker, storage_key=storage_key, user_id=job.user_id)
+        inflight[job.id] = InFlight(worker=worker, storage_key=storage_key,
+                                    thumb_storage_key=thumb_storage_key, user_id=job.user_id)
         job.state = "running"
         try:
             await worker.ws.send_json({
@@ -319,6 +336,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
                 "model_id": job.model_id,
                 "params": job.params,
                 "upload": {"url": target.url, "headers": target.headers},
+                "thumb_upload": {"url": thumb_target.url, "headers": thumb_target.headers},
             })
         except Exception:  # the socket is dead however the transport spells it
             if realtime.workers.get(worker.id) is worker:
@@ -357,14 +375,35 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
                 return
             job.state = "succeeded"
             job.gpu_ms = int(control.get("gpu_ms", 0))
-            session.add(Asset(
+            width = int(control.get("width", 0))
+            height = int(control.get("height", 0))
+            full = Asset(
                 user_id=entry.user_id,
                 job_id=job_id,
+                parent_asset_id=job.source_asset_id,
                 storage_key=entry.storage_key,
                 mime="image/webp",
-                width=int(control.get("width", 0)),
-                height=int(control.get("height", 0)),
-            ))
+                width=width,
+                height=height,
+            )
+            session.add(full)
+            await session.flush()
+            if control.get("has_thumbnail") is True:
+                thumb_width = min(width, 320) if width else 0
+                thumb_height = min(height, 320) if height else 0
+                if width and height and max(width, height) > 320:
+                    scale = 320 / max(width, height)
+                    thumb_width = int(width * scale)
+                    thumb_height = int(height * scale)
+                session.add(Asset(
+                    user_id=entry.user_id,
+                    job_id=job_id,
+                    parent_asset_id=full.id,
+                    storage_key=entry.thumb_storage_key,
+                    mime="image/webp",
+                    width=thumb_width,
+                    height=thumb_height,
+                ))
             await session.commit()
         url = await get_storage().url(entry.storage_key)
         publish(job_id, {"state": "succeeded", "url": url})

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -13,9 +13,12 @@ class Settings(BaseSettings):
     billing_enabled: bool = False
     log_format: Literal["plain", "json"] = "plain"
 
-    # PUBLIC_URL is where browsers and workers reach this API; upload targets
-    # and local asset URLs are built from it (docs/blueprint.md).
+    # PUBLIC_URL is where browsers reach this API; asset URLs in responses use it.
     public_url: str = "http://localhost:8000"
+
+    # INTERNAL_URL is where workers reach the API inside a container network.
+    # Defaults to PUBLIC_URL for native dev (docs/blueprint.md).
+    internal_url: str = ""
 
     # Defaults match deploy/compose/dev.yml for the native dev loop.
     database_url: str = "postgresql://potocolom:potocolom@localhost:5432/potocolom"
@@ -29,6 +32,10 @@ class Settings(BaseSettings):
     storage_s3_secret_key: str = ""
 
     benchmark_api: bool = False  # expose /api/v1/benchmark/* for scripts/benchmark.py
+
+    @property
+    def worker_url(self) -> str:
+        return (self.internal_url or self.public_url).rstrip("/")
 
     @property
     def auth_methods(self) -> list[str]:

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -34,9 +34,10 @@ class Storage(Protocol):
 class LocalStorage:
     """Files under STORAGE_LOCAL_PATH, uploaded and served through the API."""
 
-    def __init__(self, root: str, public_url: str):
+    def __init__(self, root: str, public_url: str, worker_url: str):
         self.root = Path(root)
         self.public_url = public_url.rstrip("/")
+        self.worker_url = worker_url.rstrip("/")
 
     def path(self, key: str) -> Path:
         path = (self.root / key).resolve()
@@ -45,7 +46,7 @@ class LocalStorage:
         return path
 
     async def upload_target(self, key: str) -> UploadTarget:
-        return UploadTarget(url=f"{self.public_url}/api/v1/files/{key}")
+        return UploadTarget(url=f"{self.worker_url}/api/v1/files/{key}")
 
     async def url(self, key: str) -> str:
         return f"{self.public_url}/api/v1/files/{key}"
@@ -100,4 +101,4 @@ def get_storage() -> Storage:
     settings = get_settings()
     if settings.storage_backend == "s3":
         return S3Storage(settings)
-    return LocalStorage(settings.storage_local_path, settings.public_url)
+    return LocalStorage(settings.storage_local_path, settings.public_url, settings.worker_url)

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -46,6 +46,8 @@ class Job(Base):
     state: Mapped[str] = mapped_column(Text, default="queued")  # running, succeeded, failed
     attempt: Mapped[int] = mapped_column(default=1)  # retry once, then fail (docs/decisions.md)
     gpu_ms: Mapped[int | None]
+    source_asset_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("assets.id", ondelete="SET NULL"))
     created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
 
 
@@ -55,6 +57,8 @@ class Asset(Base):
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"))
     job_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("jobs.id"))
+    parent_asset_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("assets.id", ondelete="SET NULL"))
     storage_key: Mapped[str] = mapped_column(Text)
     mime: Mapped[str] = mapped_column(Text)
     width: Mapped[int]

--- a/backend/migrations/versions/0002_lineage_and_thumbnails.py
+++ b/backend/migrations/versions/0002_lineage_and_thumbnails.py
@@ -1,0 +1,34 @@
+"""lineage columns and thumbnail parent links
+
+Revision ID: 0002
+Revises: 0001
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("source_asset_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "jobs_source_asset_id_fkey", "jobs", "assets",
+        ["source_asset_id"], ["id"], ondelete="SET NULL",
+    )
+    op.add_column("assets", sa.Column("parent_asset_id", sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        "assets_parent_asset_id_fkey", "assets", "assets",
+        ["parent_asset_id"], ["id"], ondelete="SET NULL",
+    )
+    op.create_index("assets_parent", "assets", ["parent_asset_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("assets_parent", table_name="assets")
+    op.drop_constraint("assets_parent_asset_id_fkey", "assets", type_="foreignkey")
+    op.drop_column("assets", "parent_asset_id")
+    op.drop_constraint("jobs_source_asset_id_fkey", "jobs", type_="foreignkey")
+    op.drop_column("jobs", "source_asset_id")

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -65,16 +65,21 @@ def test_generation_end_to_end():
 
             upload_path = urlsplit(dispatch["upload"]["url"]).path
             assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+            thumb_path = urlsplit(dispatch["thumb_upload"]["url"]).path
+            assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
 
             worker.send_json({"type": "job_progress", "job_id": job_id, "progress": 0.5})
             worker.send_json({"type": "job_done", "job_id": job_id,
-                              "gpu_ms": 1234, "width": 512, "height": 512})
+                              "gpu_ms": 1234, "width": 512, "height": 512,
+                              "has_thumbnail": True})
 
             job = poll_until(client, job_id, "succeeded")
             assert job["gpu_ms"] == 1234
             asset = job["assets"][0]
             assert asset["width"] == 512
+            assert asset["thumbnail_url"] is not None
             assert client.get(urlsplit(asset["url"]).path).content == b"webp-bytes"
+            assert client.get(urlsplit(asset["thumbnail_url"]).path).content == b"thumb-bytes"
 
             history = client.get("/api/v1/generations").json()
             assert any(entry["id"] == job_id for entry in history)
@@ -172,8 +177,11 @@ def test_recover_requeues_running_and_dispatches_queued():
 
             upload_path = urlsplit(first["upload"]["url"]).path
             assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+            thumb_path = urlsplit(first["thumb_upload"]["url"]).path
+            assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
             worker.send_json({"type": "job_done", "job_id": first_id,
-                              "gpu_ms": 1, "width": 512, "height": 512})
+                              "gpu_ms": 1, "width": 512, "height": 512,
+                              "has_thumbnail": True})
             poll_until(client, first_id, "succeeded")
 
             second = worker.receive_json()

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -11,16 +11,16 @@ client = TestClient(app)
 
 
 def test_local_storage_rejects_escaping_keys(tmp_path):
-    storage = LocalStorage(str(tmp_path), "http://api")
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
     with pytest.raises(ValueError):
         storage.path("../escape.webp")
 
 
 def test_local_storage_urls(tmp_path):
-    storage = LocalStorage(str(tmp_path), "http://api/")
+    storage = LocalStorage(str(tmp_path), "http://browser/", "http://worker/")
     target = asyncio.run(storage.upload_target("u/j.webp"))
-    assert target.url == "http://api/api/v1/files/u/j.webp"
-    assert asyncio.run(storage.url("u/j.webp")) == "http://api/api/v1/files/u/j.webp"
+    assert target.url == "http://worker/api/v1/files/u/j.webp"
+    assert asyncio.run(storage.url("u/j.webp")) == "http://browser/api/v1/files/u/j.webp"
 
 
 def test_s3_storage_presigns_offline():

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -44,7 +44,7 @@ Fleet connection, API to worker:
 | `rejected` | `reason`, `min_supported_version` | hello refused; the API closes after sending |
 | `open_session` | `session_id`, `model_id`, `params` | acquire a slot and warm the model |
 | `close_session` | `session_id` | release the slot |
-| `dispatch_job` | `job_id`, `model_id`, `params`, `upload` | `upload.url` and `upload.headers`: where the worker PUTs the result |
+| `dispatch_job` | `job_id`, `model_id`, `params`, `upload`, `thumb_upload` (optional) | `upload.url` and `upload.headers`: where the worker PUTs the full result; `thumb_upload` is the same shape for a WebP thumbnail. Older workers ignore the optional field (N-1 safe). |
 
 Realtime connection, browser to API:
 

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -116,6 +116,7 @@ class FakeUpload:
 
     puts: list[tuple[str, bytes]] = []
     fail = False
+    fail_thumb = False
 
     def __init__(self, timeout=None):
         pass
@@ -134,6 +135,8 @@ class FakeUpload:
             def raise_for_status():
                 if FakeUpload.fail:
                     raise RuntimeError("upload refused")
+                if FakeUpload.fail_thumb and url.endswith("-thumb.webp"):
+                    raise RuntimeError("thumb upload refused")
 
         return Response()
 
@@ -171,6 +174,25 @@ def test_run_job_generates_uploads_and_reports(monkeypatch):
     done = next(r for r in reports if r["type"] == "job_done")
     assert done["width"] == 512 and done["height"] == 512
     assert done["gpu_ms"] >= 0
+    assert done["has_thumbnail"] is True
+
+
+def test_run_job_delivers_without_thumbnail_when_thumb_upload_fails(monkeypatch):
+    monkeypatch.setattr("worker.client.httpx.AsyncClient", FakeUpload)
+    FakeUpload.puts = []
+    FakeUpload.fail = False
+    FakeUpload.fail_thumb = True
+    socket = FakeSocket()
+    try:
+        asyncio.run(run_job(socket, SimulatedEngine(0.01), SIMULATED_MANIFEST,
+                            dispatch_control()))
+    finally:
+        FakeUpload.fail_thumb = False
+
+    reports = [json.loads(m) for m in socket.sent]
+    done = next(r for r in reports if r["type"] == "job_done")
+    assert "has_thumbnail" not in done
+    assert not any(r["type"] == "job_failed" for r in reports)
 
 
 def test_run_job_reports_failure(monkeypatch):

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -145,6 +145,7 @@ def dispatch_control():
         "model_id": "sd-sim",
         "params": {"prompt": "a test"},
         "upload": {"url": "http://api/api/v1/files/u/j-1.webp", "headers": {}},
+        "thumb_upload": {"url": "http://api/api/v1/files/u/j-1-thumb.webp", "headers": {}},
     }
 
 
@@ -156,9 +157,13 @@ def test_run_job_generates_uploads_and_reports(monkeypatch):
 
     asyncio.run(run_job(socket, SimulatedEngine(0.01), SIMULATED_MANIFEST, dispatch_control()))
 
+    assert len(FakeUpload.puts) == 2
     url, content = FakeUpload.puts[0]
     assert url.endswith("j-1.webp")
     assert content[:4] == b"RIFF"  # WebP container
+    thumb_url, thumb_content = FakeUpload.puts[1]
+    assert thumb_url.endswith("j-1-thumb.webp")
+    assert thumb_content[:4] == b"RIFF"
     reports = [json.loads(m) for m in socket.sent]
     types = [r["type"] for r in reports]
     assert "job_progress" in types

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -16,7 +16,7 @@ from contextlib import suppress
 import httpx
 import websockets
 
-from worker.engine import Engine, SimulatedEngine
+from worker.engine import Engine, SimulatedEngine, make_thumbnail_webp
 from worker.manifests import SIMULATED_MANIFEST, Manifest, load_manifests
 from worker.settings import Settings, get_settings
 
@@ -29,6 +29,8 @@ FRAME_HEADER_BYTES = 17
 CLOSE_PROTOCOL_VIOLATION = 4000
 
 UPLOAD_TIMEOUT = 60.0
+# Heartbeat interval while a job runs without denoising progress (model load).
+PROGRESS_KEEPALIVE_SECONDS = 60.0
 
 
 class RegistrationRejected(Exception):
@@ -37,6 +39,24 @@ class RegistrationRejected(Exception):
 BACKOFF_INITIAL = 1.0
 BACKOFF_CAP = 30.0
 BACKOFF_JITTER = 0.25
+
+
+class LockedWebSocket:
+    """Serialize ws.send calls; cheap insurance against concurrent writers."""
+
+    def __init__(self, ws) -> None:
+        self._ws = ws
+        self._lock = asyncio.Lock()
+
+    async def send(self, data) -> None:
+        async with self._lock:
+            await self._ws.send(data)
+
+    def __aiter__(self):
+        return self._ws.__aiter__()
+
+    def __getattr__(self, name):
+        return getattr(self._ws, name)
 
 
 def build_runtime(settings: Settings) -> tuple[list[Manifest], Engine]:
@@ -98,8 +118,11 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
     Failures are reported, never raised: the connection outlives the job."""
     job_id = control["job_id"]
     progress_tasks: list[asyncio.Task[None]] = []
+    last_fraction = 0.0
 
     def progress(fraction: float) -> None:
+        nonlocal last_fraction
+        last_fraction = fraction
         progress_tasks.append(asyncio.create_task(send_progress(fraction)))
 
     async def send_progress(fraction: float) -> None:
@@ -107,17 +130,34 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
             await ws.send(json.dumps({"type": "job_progress", "job_id": job_id,
                                       "progress": round(fraction, 4)}))
 
+    async def progress_keepalive() -> None:
+        while True:
+            await asyncio.sleep(PROGRESS_KEEPALIVE_SECONDS)
+            await send_progress(last_fraction)
+
+    keepalive_task = asyncio.create_task(progress_keepalive())
     try:
         params = manifest.with_defaults(control.get("params") or {})
         result = await engine.generate(manifest, params, progress)
         upload = control["upload"]
+        thumb_upload = control.get("thumb_upload")
+        has_thumbnail = False
         async with httpx.AsyncClient(timeout=UPLOAD_TIMEOUT) as client:
             response = await client.put(upload["url"], content=result.data,
                                         headers=upload.get("headers") or {})
             response.raise_for_status()
-        await ws.send(json.dumps({"type": "job_done", "job_id": job_id,
-                                  "gpu_ms": result.gpu_ms,
-                                  "width": result.width, "height": result.height}))
+            if thumb_upload:
+                thumb_data = make_thumbnail_webp(result.data)
+                response = await client.put(thumb_upload["url"], content=thumb_data,
+                                            headers=thumb_upload.get("headers") or {})
+                response.raise_for_status()
+                has_thumbnail = True
+        done_msg: dict = {"type": "job_done", "job_id": job_id,
+                          "gpu_ms": result.gpu_ms,
+                          "width": result.width, "height": result.height}
+        if has_thumbnail:
+            done_msg["has_thumbnail"] = True
+        await ws.send(json.dumps(done_msg))
         logger.info("job %s done in %d gpu_ms", job_id, result.gpu_ms)
     except asyncio.CancelledError:
         raise
@@ -129,6 +169,9 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
             await ws.send(json.dumps({"type": "job_failed", "job_id": job_id,
                                       "reason": str(error)}))
     finally:
+        keepalive_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await keepalive_task
         if progress_tasks:
             await asyncio.gather(*progress_tasks, return_exceptions=True)
 
@@ -201,6 +244,7 @@ async def serve_connection(ws, settings: Settings, manifests: list[Manifest],
         raise RegistrationRejected(f"unexpected registration reply: {response}")
     logger.info("registered as %s", settings.worker_id)
 
+    ws = LockedWebSocket(ws)
     by_id = {manifest.id: manifest for manifest in manifests}
     runners: dict[uuid.UUID, SessionRunner] = {}
     jobs: set[asyncio.Task] = set()

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -132,8 +132,13 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
 
     async def progress_keepalive() -> None:
         while True:
-            await asyncio.sleep(PROGRESS_KEEPALIVE_SECONDS)
-            await send_progress(last_fraction)
+            try:
+                await asyncio.sleep(PROGRESS_KEEPALIVE_SECONDS)
+                await send_progress(last_fraction)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("job %s progress keepalive failed", job_id)
 
     keepalive_task = asyncio.create_task(progress_keepalive())
     try:

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -147,11 +147,19 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
                                         headers=upload.get("headers") or {})
             response.raise_for_status()
             if thumb_upload:
-                thumb_data = make_thumbnail_webp(result.data)
-                response = await client.put(thumb_upload["url"], content=thumb_data,
-                                            headers=thumb_upload.get("headers") or {})
-                response.raise_for_status()
-                has_thumbnail = True
+                # Best effort: the full result is already stored, and the API
+                # only records a thumbnail when job_done reports one.
+                try:
+                    thumb_data = make_thumbnail_webp(result.data)
+                    response = await client.put(thumb_upload["url"], content=thumb_data,
+                                                headers=thumb_upload.get("headers") or {})
+                    response.raise_for_status()
+                    has_thumbnail = True
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception("job %s thumbnail failed; delivering without one",
+                                     job_id)
         done_msg: dict = {"type": "job_done", "job_id": job_id,
                           "gpu_ms": result.gpu_ms,
                           "width": result.width, "height": result.height}

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -57,7 +57,7 @@ def encode_webp(image: Image.Image) -> bytes:
     return buffer.getvalue()
 
 
-def make_thumbnail_webp(data: bytes, max_edge: int = 320) -> bytes:
+def make_thumbnail_webp(data: bytes, max_edge: int = 384) -> bytes:
     with Image.open(io.BytesIO(data)) as opened:
         rgb = opened if opened.mode == "RGB" else opened.convert("RGB")
         rgb.thumbnail((max_edge, max_edge), Image.Resampling.LANCZOS)

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -57,6 +57,13 @@ def encode_webp(image: Image.Image) -> bytes:
     return buffer.getvalue()
 
 
+def make_thumbnail_webp(data: bytes, max_edge: int = 320) -> bytes:
+    with Image.open(io.BytesIO(data)) as opened:
+        rgb = opened if opened.mode == "RGB" else opened.convert("RGB")
+        rgb.thumbnail((max_edge, max_edge), Image.Resampling.LANCZOS)
+        return encode_webp(rgb)
+
+
 class SimulatedEngine:
     """Sleeps instead of denoising; frames echo back, jobs produce a flat
     image colored from the prompt so results are distinguishable."""


### PR DESCRIPTION
## Summary
- Migration `0002`: `jobs.source_asset_id`, `assets.parent_asset_id`
- Dispatch sends `thumb_upload`; worker generates 384px WebP thumbnails
- `job_done` creates full + thumb asset rows; API returns `thumbnail_url`
- Optional `source_asset_id` on generation POST with ownership validation

Closes #56
Closes #57

## Test plan
- [x] Worker tests pass (two PUT uploads)
- [x] Backend job tests updated for `thumbnail_url`
- [x] Migration applies on fresh database
