### PR TITLE
Image+prompt to image generation jobs

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -120,6 +120,8 @@ async def create_generation(
         source = await session.get(Asset, source_asset_id)
         if source is None or source.user_id != user.id:
             raise HTTPException(status_code=404, detail="unknown source asset")
+        if "image_to_image" not in manifest.capabilities:
+            raise HTTPException(status_code=422, detail="model does not support image_to_image")
     # The model row may be missing if the worker registered while the database
     # was down; upserting here keeps the foreign key satisfied either way.
     await registry.persist_manifests([manifest])
@@ -329,15 +331,29 @@ async def dispatch(job_id: uuid.UUID) -> bool:
         inflight[job.id] = InFlight(worker=worker, storage_key=storage_key,
                                     thumb_storage_key=thumb_storage_key, user_id=job.user_id)
         job.state = "running"
+        dispatch_msg: dict = {
+            "type": "dispatch_job",
+            "job_id": str(job.id),
+            "model_id": job.model_id,
+            "params": job.params,
+            "upload": {"url": target.url, "headers": target.headers},
+            "thumb_upload": {"url": thumb_target.url, "headers": thumb_target.headers},
+        }
+        if job.source_asset_id is not None:
+            source = await session.get(Asset, job.source_asset_id)
+            if source is None:
+                inflight.pop(job.id, None)
+                worker.job_busy = False
+                job.state = "failed"
+                await session.commit()
+                publish(job_id, {"state": "failed", "reason": "source asset not found"})
+                logger.warning("job %s failed: source asset not found", job_id)
+                return True
+            dispatch_msg["input"] = {
+                "url": await get_storage().worker_fetch_url(source.storage_key),
+            }
         try:
-            await worker.ws.send_json({
-                "type": "dispatch_job",
-                "job_id": str(job.id),
-                "model_id": job.model_id,
-                "params": job.params,
-                "upload": {"url": target.url, "headers": target.headers},
-                "thumb_upload": {"url": thumb_target.url, "headers": thumb_target.headers},
-            })
+            await worker.ws.send_json(dispatch_msg)
         except Exception:  # the socket is dead however the transport spells it
             if realtime.workers.get(worker.id) is worker:
                 del realtime.workers[worker.id]  # what the reaper would conclude

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -28,6 +28,8 @@ class Storage(Protocol):
 
     async def url(self, key: str) -> str: ...
 
+    async def worker_fetch_url(self, key: str) -> str: ...
+
     async def delete(self, key: str) -> None: ...
 
 
@@ -50,6 +52,9 @@ class LocalStorage:
 
     async def url(self, key: str) -> str:
         return f"{self.public_url}/api/v1/files/{key}"
+
+    async def worker_fetch_url(self, key: str) -> str:
+        return f"{self.worker_url}/api/v1/files/{key}"
 
     async def delete(self, key: str) -> None:
         self.path(key).unlink(missing_ok=True)
@@ -91,6 +96,9 @@ class S3Storage:
             Params={"Bucket": self.bucket, "Key": key},
             ExpiresIn=SIGNED_URL_TTL,
         )
+
+    async def worker_fetch_url(self, key: str) -> str:
+        return await self.url(key)
 
     async def delete(self, key: str) -> None:
         await asyncio.to_thread(self.client.delete_object, Bucket=self.bucket, Key=key)

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -17,7 +17,7 @@ from app.tables import Job, Model
 MANIFEST = {
     "id": "sd-test",
     "name": "SD Test",
-    "capabilities": ["text_to_image"],
+    "capabilities": ["text_to_image", "image_to_image"],
     "parameters": {
         "type": "object",
         "properties": {"prompt": {"type": "string"}},
@@ -26,10 +26,16 @@ MANIFEST = {
     "min_vram_gb": 0,
 }
 
+MANIFEST_T2I_ONLY = {
+    **MANIFEST,
+    "id": "sd-t2i",
+    "capabilities": ["text_to_image"],
+}
 
-def fleet_hello(ws, worker_id):
+
+def fleet_hello(ws, worker_id, manifest=MANIFEST):
     ws.send_json({"type": "hello", "protocol_version": PROTOCOL_VERSION,
-                  "worker_id": worker_id, "models": [MANIFEST], "realtime_slots": 1})
+                  "worker_id": worker_id, "models": [manifest], "realtime_slots": 1})
     assert ws.receive_json()["type"] == "registered"
 
 
@@ -188,3 +194,71 @@ def test_recover_requeues_running_and_dispatches_queued():
             assert second["type"] == "dispatch_job"
             second_id = second["job_id"]
             assert {first_id, second_id} == {str(queued_id), str(running_id)}
+
+
+@pytest.mark.db
+def test_img2img_dispatch_includes_input_url():
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-i2i")
+
+            created = client.post("/api/v1/generations",
+                                  json={"model_id": "sd-test",
+                                        "params": {"prompt": "a lighthouse"}})
+            assert created.status_code == 202
+            source_job_id = created.json()["job_id"]
+
+            dispatch = worker.receive_json()
+            upload_path = urlsplit(dispatch["upload"]["url"]).path
+            assert client.put(upload_path, content=b"source-webp").status_code == 200
+            worker.send_json({"type": "job_done", "job_id": source_job_id,
+                              "gpu_ms": 100, "width": 512, "height": 512})
+            source_job = poll_until(client, source_job_id, "succeeded")
+            source_asset_id = source_job["assets"][0]["id"]
+
+            edit = client.post("/api/v1/generations",
+                               json={"model_id": "sd-test",
+                                     "params": {"prompt": "a red lighthouse"},
+                                     "source_asset_id": source_asset_id})
+            assert edit.status_code == 202
+            edit_job_id = edit.json()["job_id"]
+
+            i2i_dispatch = worker.receive_json()
+            assert i2i_dispatch["type"] == "dispatch_job"
+            assert i2i_dispatch["job_id"] == edit_job_id
+            assert "input" in i2i_dispatch
+            input_path = urlsplit(i2i_dispatch["input"]["url"]).path
+            assert client.get(input_path).content == b"source-webp"
+
+            assert client.put(urlsplit(i2i_dispatch["upload"]["url"]).path,
+                              content=b"edited-webp").status_code == 200
+            worker.send_json({"type": "job_done", "job_id": edit_job_id,
+                              "gpu_ms": 200, "width": 512, "height": 512})
+            edit_job = poll_until(client, edit_job_id, "succeeded")
+            assert edit_job["assets"][0]["url"].endswith(".webp")
+
+
+@pytest.mark.db
+def test_img2img_rejects_model_without_capability():
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-i2i-cap", MANIFEST_T2I_ONLY)
+
+            created = client.post("/api/v1/generations",
+                                  json={"model_id": "sd-t2i",
+                                        "params": {"prompt": "seed"}})
+            job_id = created.json()["job_id"]
+            dispatch = worker.receive_json()
+            upload_path = urlsplit(dispatch["upload"]["url"]).path
+            assert client.put(upload_path, content=b"source").status_code == 200
+            worker.send_json({"type": "job_done", "job_id": job_id,
+                              "gpu_ms": 1, "width": 512, "height": 512})
+            source_job = poll_until(client, job_id, "succeeded")
+            source_asset_id = source_job["assets"][0]["id"]
+
+            rejected = client.post("/api/v1/generations",
+                                   json={"model_id": "sd-t2i",
+                                         "params": {"prompt": "edit"},
+                                         "source_asset_id": source_asset_id})
+            assert rejected.status_code == 422
+            assert "image_to_image" in rejected.json()["detail"]

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -44,7 +44,7 @@ Fleet connection, API to worker:
 | `rejected` | `reason`, `min_supported_version` | hello refused; the API closes after sending |
 | `open_session` | `session_id`, `model_id`, `params` | acquire a slot and warm the model |
 | `close_session` | `session_id` | release the slot |
-| `dispatch_job` | `job_id`, `model_id`, `params`, `upload`, `thumb_upload` (optional) | `upload.url` and `upload.headers`: where the worker PUTs the full result; `thumb_upload` is the same shape for a WebP thumbnail. Older workers ignore the optional field (N-1 safe). |
+| `dispatch_job` | `job_id`, `model_id`, `params`, `upload`, `thumb_upload` (optional), `input` (optional) | `upload.url` and `upload.headers`: where the worker PUTs the full result; `thumb_upload` is the same shape for a WebP thumbnail. `input.url`: presigned GET for the source image on image_to_image jobs. Older workers ignore the optional fields (N-1 safe). |
 
 Realtime connection, browser to API:
 

--- a/frontend/src/lib/components/generate-panel.svelte
+++ b/frontend/src/lib/components/generate-panel.svelte
@@ -48,6 +48,7 @@
 	let count = $state('1');
 	let normsReady = $state(false);
 	let seed = $state('');
+	let sourceAssetId = $state<string | null>(null);
 	let errorText = $state('');
 
 	// The viewer shows the clicked generation, or the newest finished one.
@@ -78,6 +79,11 @@
 	// The manifest schema decides which resolutions a model supports
 	// (docs/architecture.md, model manifests); no enum means unconstrained.
 	const selectedModel = $derived(studio.models.find((m) => m.id === studio.modelId));
+	const canEdit = $derived(
+		shown !== null &&
+			shown.assets.length > 0 &&
+			(selectedModel?.capabilities.includes('image_to_image') ?? false)
+	);
 	const stepsRange = $derived(stepsSpec(selectedModel));
 	const guidanceRange = $derived(guidanceSpec(selectedModel));
 	const sizeOptions = $derived(modelSizeOptions(selectedModel));
@@ -85,6 +91,12 @@
 	const guidanceValue = $derived(normToValue(guidanceNorm, guidanceRange));
 	const sizeValue = $derived(sizeOptions[sizeIndex] ?? sizeOptions[0]);
 	const sizeKey = $derived(String(sizeValue));
+
+	$effect(() => {
+		if (!selectedModel?.capabilities.includes('image_to_image')) {
+			sourceAssetId = null;
+		}
+	});
 
 	$effect(() => {
 		if (!selectedModel) return;
@@ -139,7 +151,13 @@
 			const response = await fetch('/api/v1/generations', {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
-				body: JSON.stringify({ model_id: studio.modelId, params })
+				body: JSON.stringify({
+					model_id: studio.modelId,
+					params,
+					...(sourceAssetId && selectedModel?.capabilities.includes('image_to_image')
+						? { source_asset_id: sourceAssetId }
+						: {})
+				})
 			});
 			if (!response.ok) {
 				const body = (await response.json().catch(() => null)) as { detail?: string } | null;
@@ -157,6 +175,17 @@
 
 	function starShown(): void {
 		if (shown !== null) toggleStarred(shown.id);
+	}
+
+	function editShown(): void {
+		if (shown === null || shown.assets.length === 0) return;
+		const assetId = shown.assets[0].id;
+		if (sourceAssetId === assetId) {
+			sourceAssetId = null;
+			return;
+		}
+		sourceAssetId = assetId;
+		if (shownPrompt !== '') studio.prompt = shownPrompt;
 	}
 
 	function onSizeChange(value: string): void {
@@ -284,11 +313,11 @@
 							</Button>
 							<Button
 								type="button"
-								variant="outline"
+								variant={sourceAssetId !== null ? 'secondary' : 'outline'}
 								size="sm"
 								class="justify-start"
-								disabled
-								title={t('app.gen.coming_soon')}
+								disabled={!canEdit}
+								onclick={editShown}
 							>
 								<PencilIcon />
 								{t('app.gen.edit')}

--- a/frontend/src/lib/model-specs.ts
+++ b/frontend/src/lib/model-specs.ts
@@ -24,7 +24,7 @@ export const MODEL_SPECS: ModelSpec[] = [
 		min_vram_gb: 10,
 		resolutions: '768, 1024',
 		step_range: '10-50',
-		capabilities: ['text_to_image'],
+		capabilities: ['text_to_image', 'image_to_image'],
 		license: 'CreativeML Open RAIL++-M',
 		commercial: 'Unrestricted (RAIL use policy)',
 		studio: true,

--- a/worker/models/sdxl-base.json
+++ b/worker/models/sdxl-base.json
@@ -1,7 +1,7 @@
 {
   "id": "sdxl-base",
   "name": "SDXL (default)",
-  "capabilities": ["text_to_image"],
+  "capabilities": ["text_to_image", "image_to_image"],
   "min_vram_gb": 10,
   "default": true,
   "source": "stabilityai/stable-diffusion-xl-base-1.0",
@@ -15,7 +15,8 @@
       "guidance": { "type": "number", "minimum": 0, "maximum": 15, "default": 6 },
       "seed": { "type": "integer" },
       "width": { "type": "integer", "enum": [768, 1024], "default": 1024 },
-      "height": { "type": "integer", "enum": [768, 1024], "default": 1024 }
+      "height": { "type": "integer", "enum": [768, 1024], "default": 1024 },
+      "strength": { "type": "number", "minimum": 0.05, "maximum": 1, "default": 0.75 }
     },
     "required": ["prompt"]
   }

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -1,8 +1,10 @@
 import asyncio
+import io
 import json
 import uuid
 
 import pytest
+from PIL import Image
 
 from worker.client import (
     FRAME_HEADER_BYTES,
@@ -115,6 +117,8 @@ class FakeUpload:
     """Stands in for httpx.AsyncClient; records the PUT it receives."""
 
     puts: list[tuple[str, bytes]] = []
+    gets: list[str] = []
+    get_body = b"input-webp"
     fail = False
 
     def __init__(self, timeout=None):
@@ -125,6 +129,19 @@ class FakeUpload:
 
     async def __aexit__(self, *exc):
         return None
+
+    async def get(self, url, headers=None):
+        FakeUpload.gets.append(url)
+
+        class Response:
+            content = FakeUpload.get_body
+
+            @staticmethod
+            def raise_for_status():
+                if FakeUpload.fail:
+                    raise RuntimeError("download refused")
+
+        return Response()
 
     async def put(self, url, content=b"", headers=None):
         FakeUpload.puts.append((url, content))
@@ -186,3 +203,23 @@ def test_run_job_reports_failure(monkeypatch):
     failed = next(r for r in reports if r["type"] == "job_failed")
     assert failed["job_id"] == "j-1"
     assert "upload refused" in failed["reason"]
+
+
+def test_run_job_downloads_input_image(monkeypatch):
+    monkeypatch.setattr("worker.client.httpx.AsyncClient", FakeUpload)
+    FakeUpload.puts = []
+    FakeUpload.gets = []
+    FakeUpload.fail = False
+    buffer = io.BytesIO()
+    Image.new("RGB", (64, 64), (10, 20, 30)).save(buffer, "WEBP")
+    FakeUpload.get_body = buffer.getvalue()
+    socket = FakeSocket()
+    control = dispatch_control()
+    control["input"] = {"url": "http://api/api/v1/files/source.webp"}
+
+    asyncio.run(run_job(socket, SimulatedEngine(0.01), SIMULATED_MANIFEST, control))
+
+    assert FakeUpload.gets == ["http://api/api/v1/files/source.webp"]
+    assert len(FakeUpload.puts) == 2
+    reports = [json.loads(m) for m in socket.sent]
+    assert any(r["type"] == "job_done" for r in reports)

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -1,4 +1,7 @@
 import asyncio
+import io
+
+from PIL import Image
 
 from worker.engine import SimulatedEngine
 from worker.manifests import SIMULATED_MANIFEST
@@ -16,3 +19,24 @@ def test_simulated_gpu_lifecycle():
         assert engine.loaded_models() == []
 
     asyncio.run(scenario())
+
+
+def test_simulated_generate_with_input_image():
+    engine = SimulatedEngine(0.01)
+    buffer = io.BytesIO()
+    Image.new("RGB", (256, 128), (40, 80, 120)).save(buffer, "WEBP")
+    input_image = buffer.getvalue()
+    progress_values: list[float] = []
+
+    async def scenario():
+        result = await engine.generate(
+            SIMULATED_MANIFEST, {"prompt": "blend"}, progress_values.append,
+            input_image=input_image,
+        )
+        return result
+
+    result = asyncio.run(scenario())
+    assert progress_values[-1] == 1.0
+    assert result.width == 256
+    assert result.height == 128
+    assert result.data[:4] == b"RIFF"

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -141,15 +141,18 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
         upload = control["upload"]
         thumb_upload = control.get("thumb_upload")
         has_thumbnail = False
-        async with httpx.AsyncClient(timeout=UPLOAD_TIMEOUT) as client:
-            input_image = None
-            input_spec = control.get("input")
-            if input_spec and input_spec.get("url"):
+        input_image = None
+        input_spec = control.get("input")
+        if input_spec and input_spec.get("url"):
+            # Short-lived client: inference can run for minutes and must not
+            # hold a connection pool open.
+            async with httpx.AsyncClient(timeout=UPLOAD_TIMEOUT) as client:
                 response = await client.get(input_spec["url"])
                 response.raise_for_status()
                 input_image = response.content
-            result = await engine.generate(manifest, params, progress,
-                                           input_image=input_image)
+        result = await engine.generate(manifest, params, progress,
+                                        input_image=input_image)
+        async with httpx.AsyncClient(timeout=UPLOAD_TIMEOUT) as client:
             response = await client.put(upload["url"], content=result.data,
                                         headers=upload.get("headers") or {})
             response.raise_for_status()

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -138,11 +138,18 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
     keepalive_task = asyncio.create_task(progress_keepalive())
     try:
         params = manifest.with_defaults(control.get("params") or {})
-        result = await engine.generate(manifest, params, progress)
         upload = control["upload"]
         thumb_upload = control.get("thumb_upload")
         has_thumbnail = False
         async with httpx.AsyncClient(timeout=UPLOAD_TIMEOUT) as client:
+            input_image = None
+            input_spec = control.get("input")
+            if input_spec and input_spec.get("url"):
+                response = await client.get(input_spec["url"])
+                response.raise_for_status()
+                input_image = response.content
+            result = await engine.generate(manifest, params, progress,
+                                           input_image=input_image)
             response = await client.put(upload["url"], content=result.data,
                                         headers=upload.get("headers") or {})
             response.raise_for_status()

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -37,7 +37,8 @@ class GeneratedImage:
 
 class Engine(Protocol):
     async def generate(
-        self, manifest: Manifest, params: dict, progress: ProgressFn
+        self, manifest: Manifest, params: dict, progress: ProgressFn,
+        *, input_image: bytes | None = None,
     ) -> GeneratedImage: ...
 
     async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes: ...
@@ -88,18 +89,35 @@ class SimulatedEngine:
         self._loaded.clear()
 
     async def generate(
-        self, manifest: Manifest, params: dict, progress: ProgressFn
+        self, manifest: Manifest, params: dict, progress: ProgressFn,
+        *, input_image: bytes | None = None,
     ) -> GeneratedImage:
+        if input_image is not None and "image_to_image" not in manifest.capabilities:
+            raise ValueError(f"model {manifest.id} does not support image_to_image jobs")
         steps = 4
         start = time.monotonic()
         for step in range(steps):
             await asyncio.sleep(self.inference_seconds / steps)
             progress((step + 1) / steps)
         color = sha256(str(params.get("prompt", "")).encode()).digest()
-        image = Image.new("RGB", (REALTIME_SIZE, REALTIME_SIZE),
-                          (color[0], color[1], color[2]))
+        if input_image is not None:
+            source = Image.open(io.BytesIO(input_image)).convert("RGB")
+            width = params.get("width")
+            height = params.get("height")
+            if width and height:
+                width, height = int(width), int(height)
+                source = source.resize((width, height), Image.Resampling.LANCZOS)
+            else:
+                width, height = source.size
+            color = sha256((str(params.get("prompt", "")) + ":i2i").encode()).digest()
+            rgb = (color[0], color[1], color[2])
+            image = Image.new("RGB", (width, height), rgb)
+        else:
+            width = height = REALTIME_SIZE
+            rgb = (color[0], color[1], color[2])
+            image = Image.new("RGB", (width, height), rgb)
         gpu_ms = int((time.monotonic() - start) * 1000)
-        return GeneratedImage(encode_webp(image), REALTIME_SIZE, REALTIME_SIZE, gpu_ms)
+        return GeneratedImage(encode_webp(image), width, height, gpu_ms)
 
     async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes:
         await asyncio.sleep(self.inference_seconds)
@@ -256,25 +274,33 @@ class DiffusersEngine:
         return cls.from_pretrained(source, **kwargs)
 
     async def generate(
-        self, manifest: Manifest, params: dict, progress: ProgressFn
+        self, manifest: Manifest, params: dict, progress: ProgressFn,
+        *, input_image: bytes | None = None,
     ) -> GeneratedImage:
-        if "text_to_image" not in manifest.capabilities:
-            raise ValueError(f"model {manifest.id} does not support text_to_image jobs")
+        if input_image is not None:
+            if "image_to_image" not in manifest.capabilities:
+                raise ValueError(f"model {manifest.id} does not support image_to_image jobs")
+            runner = self._generate_i2i
+        else:
+            if "text_to_image" not in manifest.capabilities:
+                raise ValueError(f"model {manifest.id} does not support text_to_image jobs")
+            runner = self._generate
         loop = asyncio.get_running_loop()
         async with self._gpu:
             try:
-                return await asyncio.to_thread(self._generate, manifest, dict(params),
-                                               progress, loop)
+                return await asyncio.to_thread(runner, manifest, dict(params),
+                                               progress, loop, input_image)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
             # Two resident models plus activations can exceed a 16 GB card
             # mid-denoise; free the others and run once more.
             self._evict_except(manifest.id)
-            return await asyncio.to_thread(self._generate, manifest, dict(params),
-                                           progress, loop)
+            return await asyncio.to_thread(runner, manifest, dict(params),
+                                           progress, loop, input_image)
 
     def _generate(self, manifest: Manifest, params: dict, progress: ProgressFn,
-                  loop: asyncio.AbstractEventLoop) -> GeneratedImage:
+                  loop: asyncio.AbstractEventLoop,
+                  input_image: bytes | None = None) -> GeneratedImage:
         pipeline = self._pipeline(manifest, "t2i")
         steps = max(1, int(params.get("steps", 2)))
         generator = None
@@ -300,6 +326,42 @@ class DiffusersEngine:
             callback_on_step_end=on_step,
         ).images[0]
         gpu_ms = int((time.monotonic() - start) * 1000)
+        return GeneratedImage(encode_webp(image), image.width, image.height, gpu_ms)
+
+    def _generate_i2i(self, manifest: Manifest, params: dict, progress: ProgressFn,
+                      loop: asyncio.AbstractEventLoop,
+                      input_image: bytes | None) -> GeneratedImage:
+        if input_image is None:
+            raise ValueError("image_to_image job requires input_image")
+        pipeline = self._pipeline(manifest, "i2i")
+        source = Image.open(io.BytesIO(input_image)).convert("RGB")
+        width = params.get("width")
+        height = params.get("height")
+        if width and height:
+            source = source.resize((int(width), int(height)), Image.Resampling.LANCZOS)
+        steps = max(1, int(params.get("steps", 2)))
+        strength = min(max(float(params.get("strength", 0.75)), 0.05), 1.0)
+        actual_steps = max(1, math.ceil(steps * strength))
+        generator = None
+        if params.get("seed") is not None:
+            generator = self.torch.Generator(self.device).manual_seed(int(params["seed"]))
+
+        def on_step(pipe: Any, step: int, timestep: Any, kwargs: dict) -> dict:
+            loop.call_soon_threadsafe(progress, (step + 1) / actual_steps)
+            return kwargs
+
+        start = time.monotonic()
+        image = pipeline(
+            prompt=str(params.get("prompt", "")),
+            image=source,
+            num_inference_steps=steps,
+            strength=strength,
+            guidance_scale=float(params.get("guidance", 0.0)),
+            generator=generator,
+            callback_on_step_end=on_step,
+        ).images[0]
+        gpu_ms = int((time.monotonic() - start) * 1000)
+        loop.call_soon_threadsafe(progress, 1.0)
         return GeneratedImage(encode_webp(image), image.width, image.height, gpu_ms)
 
     async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes:

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -110,7 +110,7 @@ class SimulatedEngine:
             progress((step + 1) / steps)
         color = sha256(str(params.get("prompt", "")).encode()).digest()
         if input_image is not None:
-            source = Image.open(io.BytesIO(input_image)).convert("RGB")
+            source = decode_input_image(input_image)
             width = params.get("width")
             height = params.get("height")
             if width and height:
@@ -343,7 +343,7 @@ class DiffusersEngine:
         if input_image is None:
             raise ValueError("image_to_image job requires input_image")
         pipeline = self._pipeline(manifest, "i2i")
-        source = Image.open(io.BytesIO(input_image)).convert("RGB")
+        source = decode_input_image(input_image)
         width = params.get("width")
         height = params.get("height")
         if width and height:

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -52,6 +52,15 @@ class Engine(Protocol):
     async def unload_all(self) -> None: ...
 
 
+def decode_input_image(data: bytes) -> Image.Image:
+    """Decode a job's source image; a clear ValueError beats a Pillow OSError."""
+    try:
+        with Image.open(io.BytesIO(data)) as opened:
+            return opened.convert("RGB")
+    except OSError as error:
+        raise ValueError("source image could not be decoded") from error
+
+
 def encode_webp(image: Image.Image) -> bytes:
     buffer = io.BytesIO()
     image.save(buffer, "WEBP", quality=80)
@@ -341,7 +350,8 @@ class DiffusersEngine:
             source = source.resize((int(width), int(height)), Image.Resampling.LANCZOS)
         steps = max(1, int(params.get("steps", 2)))
         strength = min(max(float(params.get("strength", 0.75)), 0.05), 1.0)
-        actual_steps = max(1, math.ceil(steps * strength))
+        # diffusers img2img floors the step count: int(steps * strength).
+        actual_steps = max(1, int(steps * strength))
         generator = None
         if params.get("seed") is not None:
             generator = self.torch.Generator(self.device).manual_seed(int(params["seed"]))


### PR DESCRIPTION
## Summary
- Queued img2img jobs via `source_asset_id` and presigned input URL on `dispatch_job`
- Worker downloads input image and runs i2i pipeline at job resolution with progress
- `sdxl-base` gains `image_to_image` capability and `strength` parameter
- Generate panel Edit button wires history asset as source

Depends on #56/#57 lineage PR (stacked base branch).

Closes #2

## Test plan
- [x] Backend img2img dispatch and capability validation tests
- [x] Worker input download tests
- [x] End-to-end img2img on GPU worker