### PR TITLE
Worker memory ladder and low-VRAM foundation (closes #15)

### DIFF
--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -25,7 +25,7 @@ dev = [
 # install this extra. See docs/local-development.md for the ROCm notes.
 inference = [
     "torch>=2.5",
-    "diffusers>=0.30",
+    "diffusers>=0.39",
     "transformers>=4.44",
     "accelerate>=0.33",
     "peft>=0.13",

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -47,6 +47,7 @@ def test_diffusers_measured_manifests_use_free_vram():
     engine = DiffusersEngine.__new__(DiffusersEngine)
     engine.device = "cuda"
     engine.memory_mode = "auto"
+    engine._rungs = {}
     manifest = Manifest(
         id="xl",
         name="XL",
@@ -59,10 +60,29 @@ def test_diffusers_measured_manifests_use_free_vram():
     assert "realtime" not in wires[0]["capabilities"]
 
 
+def test_measured_manifests_respect_pinned_rungs():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.device = "cuda"
+    engine.memory_mode = "auto"
+    engine._rungs = {"xl": "model_offload"}
+    manifest = Manifest(
+        id="xl",
+        name="XL",
+        capabilities=["text_to_image", "realtime"],
+        min_vram_gb=10,
+    )
+    # Plenty of free VRAM, but the loaded pipeline is pinned to an offload
+    # rung: the hello must not re-advertise realtime for it.
+    with patch.object(DiffusersEngine, "_free_vram_bytes", return_value=64 * 1024**3):
+        wire = engine.measured_manifests([manifest])
+    assert "realtime" not in wire[0]["capabilities"]
+
+
 def test_diffusers_effective_realtime_slots_zero_without_realtime():
     engine = DiffusersEngine.__new__(DiffusersEngine)
     engine.device = "cuda"
     engine.memory_mode = "auto"
+    engine._rungs = {}
     manifest = Manifest(
         id="xl",
         name="XL",

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -70,7 +70,8 @@ def test_diffusers_effective_realtime_slots_zero_without_realtime():
         min_vram_gb=10,
     )
     with patch.object(DiffusersEngine, "_free_vram_bytes", return_value=3 * 1024**3):
-        assert engine.effective_realtime_slots([manifest], 2) == 0
+        wire = engine.measured_manifests([manifest])
+        assert engine.effective_realtime_slots(wire, 2) == 0
 
 
 def test_evict_cold_removes_oldest_first():

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -1,10 +1,11 @@
 import asyncio
 import io
+from unittest.mock import MagicMock, patch
 
 from PIL import Image
 
-from worker.engine import SimulatedEngine
-from worker.manifests import SIMULATED_MANIFEST
+from worker.engine import DiffusersEngine, SimulatedEngine
+from worker.manifests import Manifest, SIMULATED_MANIFEST
 
 
 def test_simulated_gpu_lifecycle():
@@ -40,3 +41,48 @@ def test_simulated_generate_with_input_image():
     assert result.width == 256
     assert result.height == 128
     assert result.data[:4] == b"RIFF"
+
+
+def test_diffusers_measured_manifests_use_free_vram():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.device = "cuda"
+    engine.memory_mode = "auto"
+    manifest = Manifest(
+        id="xl",
+        name="XL",
+        capabilities=["text_to_image", "realtime"],
+        min_vram_gb=10,
+    )
+    with patch.object(DiffusersEngine, "_free_vram_bytes", return_value=3 * 1024**3):
+        wires = engine.measured_manifests([manifest])
+    assert wires[0]["id"] == "xl"
+    assert "realtime" not in wires[0]["capabilities"]
+
+
+def test_diffusers_effective_realtime_slots_zero_without_realtime():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.device = "cuda"
+    engine.memory_mode = "auto"
+    manifest = Manifest(
+        id="xl",
+        name="XL",
+        capabilities=["text_to_image", "realtime"],
+        min_vram_gb=10,
+    )
+    with patch.object(DiffusersEngine, "_free_vram_bytes", return_value=3 * 1024**3):
+        assert engine.effective_realtime_slots([manifest], 2) == 0
+
+
+def test_evict_cold_removes_oldest_first():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine._pipelines = {("a", "t2i"): object(), ("b", "t2i"): object()}
+    engine._rungs = {"a": "full", "b": "full"}
+    engine._last_used = {"a": 20.0, "b": 10.0}
+    engine._free_gpu_cache = MagicMock()
+    engine._free_vram_bytes = MagicMock(return_value=0)
+
+    engine._evict_cold(except_model_id="a")
+
+    assert ("a", "t2i") in engine._pipelines
+    assert ("b", "t2i") not in engine._pipelines
+    assert "b" not in engine._rungs

--- a/worker/tests/test_memory_ladder.py
+++ b/worker/tests/test_memory_ladder.py
@@ -1,0 +1,77 @@
+from worker.manifests import Manifest
+from worker.memory_ladder import (
+    GB,
+    capabilities_for_rung,
+    effective_realtime_slots,
+    full_residency_bytes,
+    group_offload_bytes,
+    measured_wire_manifest,
+    measured_wire_manifests,
+    model_offload_bytes,
+    select_rung,
+)
+
+
+def manifest(min_vram_gb: int = 8) -> Manifest:
+    return Manifest(
+        id="test-model",
+        name="Test",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+        min_vram_gb=min_vram_gb,
+    )
+
+
+def test_select_rung_full_when_enough_vram():
+    assert select_rung(8, full_residency_bytes(8), "auto", on_cpu=False) == "full"
+
+
+def test_select_rung_model_offload_when_pipeline_too_large():
+    free = model_offload_bytes(10) + 1
+    assert select_rung(10, free, "auto", on_cpu=False) == "model_offload"
+
+
+def test_select_rung_group_offload_when_tight():
+    free = group_offload_bytes() - 1
+    assert select_rung(10, free, "auto", on_cpu=False) == "group_offload"
+
+
+def test_select_rung_respects_pin():
+    assert select_rung(8, 100 * GB, "group_offload", on_cpu=False) == "group_offload"
+    assert select_rung(8, 1, "full", on_cpu=False) == "full"
+
+
+def test_select_rung_cpu_is_always_full():
+    assert select_rung(8, 1, "auto", on_cpu=True) == "full"
+
+
+def test_capabilities_drop_realtime_off_full():
+    caps = ["text_to_image", "realtime"]
+    assert capabilities_for_rung(caps, "full") == caps
+    assert capabilities_for_rung(caps, "model_offload") == ["text_to_image"]
+    assert capabilities_for_rung(caps, "group_offload") == ["text_to_image"]
+
+
+def test_measured_wire_manifest():
+    wire = measured_wire_manifest(manifest(), "model_offload")
+    assert wire["id"] == "test-model"
+    assert "realtime" not in wire["capabilities"]
+    assert "text_to_image" in wire["capabilities"]
+
+
+def test_measured_wire_manifests_per_model():
+    small = manifest(min_vram_gb=4)
+    large = manifest(min_vram_gb=16)
+    large = large.model_copy(update={"id": "big"})
+    wires = measured_wire_manifests([small, large], 6 * GB, "auto", on_cpu=False)
+    by_id = {wire["id"]: wire for wire in wires}
+    assert "realtime" in by_id["test-model"]["capabilities"]
+    assert "realtime" not in by_id["big"]["capabilities"]
+
+
+def test_effective_realtime_slots():
+    full = measured_wire_manifest(manifest(), "full")
+    offload = measured_wire_manifest(manifest(), "model_offload")
+    assert effective_realtime_slots([full], 2) == 2
+    assert effective_realtime_slots([offload], 2) == 0
+    assert effective_realtime_slots([full, offload], 2) == 2
+    assert effective_realtime_slots([full], 0) == 0

--- a/worker/tests/test_settings.py
+++ b/worker/tests/test_settings.py
@@ -9,7 +9,9 @@ def test_defaults():
 
 def test_env_override(monkeypatch):
     monkeypatch.setenv("DEVICE", "rocm")
+    monkeypatch.setenv("MEMORY_MODE", "model_offload")
     monkeypatch.setenv("API_URL", "ws://api:8080/api/v1/fleet")
     settings = Settings()
     assert settings.device == "rocm"
+    assert settings.memory_mode == "model_offload"
     assert settings.api_url == "ws://api:8080/api/v1/fleet"

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -254,7 +254,8 @@ async def serve_connection(ws, settings: Settings, manifests: list[Manifest],
         "protocol_version": PROTOCOL_VERSION,
         "worker_id": settings.worker_id,
         "models": wire_manifests,
-        "realtime_slots": engine.effective_realtime_slots(manifests, settings.realtime_slots),
+        "realtime_slots": engine.effective_realtime_slots(wire_manifests,
+                                                           settings.realtime_slots),
     }))
     try:
         response = json.loads(await ws.recv())

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -64,7 +64,11 @@ def build_runtime(settings: Settings) -> tuple[list[Manifest], Engine]:
     if settings.models_dir:
         from worker.engine import DiffusersEngine
 
-        return load_manifests(settings.models_dir), DiffusersEngine(settings.device)
+        return load_manifests(settings.models_dir), DiffusersEngine(
+            settings.device,
+            memory_mode=settings.memory_mode,
+            models_dir=settings.models_dir,
+        )
     return [SIMULATED_MANIFEST], SimulatedEngine(settings.inference_seconds)
 
 
@@ -244,12 +248,13 @@ async def _gpu_unload(ws, engine: Engine, control: dict) -> None:
 
 async def serve_connection(ws, settings: Settings, manifests: list[Manifest],
                            engine: Engine) -> None:
+    wire_manifests = engine.measured_manifests(manifests)
     await ws.send(json.dumps({
         "type": "hello",
         "protocol_version": PROTOCOL_VERSION,
         "worker_id": settings.worker_id,
-        "models": [manifest.wire() for manifest in manifests],
-        "realtime_slots": settings.realtime_slots,
+        "models": wire_manifests,
+        "realtime_slots": engine.effective_realtime_slots(manifests, settings.realtime_slots),
     }))
     try:
         response = json.loads(await ws.recv())

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -16,11 +16,19 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from hashlib import sha256
+from pathlib import Path
 from typing import Any, Protocol
 
 from PIL import Image
 
 from worker.manifests import Manifest
+from worker.memory_ladder import (
+    MemoryMode,
+    MemoryRung,
+    measured_wire_manifests,
+    rung_vram_bytes,
+    select_rung,
+)
 
 ProgressFn = Callable[[float], None]
 
@@ -44,6 +52,10 @@ class Engine(Protocol):
     async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes: ...
 
     def loaded_models(self) -> list[str]: ...
+
+    def measured_manifests(self, manifests: list[Manifest]) -> list[dict]: ...
+
+    def effective_realtime_slots(self, manifests: list[Manifest], configured: int) -> int: ...
 
     async def load_model(self, manifest: Manifest) -> int: ...
 
@@ -84,6 +96,14 @@ class SimulatedEngine:
 
     def loaded_models(self) -> list[str]:
         return sorted(self._loaded)
+
+    def measured_manifests(self, manifests: list[Manifest]) -> list[dict]:
+        return measured_wire_manifests(manifests, 1 << 60, "full", on_cpu=True)
+
+    def effective_realtime_slots(self, manifests: list[Manifest], configured: int) -> int:
+        from worker.memory_ladder import effective_realtime_slots
+
+        return effective_realtime_slots(self.measured_manifests(manifests), configured)
 
     async def load_model(self, manifest: Manifest) -> int:
         start = time.monotonic()
@@ -136,7 +156,8 @@ class SimulatedEngine:
 class DiffusersEngine:
     """Hugging Face diffusers pipelines, one GPU, all inference serialized."""
 
-    def __init__(self, device: str):
+    def __init__(self, device: str, *, memory_mode: MemoryMode = "auto",
+                 models_dir: str = ""):
         if device == "rocm":
             # RDNA3 consumer cards gate their fused attention kernels behind
             # this flag; the fallback is math attention, several times slower.
@@ -149,12 +170,46 @@ class DiffusersEngine:
         # in which image variant and driver stack surrounds this process.
         self.device = "cuda" if device in ("cuda", "rocm") else "cpu"
         self.dtype = torch.float16 if self.device == "cuda" else torch.float32
+        self.memory_mode = memory_mode
+        self.models_dir = models_dir
         self._pipelines: dict[tuple[str, str], Any] = {}
+        self._rungs: dict[str, MemoryRung] = {}
+        self._last_used: dict[str, float] = {}
         self._gpu = asyncio.Lock()
+
+    def _free_vram_bytes(self) -> int:
+        if self.device != "cuda":
+            return 1 << 60
+        free, _total = self.torch.cuda.mem_get_info()
+        return int(free)
+
+    def measured_manifests(self, manifests: list[Manifest]) -> list[dict]:
+        return measured_wire_manifests(
+            manifests, self._free_vram_bytes(), self.memory_mode,
+            on_cpu=self.device != "cuda",
+        )
+
+    def effective_realtime_slots(self, manifests: list[Manifest], configured: int) -> int:
+        from worker.memory_ladder import effective_realtime_slots
+
+        return effective_realtime_slots(self.measured_manifests(manifests), configured)
+
+    def model_rung(self, model_id: str) -> MemoryRung | None:
+        return self._rungs.get(model_id)
+
+    def _touch(self, model_id: str) -> None:
+        self._last_used[model_id] = time.monotonic()
+
+    def _ensure_vram(self, manifest: Manifest) -> None:
+        rung = self._pick_rung(manifest)
+        required = rung_vram_bytes(manifest.min_vram_gb, rung)
+        if self._free_vram_bytes() < required:
+            self._evict_cold(except_model_id=manifest.id, required_bytes=required)
 
     def _pipeline(self, manifest: Manifest, mode: str) -> Any:
         key = (manifest.id, mode)
         if key not in self._pipelines:
+            self._ensure_vram(manifest)
             try:
                 self._pipelines[key] = self._load(manifest, mode)
             except self.torch.OutOfMemoryError:
@@ -163,12 +218,40 @@ class DiffusersEngine:
                 # attempt and the eviction below could not reclaim them.
                 pass
             if key not in self._pipelines:
-                # A 16 GB card fits roughly one XL model plus headroom: evict
-                # every other model and retry once. A real eviction policy
-                # (LRU with a min-warm TTL) lands with issue #15.
-                self._evict_except(manifest.id)
+                self._evict_cold(except_model_id=manifest.id)
                 self._pipelines[key] = self._load(manifest, mode)
+        self._touch(manifest.id)
         return self._pipelines[key]
+
+    def _pick_rung(self, manifest: Manifest) -> MemoryRung:
+        if manifest.id in self._rungs:
+            return self._rungs[manifest.id]
+        rung = select_rung(
+            manifest.min_vram_gb, self._free_vram_bytes(), self.memory_mode,
+            on_cpu=self.device != "cuda",
+        )
+        self._rungs[manifest.id] = rung
+        return rung
+
+    def _apply_rung(self, pipeline: Any, manifest: Manifest, rung: MemoryRung) -> Any:
+        if rung == "full":
+            return pipeline.to(self.device)
+        if rung == "model_offload":
+            if self.device == "cuda":
+                pipeline.enable_model_cpu_offload(gpu_id=0)
+            else:
+                pipeline.enable_model_cpu_offload()
+            return pipeline
+        offload_dir = None
+        if self.models_dir:
+            offload_dir = str(Path(self.models_dir) / ".offload" / manifest.id)
+            Path(offload_dir).mkdir(parents=True, exist_ok=True)
+        pipeline.enable_group_offload(
+            onload_device=self.device,
+            use_stream=True,
+            offload_to_disk_path=offload_dir,
+        )
+        return pipeline
 
     def _load(self, manifest: Manifest, mode: str) -> Any:
         from diffusers import AutoPipelineForImage2Image, AutoPipelineForText2Image
@@ -193,7 +276,8 @@ class DiffusersEngine:
                     module = getattr(pipeline, name, None)
                     if module is not None:
                         module.to(memory_format=self.torch.channels_last)
-            pipeline = pipeline.to(self.device)
+            rung = self._pick_rung(manifest)
+            pipeline = self._apply_rung(pipeline, manifest, rung)
         if manifest.scheduler:
             pipeline.scheduler = self._scheduler(manifest.scheduler, pipeline.scheduler.config)
         pipeline.set_progress_bar_config(disable=True)
@@ -226,15 +310,23 @@ class DiffusersEngine:
         if self.device == "cuda":
             self.torch.cuda.empty_cache()
 
+    def _evict_cold(self, except_model_id: str, *, required_bytes: int = 0) -> None:
+        loaded = sorted({key[0] for key in self._pipelines})
+        candidates = [model_id for model_id in loaded if model_id != except_model_id]
+        candidates.sort(key=lambda model_id: self._last_used.get(model_id, 0.0))
+        for model_id in candidates:
+            if required_bytes and self._free_vram_bytes() >= required_bytes:
+                break
+            self._evict_model(model_id)
+
     def _evict_except(self, model_id: str) -> None:
-        evicted = [key for key in self._pipelines if key[0] != model_id]
-        for key in evicted:
-            del self._pipelines[key]
-        self._free_gpu_cache()
+        self._evict_cold(except_model_id=model_id)
 
     def _evict_model(self, model_id: str) -> None:
         for key in [key for key in self._pipelines if key[0] == model_id]:
             del self._pipelines[key]
+        self._rungs.pop(model_id, None)
+        self._last_used.pop(model_id, None)
         self._free_gpu_cache()
 
     def _evict_all(self) -> None:
@@ -247,12 +339,18 @@ class DiffusersEngine:
 
     def _load_model(self, manifest: Manifest) -> int:
         self._evict_all()
+        rung = select_rung(
+            manifest.min_vram_gb, self._free_vram_bytes(), self.memory_mode,
+            on_cpu=self.device != "cuda",
+        )
+        self._rungs[manifest.id] = rung
         start = time.monotonic()
         try:
             self._pipelines[(manifest.id, "t2i")] = self._load(manifest, "t2i")
         except self.torch.OutOfMemoryError:
             self._evict_all()
             self._pipelines[(manifest.id, "t2i")] = self._load(manifest, "t2i")
+        self._touch(manifest.id)
         return int((time.monotonic() - start) * 1000)
 
     async def unload_model(self, model_id: str) -> None:
@@ -384,6 +482,8 @@ class DiffusersEngine:
             return await asyncio.to_thread(self._frame, manifest, dict(params), payload)
 
     def _frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes:
+        if self._pick_rung(manifest) != "full":
+            raise ValueError(f"model {manifest.id} is not fully resident for realtime")
         canvas = Image.open(io.BytesIO(payload)).convert("RGB")
         canvas = canvas.resize((REALTIME_SIZE, REALTIME_SIZE))
         strength = min(max(float(params.get("strength", 0.7)), 0.05), 1.0)

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -25,6 +25,7 @@ from worker.manifests import Manifest
 from worker.memory_ladder import (
     MemoryMode,
     MemoryRung,
+    measured_wire_manifest,
     measured_wire_manifests,
     rung_vram_bytes,
     select_rung,
@@ -184,10 +185,20 @@ class DiffusersEngine:
         return int(free)
 
     def measured_manifests(self, manifests: list[Manifest]) -> list[dict]:
-        return measured_wire_manifests(
-            manifests, self._free_vram_bytes(), self.memory_mode,
-            on_cpu=self.device != "cuda",
-        )
+        # Loaded models keep their pinned rung: an offloaded pipeline leaves
+        # VRAM looking free, and a reconnect must not re-advertise realtime
+        # for a model that _frame would refuse.
+        free = self._free_vram_bytes()
+        on_cpu = self.device != "cuda"
+        return [
+            measured_wire_manifest(
+                manifest,
+                self._rungs.get(manifest.id)
+                or select_rung(manifest.min_vram_gb, free, self.memory_mode,
+                               on_cpu=on_cpu),
+            )
+            for manifest in manifests
+        ]
 
     def effective_realtime_slots(self, wire_manifests: list[dict], configured: int) -> int:
         from worker.memory_ladder import effective_realtime_slots

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -201,6 +201,12 @@ class DiffusersEngine:
         self._last_used[model_id] = time.monotonic()
 
     def _ensure_vram(self, manifest: Manifest) -> None:
+        if self.memory_mode == "auto" and manifest.id not in self._rungs:
+            # Prefer evicting cold residents over degrading the new model to
+            # an offload rung: make room for full residency before picking.
+            wanted = rung_vram_bytes(manifest.min_vram_gb, "full")
+            if self._free_vram_bytes() < wanted:
+                self._evict_cold(except_model_id=manifest.id, required_bytes=wanted)
         rung = self._pick_rung(manifest)
         required = rung_vram_bytes(manifest.min_vram_gb, rung)
         if self._free_vram_bytes() < required:
@@ -247,7 +253,10 @@ class DiffusersEngine:
             offload_dir = str(Path(self.models_dir) / ".offload" / manifest.id)
             Path(offload_dir).mkdir(parents=True, exist_ok=True)
         pipeline.enable_group_offload(
-            onload_device=self.device,
+            onload_device=self.torch.device(self.device),
+            # leaf_level streams layer by layer and needs no block sizing;
+            # block_level raises when num_blocks_per_group is unset.
+            offload_type="leaf_level",
             use_stream=True,
             offload_to_disk_path=offload_dir,
         )
@@ -331,6 +340,8 @@ class DiffusersEngine:
 
     def _evict_all(self) -> None:
         self._pipelines.clear()
+        self._rungs.clear()
+        self._last_used.clear()
         self._free_gpu_cache()
 
     async def load_model(self, manifest: Manifest) -> int:

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -55,7 +55,7 @@ class Engine(Protocol):
 
     def measured_manifests(self, manifests: list[Manifest]) -> list[dict]: ...
 
-    def effective_realtime_slots(self, manifests: list[Manifest], configured: int) -> int: ...
+    def effective_realtime_slots(self, wire_manifests: list[dict], configured: int) -> int: ...
 
     async def load_model(self, manifest: Manifest) -> int: ...
 
@@ -100,10 +100,10 @@ class SimulatedEngine:
     def measured_manifests(self, manifests: list[Manifest]) -> list[dict]:
         return measured_wire_manifests(manifests, 1 << 60, "full", on_cpu=True)
 
-    def effective_realtime_slots(self, manifests: list[Manifest], configured: int) -> int:
+    def effective_realtime_slots(self, wire_manifests: list[dict], configured: int) -> int:
         from worker.memory_ladder import effective_realtime_slots
 
-        return effective_realtime_slots(self.measured_manifests(manifests), configured)
+        return effective_realtime_slots(wire_manifests, configured)
 
     async def load_model(self, manifest: Manifest) -> int:
         start = time.monotonic()
@@ -189,10 +189,10 @@ class DiffusersEngine:
             on_cpu=self.device != "cuda",
         )
 
-    def effective_realtime_slots(self, manifests: list[Manifest], configured: int) -> int:
+    def effective_realtime_slots(self, wire_manifests: list[dict], configured: int) -> int:
         from worker.memory_ladder import effective_realtime_slots
 
-        return effective_realtime_slots(self.measured_manifests(manifests), configured)
+        return effective_realtime_slots(wire_manifests, configured)
 
     def model_rung(self, model_id: str) -> MemoryRung | None:
         return self._rungs.get(model_id)
@@ -250,7 +250,8 @@ class DiffusersEngine:
             return pipeline
         offload_dir = None
         if self.models_dir:
-            offload_dir = str(Path(self.models_dir) / ".offload" / manifest.id)
+            safe_id = "".join(c if c.isalnum() or c in "._-" else "-" for c in manifest.id)
+            offload_dir = str(Path(self.models_dir) / ".offload" / safe_id.lstrip("."))
             Path(offload_dir).mkdir(parents=True, exist_ok=True)
         pipeline.enable_group_offload(
             onload_device=self.torch.device(self.device),
@@ -493,6 +494,8 @@ class DiffusersEngine:
             return await asyncio.to_thread(self._frame, manifest, dict(params), payload)
 
     def _frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes:
+        if "realtime" not in manifest.capabilities:
+            raise ValueError(f"model {manifest.id} does not support realtime frames")
         if self._pick_rung(manifest) != "full":
             raise ValueError(f"model {manifest.id} is not fully resident for realtime")
         canvas = Image.open(io.BytesIO(payload)).convert("RGB")

--- a/worker/worker/memory_ladder.py
+++ b/worker/worker/memory_ladder.py
@@ -40,7 +40,8 @@ def select_rung(
     *,
     on_cpu: bool,
 ) -> MemoryRung:
-    """Pick the highest rung that fits, or the pinned rung when not auto."""
+    """Pick the highest rung that fits (group offload is the floor even when
+    free memory is below its working set), or the pinned rung when not auto."""
     if on_cpu:
         return "full"
     if memory_mode == "full":

--- a/worker/worker/memory_ladder.py
+++ b/worker/worker/memory_ladder.py
@@ -1,0 +1,100 @@
+"""Per-model memory ladder (docs/architecture.md, docs/decisions.md).
+
+At load time the worker measures free VRAM and picks the highest rung that
+fits, or the rung pinned by MEMORY_MODE. Only full residency advertises the
+realtime capability.
+"""
+
+from typing import Literal
+
+from worker.manifests import Manifest
+
+GB = 1024**3
+
+MemoryMode = Literal["auto", "full", "model_offload", "group_offload"]
+MemoryRung = Literal["full", "model_offload", "group_offload"]
+
+# UNet is the largest single component; ~55% of full-pipeline VRAM is a
+# stable heuristic across SD and SDXL class models.
+LARGEST_COMPONENT_FRACTION = 0.55
+# Group offload holds a few layer groups on the GPU.
+GROUP_OFFLOAD_GB = 2
+
+
+def full_residency_bytes(min_vram_gb: int) -> int:
+    return min_vram_gb * GB
+
+
+def model_offload_bytes(min_vram_gb: int) -> int:
+    return max(int(min_vram_gb * GB * LARGEST_COMPONENT_FRACTION), GROUP_OFFLOAD_GB * GB)
+
+
+def group_offload_bytes() -> int:
+    return GROUP_OFFLOAD_GB * GB
+
+
+def select_rung(
+    min_vram_gb: int,
+    free_bytes: int,
+    memory_mode: MemoryMode,
+    *,
+    on_cpu: bool,
+) -> MemoryRung:
+    """Pick the highest rung that fits, or the pinned rung when not auto."""
+    if on_cpu:
+        return "full"
+    if memory_mode == "full":
+        return "full"
+    if memory_mode == "model_offload":
+        return "model_offload"
+    if memory_mode == "group_offload":
+        return "group_offload"
+    if free_bytes >= full_residency_bytes(min_vram_gb):
+        return "full"
+    if free_bytes >= model_offload_bytes(min_vram_gb):
+        return "model_offload"
+    return "group_offload"
+
+
+def capabilities_for_rung(capabilities: list[str], rung: MemoryRung) -> list[str]:
+    if rung == "full":
+        return list(capabilities)
+    return [cap for cap in capabilities if cap != "realtime"]
+
+
+def measured_wire_manifest(manifest: Manifest, rung: MemoryRung) -> dict:
+    wire = manifest.wire()
+    wire["capabilities"] = capabilities_for_rung(manifest.capabilities, rung)
+    return wire
+
+
+def measured_wire_manifests(
+    manifests: list[Manifest],
+    free_bytes: int,
+    memory_mode: MemoryMode,
+    *,
+    on_cpu: bool,
+) -> list[dict]:
+    return [
+        measured_wire_manifest(
+            manifest,
+            select_rung(manifest.min_vram_gb, free_bytes, memory_mode, on_cpu=on_cpu),
+        )
+        for manifest in manifests
+    ]
+
+
+def effective_realtime_slots(wire_manifests: list[dict], configured: int) -> int:
+    if configured <= 0:
+        return 0
+    if any("realtime" in manifest["capabilities"] for manifest in wire_manifests):
+        return configured
+    return 0
+
+
+def rung_vram_bytes(min_vram_gb: int, rung: MemoryRung) -> int:
+    if rung == "full":
+        return full_residency_bytes(min_vram_gb)
+    if rung == "model_offload":
+        return model_offload_bytes(min_vram_gb)
+    return group_offload_bytes()

--- a/worker/worker/settings.py
+++ b/worker/worker/settings.py
@@ -12,6 +12,7 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     device: Literal["cuda", "rocm", "cpu"] = "cpu"
+    memory_mode: Literal["auto", "full", "model_offload", "group_offload"] = "auto"
     api_url: str = "ws://localhost:8000/api/v1/fleet"
     log_format: Literal["plain", "json"] = "plain"
     worker_id: str = Field(default_factory=lambda: f"worker-{uuid.uuid4().hex[:8]}")


### PR DESCRIPTION
## Summary

- Add per-model memory ladder (`auto` / `full` / `model_offload` / `group_offload`) driven by measured free VRAM at load time, with `MEMORY_MODE` to pin a rung.
- Apply native diffusers offload paths in `DiffusersEngine`; only full residency keeps the `realtime` capability.
- Hello registration advertises capabilities as measured and `realtime_slots` reflects actual capacity (zero when no model can serve realtime).
- Replace blunt evict-all-on-OOM with LRU cold-model eviction when switching models under VRAM pressure.

Closes #15

## Test plan

- [x] `worker/.venv/bin/pytest` (29 tests, including new ladder and eviction unit tests)
- [x] `make verify` (lint, backend/worker/frontend tests, frontend build)
- [ ] Manual: `make worker-rocm` on 8 GB card with `MEMORY_MODE=auto` - confirm hello drops `realtime` for SDXL manifests while sd-turbo stays realtime-capable
- [ ] Manual: pin `MEMORY_MODE=model_offload` and confirm jobs run without realtime admission

## Deferred

- Backend scheduler preference for lower-rung workers (documented in architecture; separate issue)
- GPU info in hello payload (blueprint mentions it; not required for ladder)
- Min-warm TTL on eviction (simple LRU only for now)