### PR TITLE
Per-model GPU time estimates in models API and UI

### DIFF
--- a/backend/app/estimates.py
+++ b/backend/app/estimates.py
@@ -23,7 +23,7 @@ def _load_timings() -> dict[str, dict[str, int]]:
         if model_id.startswith("_") or not isinstance(entry, dict):
             continue
         try:
-            timings[model_id] = {
+            candidate = {
                 "gpu_ms": int(entry["gpu_ms"]),
                 "width": int(entry["width"]),
                 "height": int(entry["height"]),
@@ -31,6 +31,9 @@ def _load_timings() -> dict[str, dict[str, int]]:
             }
         except (KeyError, TypeError, ValueError):
             continue
+        if any(value <= 0 for value in candidate.values()):
+            continue  # a zero baseline would divide by zero downstream
+        timings[model_id] = candidate
     return timings
 
 

--- a/backend/app/estimates.py
+++ b/backend/app/estimates.py
@@ -1,0 +1,70 @@
+"""GPU time estimates from curated benchmark baselines (issue #47)."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+TIMINGS_PATH = Path(__file__).with_name("model_timings.json")
+
+
+@lru_cache(maxsize=1)
+def _load_timings() -> dict[str, dict[str, int]]:
+    try:
+        raw = json.loads(TIMINGS_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    timings: dict[str, dict[str, int]] = {}
+    for model_id, entry in raw.items():
+        if model_id.startswith("_") or not isinstance(entry, dict):
+            continue
+        try:
+            timings[model_id] = {
+                "gpu_ms": int(entry["gpu_ms"]),
+                "width": int(entry["width"]),
+                "height": int(entry["height"]),
+                "steps": int(entry["steps"]),
+            }
+        except (KeyError, TypeError, ValueError):
+            continue
+    return timings
+
+
+def schema_defaults(parameters: dict[str, Any]) -> dict[str, Any]:
+    """Pull JSON Schema property defaults from a manifest parameters block."""
+    props = parameters.get("properties", {})
+    if not isinstance(props, dict):
+        return {}
+    defaults: dict[str, Any] = {}
+    for name, spec in props.items():
+        if isinstance(spec, dict) and "default" in spec:
+            defaults[name] = spec["default"]
+    return defaults
+
+
+def estimate_gpu_ms(model_id: str, params: dict[str, Any]) -> int | None:
+    """Estimate GPU milliseconds for model_id at the given generation params."""
+    baseline = _load_timings().get(model_id)
+    if baseline is None:
+        return None
+
+    if not all(key in params for key in ("steps", "width", "height")):
+        return None
+
+    try:
+        steps = int(params["steps"])
+        width = int(params["width"])
+        height = int(params["height"])
+    except (TypeError, ValueError):
+        return None
+
+    if steps <= 0 or width <= 0 or height <= 0:
+        return None
+
+    step_scale = steps / baseline["steps"]
+    pixel_scale = (width * height) / (baseline["width"] * baseline["height"])
+    return max(1, round(baseline["gpu_ms"] * step_scale * pixel_scale))

--- a/backend/app/estimates.py
+++ b/backend/app/estimates.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import json
+import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger("potocolom.estimates")
 
 TIMINGS_PATH = Path(__file__).with_name("model_timings.json")
 
@@ -15,6 +18,8 @@ def _load_timings() -> dict[str, dict[str, int]]:
     try:
         raw = json.loads(TIMINGS_PATH.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        # Cached, so this logs once per process.
+        logger.warning("model_timings.json missing or invalid; estimates disabled")
         return {}
     if not isinstance(raw, dict):
         return {}

--- a/backend/app/model_timings.json
+++ b/backend/app/model_timings.json
@@ -1,0 +1,39 @@
+{
+  "_source": "RX 7600 XT benchmark (frontend/static/benchmark/results.json, 2026-07-12)",
+  "sdxl-base": {
+    "gpu_ms": 15274,
+    "width": 1024,
+    "height": 1024,
+    "steps": 20
+  },
+  "sdxl-fast": {
+    "gpu_ms": 3736,
+    "width": 1024,
+    "height": 1024,
+    "steps": 8
+  },
+  "ssd-1b": {
+    "gpu_ms": 9753,
+    "width": 1024,
+    "height": 1024,
+    "steps": 20
+  },
+  "dreamshaper-lcm": {
+    "gpu_ms": 578,
+    "width": 512,
+    "height": 512,
+    "steps": 4
+  },
+  "sd-turbo": {
+    "gpu_ms": 289,
+    "width": 512,
+    "height": 512,
+    "steps": 2
+  },
+  "sdxl-turbo": {
+    "gpu_ms": 285,
+    "width": 512,
+    "height": 512,
+    "steps": 1
+  }
+}

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter
 from sqlalchemy.dialects.postgresql import insert
 
 from app import db, realtime
+from app.estimates import estimate_gpu_ms, schema_defaults
 from app.manifests import Manifest
 from app.tables import Model
 
@@ -34,10 +35,13 @@ def public() -> dict[str, Manifest]:
 
 @router.get("/api/v1/models")
 async def list_models() -> list[dict]:
-    return [
-        manifest.model_dump()
-        for _, manifest in sorted(public().items())
-    ]
+    models = []
+    for _, manifest in sorted(public().items()):
+        payload = manifest.model_dump()
+        defaults = schema_defaults(manifest.parameters)
+        payload["estimated_gpu_ms_default"] = estimate_gpu_ms(manifest.id, defaults)
+        models.append(payload)
+    return models
 
 
 async def persist_manifests(manifests: list[Manifest]) -> None:

--- a/backend/tests/test_estimates.py
+++ b/backend/tests/test_estimates.py
@@ -1,0 +1,62 @@
+from app.estimates import estimate_gpu_ms, schema_defaults
+
+
+def test_schema_defaults_reads_property_defaults():
+    parameters = {
+        "type": "object",
+        "properties": {
+            "steps": {"type": "integer", "minimum": 4, "maximum": 8, "default": 8},
+            "width": {"type": "integer", "enum": [1024], "default": 1024},
+            "height": {"type": "integer", "enum": [1024], "default": 1024},
+        },
+    }
+    assert schema_defaults(parameters) == {"steps": 8, "width": 1024, "height": 1024}
+
+
+def test_estimate_gpu_ms_at_baseline_params():
+    assert estimate_gpu_ms("sdxl-fast", {"width": 1024, "height": 1024, "steps": 8}) == 3736
+
+
+def test_estimate_gpu_ms_scales_linearly_with_steps():
+    baseline = estimate_gpu_ms("sdxl-fast", {"width": 1024, "height": 1024, "steps": 8})
+    half_steps = estimate_gpu_ms("sdxl-fast", {"width": 1024, "height": 1024, "steps": 4})
+    assert baseline == 3736
+    assert half_steps == 1868
+
+
+def test_estimate_gpu_ms_scales_with_pixel_count():
+    full = estimate_gpu_ms("dreamshaper-lcm", {"width": 512, "height": 512, "steps": 4})
+    quarter_pixels = estimate_gpu_ms("dreamshaper-lcm", {"width": 256, "height": 256, "steps": 4})
+    assert full == 578
+    assert quarter_pixels == 144
+
+
+def test_estimate_gpu_ms_uses_schema_defaults_when_params_omitted():
+    defaults = schema_defaults({
+        "properties": {
+            "steps": {"default": 20},
+            "width": {"default": 1024},
+            "height": {"default": 1024},
+        },
+    })
+    assert estimate_gpu_ms("sdxl-base", defaults) == 15274
+
+
+def test_estimate_gpu_ms_unknown_model_returns_none():
+    assert estimate_gpu_ms("missing-model", {"width": 512, "height": 512, "steps": 4}) is None
+
+
+def test_estimate_gpu_ms_requires_explicit_params():
+    assert estimate_gpu_ms("sdxl-fast", {}) is None
+    assert estimate_gpu_ms("sdxl-fast", {"steps": 8}) is None
+
+
+def test_load_timings_survives_bad_json(tmp_path, monkeypatch):
+    from app import estimates
+
+    bad = tmp_path / "model_timings.json"
+    bad.write_text("{not json", encoding="utf-8")
+    monkeypatch.setattr(estimates, "TIMINGS_PATH", bad)
+    estimates._load_timings.cache_clear()
+    assert estimates._load_timings() == {}
+    estimates._load_timings.cache_clear()

--- a/frontend/src/lib/components/generate-panel.svelte
+++ b/frontend/src/lib/components/generate-panel.svelte
@@ -22,6 +22,8 @@
 		stepsSpec,
 		valueToNorm
 	} from '$lib/model-params';
+	import { formatMs } from '$lib/benchmark';
+	import { estimateGpuMs } from '$lib/gpu-estimate';
 	import {
 		generationById,
 		isStarred,
@@ -85,6 +87,14 @@
 	const guidanceValue = $derived(normToValue(guidanceNorm, guidanceRange));
 	const sizeValue = $derived(sizeOptions[sizeIndex] ?? sizeOptions[0]);
 	const sizeKey = $derived(String(sizeValue));
+	const gpuEstimateMs = $derived(
+		estimateGpuMs(selectedModel, {
+			steps: stepsValue,
+			width: sizeValue,
+			height: sizeValue
+		})
+	);
+	const gpuEstimateLabel = $derived(gpuEstimateMs != null ? `~${formatMs(gpuEstimateMs)}` : null);
 
 	$effect(() => {
 		if (!selectedModel) return;
@@ -180,7 +190,11 @@
 						<Label for="gen-model">{t('app.gen.model')}</Label>
 						<select id="gen-model" class={fieldClass + ' h-8'} bind:value={studio.modelId}>
 							{#each studio.models as model (model.id)}
-								<option value={model.id}>{model.name}</option>
+								<option value={model.id}>
+									{model.name}{model.estimated_gpu_ms_default != null
+										? ` (~${formatMs(model.estimated_gpu_ms_default)})`
+										: ''}
+								</option>
 							{/each}
 						</select>
 					</div>
@@ -245,7 +259,7 @@
 						</div>
 					{/if}
 					<Button type="submit" disabled={studio.prompt.trim() === ''}>
-						{t('app.gen.generate')}
+						{t('app.gen.generate')}{gpuEstimateLabel != null ? ` ${gpuEstimateLabel}` : ''}
 					</Button>
 					{#if working > 0}
 						<p class="text-muted-foreground text-sm">

--- a/frontend/src/lib/gpu-estimate.ts
+++ b/frontend/src/lib/gpu-estimate.ts
@@ -1,0 +1,19 @@
+import { modelProperty, stepsSpec } from '$lib/model-params';
+import type { Model } from '$lib/studio.svelte';
+
+export function estimateGpuMs(
+	model: Model | undefined,
+	params: { steps: number; width: number; height: number }
+): number | null {
+	const baseMs = model?.estimated_gpu_ms_default;
+	if (baseMs == null || baseMs <= 0) return null;
+
+	const stepsDefault = stepsSpec(model).default;
+	const widthDefault = Number(modelProperty(model, 'width')?.default ?? params.width);
+	const heightDefault = Number(modelProperty(model, 'height')?.default ?? params.height);
+	if (stepsDefault <= 0 || widthDefault <= 0 || heightDefault <= 0) return null;
+
+	const stepScale = params.steps / stepsDefault;
+	const pixelScale = (params.width * params.height) / (widthDefault * heightDefault);
+	return Math.max(1, Math.round(baseMs * stepScale * pixelScale));
+}

--- a/frontend/src/lib/gpu-estimate.ts
+++ b/frontend/src/lib/gpu-estimate.ts
@@ -11,9 +11,18 @@ export function estimateGpuMs(
 	const stepsDefault = stepsSpec(model).default;
 	const widthDefault = Number(modelProperty(model, 'width')?.default ?? params.width);
 	const heightDefault = Number(modelProperty(model, 'height')?.default ?? params.height);
-	if (stepsDefault <= 0 || widthDefault <= 0 || heightDefault <= 0) return null;
+	const inputs = [
+		stepsDefault,
+		widthDefault,
+		heightDefault,
+		params.steps,
+		params.width,
+		params.height
+	];
+	if (inputs.some((value) => !Number.isFinite(value) || value <= 0)) return null;
 
 	const stepScale = params.steps / stepsDefault;
 	const pixelScale = (params.width * params.height) / (widthDefault * heightDefault);
-	return Math.max(1, Math.round(baseMs * stepScale * pixelScale));
+	const estimate = Math.round(baseMs * stepScale * pixelScale);
+	return Number.isFinite(estimate) ? Math.max(1, estimate) : null;
 }

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -6,6 +6,7 @@ export type Model = {
 	name: string;
 	capabilities: string[];
 	default: boolean;
+	estimated_gpu_ms_default: number | null;
 	parameters: {
 		properties?: Record<
 			string,


### PR DESCRIPTION
## Summary
- Curated `model_timings.json` from benchmark `gpu_ms` baselines (RX 7600 XT)
- `estimate_gpu_ms()` scales by steps and pixel count
- `GET /api/v1/models` includes `estimated_gpu_ms_default`
- Generate panel shows live time estimate as params change

Refs #47

## Test plan
- [x] `backend/tests/test_estimates.py` unit tests
- [x] Studio model select shows timing labels