### PR TITLE
Benchmark license-safe turbo candidates: Hyper-SD and VegaRT

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -115,7 +115,7 @@ async def create_generation(
     user: User = Depends(current_user),
     session: AsyncSession = Depends(db.get_session),
 ) -> dict:
-    manifest = registry.public().get(request.model_id)
+    manifest = registry.for_jobs().get(request.model_id)
     if manifest is None:
         raise HTTPException(status_code=404, detail="unknown model")
     if error := validate_params(manifest, request.params):

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -33,6 +33,15 @@ def public() -> dict[str, Manifest]:
             if not manifest.benchmark_only}
 
 
+def for_jobs() -> dict[str, Manifest]:
+    """Manifests eligible for POST /api/v1/generations."""
+    from app.settings import get_settings
+
+    if get_settings().benchmark_api:
+        return available()
+    return public()
+
+
 @router.get("/api/v1/models")
 async def list_models() -> list[dict]:
     models = []

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -96,6 +96,34 @@ def test_generation_end_to_end():
 
 
 @pytest.mark.db
+def test_benchmark_only_model_hidden_without_benchmark_api():
+    bench_manifest = {**MANIFEST, "id": "bench-only", "benchmark_only": True}
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-bench", manifest=bench_manifest)
+            missing = client.post("/api/v1/generations",
+                                  json={"model_id": "bench-only",
+                                        "params": {"prompt": "hidden"}})
+            assert missing.status_code == 404
+
+
+@pytest.mark.db
+def test_benchmark_only_model_allowed_when_benchmark_api_enabled(monkeypatch):
+    monkeypatch.setenv("BENCHMARK_API", "1")
+    from app.settings import get_settings
+
+    get_settings.cache_clear()
+    bench_manifest = {**MANIFEST, "id": "bench-only", "benchmark_only": True}
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-bench", manifest=bench_manifest)
+            created = client.post("/api/v1/generations",
+                                  json={"model_id": "bench-only",
+                                        "params": {"prompt": "benchmark"}})
+            assert created.status_code == 202
+
+
+@pytest.mark.db
 def test_unknown_model_and_invalid_params():
     with TestClient(app) as client:
         missing = client.post("/api/v1/generations", json={"model_id": "nope", "params": {}})

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -13,7 +13,7 @@ select them. Reference timings may still appear on `/benchmark`.
 | Model | License | Product status |
 | --- | --- | --- |
 | sd-turbo, sdxl-turbo | Stability AI Community | Benchmark reference |
-| sdxl-hypersd | CreativeML Open RAIL++-M + ByteDance Hyper-SD | Benchmark reference (issue #75) |
+| sdxl-hypersd | Open RAIL++-M base + Hyper-SD LoRA with NO declared license | Benchmark reference (issue #75); not promotable until ByteDance declares terms |
 | vega-rt | Apache 2.0 | Benchmark reference (issue #75) |
 | ssd-1b-lightning | Apache 2.0 + ByteDance Lightning | Benchmark reference (issue #75; experimental) |
 
@@ -44,8 +44,8 @@ requires:
 | Model | License |
 | --- | --- |
 | sdxl-base, sdxl-fast (base weights) | CreativeML Open RAIL++-M |
-| sdxl-fast (Lightning LoRA) | ByteDance SDXL Lightning (see HF model card) |
-| sdxl-hypersd (Hyper-SD LoRA) | ByteDance Hyper-SD on SDXL base (see HF model card) |
+| sdxl-fast (Lightning LoRA) | CreativeML Open RAIL++-M (openrail++ tag on the card) |
+| sdxl-hypersd (Hyper-SD LoRA) | No license declared on the ByteDance/Hyper-SD card (verified 2026-07-14); base weights Open RAIL++-M |
 | vega-rt (VegaRT LoRA) | Apache 2.0 (Segmind-Vega base) |
 | ssd-1b | Apache 2.0 |
 | dreamshaper-lcm | CreativeML Open RAIL-M |

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -15,7 +15,7 @@ select them. Reference timings may still appear on `/benchmark`.
 | sd-turbo, sdxl-turbo | Stability AI Community | Benchmark reference |
 | sdxl-hypersd | Open RAIL++-M base + Hyper-SD LoRA with NO declared license | Benchmark reference (issue #75); not promotable until ByteDance declares terms |
 | vega-rt | Apache 2.0 | Benchmark reference (issue #75) |
-| ssd-1b-lightning | Apache 2.0 + ByteDance Lightning | Benchmark reference (issue #75; experimental) |
+| ssd-1b-lightning | Apache 2.0 base + Open RAIL++-M Lightning LoRA | Benchmark reference (issue #75; experimental) |
 
 If you later offer any of these in the product, the obligations below apply.
 
@@ -45,8 +45,6 @@ requires:
 | --- | --- |
 | sdxl-base, sdxl-fast (base weights) | CreativeML Open RAIL++-M |
 | sdxl-fast (Lightning LoRA) | CreativeML Open RAIL++-M (openrail++ tag on the card) |
-| sdxl-hypersd (Hyper-SD LoRA) | No license declared on the ByteDance/Hyper-SD card (verified 2026-07-14); base weights Open RAIL++-M |
-| vega-rt (VegaRT LoRA) | Apache 2.0 (Segmind-Vega base) |
 | ssd-1b | Apache 2.0 |
 | dreamshaper-lcm | CreativeML Open RAIL-M |
 

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -13,6 +13,9 @@ select them. Reference timings may still appear on `/benchmark`.
 | Model | License | Product status |
 | --- | --- | --- |
 | sd-turbo, sdxl-turbo | Stability AI Community | Benchmark reference |
+| sdxl-hypersd | CreativeML Open RAIL++-M + ByteDance Hyper-SD | Benchmark reference (issue #75) |
+| vega-rt | Apache 2.0 | Benchmark reference (issue #75) |
+| ssd-1b-lightning | Apache 2.0 + ByteDance Lightning | Benchmark reference (issue #75; experimental) |
 
 If you later offer any of these in the product, the obligations below apply.
 
@@ -42,6 +45,8 @@ requires:
 | --- | --- |
 | sdxl-base, sdxl-fast (base weights) | CreativeML Open RAIL++-M |
 | sdxl-fast (Lightning LoRA) | ByteDance SDXL Lightning (see HF model card) |
+| sdxl-hypersd (Hyper-SD LoRA) | ByteDance Hyper-SD on SDXL base (see HF model card) |
+| vega-rt (VegaRT LoRA) | Apache 2.0 (Segmind-Vega base) |
 | ssd-1b | Apache 2.0 |
 | dreamshaper-lcm | CreativeML Open RAIL-M |
 

--- a/frontend/src/lib/model-specs.ts
+++ b/frontend/src/lib/model-specs.ts
@@ -109,8 +109,8 @@ export const MODEL_SPECS: ModelSpec[] = [
 		resolutions: '1024',
 		step_range: '4-8',
 		capabilities: ['text_to_image'],
-		license: 'RAIL++-M + ByteDance Hyper-SD',
-		commercial: 'Unrestricted (RAIL use policy)',
+		license: 'RAIL++-M base; LoRA: no declared license',
+		commercial: 'Unclear - LoRA license undeclared',
 		studio: false,
 		source: 'stabilityai/stable-diffusion-xl-base-1.0'
 	},
@@ -137,8 +137,8 @@ export const MODEL_SPECS: ModelSpec[] = [
 		resolutions: '1024',
 		step_range: '4-8',
 		capabilities: ['text_to_image'],
-		license: 'Apache 2.0 + ByteDance Lightning',
-		commercial: 'Unrestricted',
+		license: 'Apache 2.0 base + Open RAIL++-M LoRA',
+		commercial: 'RAIL use policy applies',
 		studio: false,
 		source: 'segmind/SSD-1B'
 	}

--- a/frontend/src/lib/model-specs.ts
+++ b/frontend/src/lib/model-specs.ts
@@ -99,6 +99,48 @@ export const MODEL_SPECS: ModelSpec[] = [
 		commercial: '≤ $1M revenue / year',
 		studio: false,
 		source: 'stabilityai/sdxl-turbo'
+	},
+	{
+		id: 'sdxl-hypersd',
+		name: 'SDXL Hyper-SD',
+		architecture: 'SDXL + Hyper-SD LoRA',
+		parameters: '~3.5B',
+		min_vram_gb: 10,
+		resolutions: '1024',
+		step_range: '4-8',
+		capabilities: ['text_to_image'],
+		license: 'RAIL++-M + ByteDance Hyper-SD',
+		commercial: 'Unrestricted (RAIL use policy)',
+		studio: false,
+		source: 'stabilityai/stable-diffusion-xl-base-1.0'
+	},
+	{
+		id: 'vega-rt',
+		name: 'Segmind VegaRT',
+		architecture: 'Segmind-Vega + VegaRT LCM LoRA',
+		parameters: '~1.0B',
+		min_vram_gb: 8,
+		resolutions: '512, 1024',
+		step_range: '2-8',
+		capabilities: ['text_to_image'],
+		license: 'Apache 2.0',
+		commercial: 'Unrestricted',
+		studio: false,
+		source: 'segmind/Segmind-Vega'
+	},
+	{
+		id: 'ssd-1b-lightning',
+		name: 'SSD-1B + Lightning',
+		architecture: 'SSD-1B + Lightning LoRA (experimental)',
+		parameters: '~1.3B',
+		min_vram_gb: 8,
+		resolutions: '1024',
+		step_range: '4-8',
+		capabilities: ['text_to_image'],
+		license: 'Apache 2.0 + ByteDance Lightning',
+		commercial: 'Unrestricted',
+		studio: false,
+		source: 'segmind/SSD-1B'
 	}
 ];
 

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -1,8 +1,8 @@
 # Image generation benchmark (8 GB VRAM)
 
 Curated prompt suite + parameter matrix for comparing models on a consumer GPU
-(RX 7600 class, 8 GB). Run with `make benchmark` after `make api` and
-`make worker-rocm` are up.
+(RX 7600 class, 8 GB). Run with `make benchmark` after `make api` (with
+`BENCHMARK_API=1`) and `make worker-rocm` are up.
 
 Measured baselines and the optimization backlog live in [issue #60](https://github.com/portocolom-studio/potocolom/issues/60).
 
@@ -45,6 +45,30 @@ make benchmark BENCHMARK_MODELS=ssd-1b-lightning
 
 Measured numbers decide whether a follow-up PR promotes a winner to the product
 manifests (realtime capability, `min_vram_gb` from measurement).
+
+### Issue #75 decision (RX 7600 XT, 2026-07-14)
+
+Quick run: 3 prompts, 1 variant each (`BENCHMARK_QUICK=1`), models
+`sdxl-hypersd`, `vega-rt`, `sdxl-fast`, `ssd-1b`, `sd-turbo`, `sdxl-turbo`.
+Raw output: `data/benchmark/issue-75-run/` (gitignored).
+
+| Model | Median gpu_ms | Resolution / steps | Verdict |
+| --- | ---: | --- | --- |
+| sd-turbo | 274 | 512 / 2 | Benchmark anchor (Stability cap) |
+| sdxl-turbo | 2739 | 512 / 1 | Benchmark anchor (Stability cap) |
+| **vega-rt** | **347** | 512 / 2 | **License-clean turbo-class winner** - follow-up PR to promote |
+| sdxl-fast | 7153 | 1024 / 8 | Open baseline (Lightning) |
+| sdxl-hypersd | 6665 | 1024 / 8 | Benchmark only - LoRA has no declared license |
+| ssd-1b | 9716 | 1024 / 20 | Batch tier, not realtime |
+
+**Conclusion:** No product manifest in this PR. VegaRT (Apache 2.0) matches
+turbo-class latency at 512 px and is the candidate for a follow-up promotion PR
+with `realtime` capability and measured `min_vram_gb`. Hyper-SD stays
+benchmark-only (license gap on the LoRA weights; no speed win over Lightning at
+1024). Stability Community models remain the capped commercial anchors.
+
+**ssd-1b-lightning** was not run in this sweep; run it alone if the combo
+mapping question still needs a recorded fail/pass.
 
 ## Capped commercial models (benchmark reference only)
 

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -17,6 +17,31 @@ No annual revenue cap. Safe to publish on `/benchmark` without qualification.
 | **ssd-1b** | Apache 2.0 | ~8 GB | 768 / 1024 | Speed/quality balance |
 | **dreamshaper-lcm** | Open RAIL-M | ~4-6 GB | 512 / 768 | Illustration, stylized art |
 
+## License-safe turbo candidates (benchmark reference only)
+
+Issue #75: evaluate Hyper-SD and VegaRT against the Stability turbo anchors before
+promoting either to the studio. Manifests set `benchmark_only: true` like
+sd-turbo and sdxl-turbo.
+
+| Model | License | VRAM | Resolution | Notes |
+| --- | --- | --- | --- | --- |
+| **sdxl-hypersd** | Open RAIL++-M + ByteDance Hyper-SD | ~10 GB | 1024 | 8-step distillation LoRA; euler-trailing |
+| **vega-rt** | Apache 2.0 | ~8 GB | 512 / 1024 | Segmind-Vega + VegaRT LCM LoRA |
+| **ssd-1b-lightning** | Apache 2.0 + Lightning | ~8 GB | 1024 | Experimental combo; load may fail |
+
+```bash
+# Issue #75 comparison run (smoke: 3 prompts, include Stability anchors)
+make benchmark BENCHMARK_QUICK=1 BENCHMARK_INCLUDE_CAPPED=1 \
+  BENCHMARK_MODELS=sdxl-hypersd,vega-rt,sdxl-fast,ssd-1b,sd-turbo,sdxl-turbo
+
+# Full candidate sweep including the experimental SSD-1B combo
+make benchmark BENCHMARK_INCLUDE_CAPPED=1 \
+  BENCHMARK_MODELS=sdxl-hypersd,vega-rt,ssd-1b-lightning,sdxl-fast,ssd-1b,sd-turbo,sdxl-turbo
+```
+
+Measured numbers decide whether a follow-up PR promotes a winner to the product
+manifests (realtime capability, `min_vram_gb` from measurement).
+
 ## Capped commercial models (benchmark reference only)
 
 Models under a **$1M annual revenue cap** (Stability AI Community License).
@@ -107,5 +132,6 @@ make benchmark BENCHMARK_MODELS=sdxl-fast,ssd-1b
 ## References
 
 - [Issue #60 - Inference speed baseline and backlog](https://github.com/portocolom-studio/potocolom/issues/60)
+- [Issue #75 - License-safe turbo candidates (Hyper-SD, VegaRT)](https://github.com/portocolom-studio/potocolom/issues/75)
 - Measured timings on RX 7600 XT in ROADMAP.md
 - VRAM guidance from Stability AI / Black Forest Labs docs, Hugging Face model cards, and community tables

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -34,9 +34,13 @@ sd-turbo and sdxl-turbo.
 make benchmark BENCHMARK_QUICK=1 BENCHMARK_INCLUDE_CAPPED=1 \
   BENCHMARK_MODELS=sdxl-hypersd,vega-rt,sdxl-fast,ssd-1b,sd-turbo,sdxl-turbo
 
-# Full candidate sweep including the experimental SSD-1B combo
+# Full candidate sweep
 make benchmark BENCHMARK_INCLUDE_CAPPED=1 \
-  BENCHMARK_MODELS=sdxl-hypersd,vega-rt,ssd-1b-lightning,sdxl-fast,ssd-1b,sd-turbo,sdxl-turbo
+  BENCHMARK_MODELS=sdxl-hypersd,vega-rt,sdxl-fast,ssd-1b,sd-turbo,sdxl-turbo
+
+# The experimental combo runs alone: the harness aborts a run when a model
+# fails to load, and a failed load is a possible (and valid) outcome here.
+make benchmark BENCHMARK_MODELS=ssd-1b-lightning
 ```
 
 Measured numbers decide whether a follow-up PR promotes a winner to the product

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -25,9 +25,9 @@ sd-turbo and sdxl-turbo.
 
 | Model | License | VRAM | Resolution | Notes |
 | --- | --- | --- | --- | --- |
-| **sdxl-hypersd** | Open RAIL++-M + ByteDance Hyper-SD | ~10 GB | 1024 | 8-step distillation LoRA; euler-trailing |
+| **sdxl-hypersd** | Base Open RAIL++-M; LoRA has NO declared license | ~10 GB | 1024 | 8-step distillation LoRA; euler-trailing; measure only, not promotable as-is |
 | **vega-rt** | Apache 2.0 | ~8 GB | 512 / 1024 | Segmind-Vega + VegaRT LCM LoRA |
-| **ssd-1b-lightning** | Apache 2.0 + Lightning | ~8 GB | 1024 | Experimental combo; load may fail |
+| **ssd-1b-lightning** | Apache 2.0 base + Open RAIL++-M LoRA | ~8 GB | 1024 | Experimental combo; load may fail |
 
 ```bash
 # Issue #75 comparison run (smoke: 3 prompts, include Stability anchors)

--- a/scripts/benchmark-matrix.json
+++ b/scripts/benchmark-matrix.json
@@ -56,8 +56,8 @@
     },
     {
       "id": "sdxl-hypersd",
-      "license": "CreativeML Open RAIL++-M (base) + ByteDance Hyper-SD LoRA",
-      "commercial": "yes - no revenue cap; RAIL use restrictions on base weights",
+      "license": "CreativeML Open RAIL++-M (base); Hyper-SD LoRA has NO declared license",
+      "commercial": "unclear - the LoRA card declares no license (verified 2026-07-14)",
       "notes": "Hyper-SD 8-step LoRA on SDXL base; euler-trailing scheduler (issue #75).",
       "variants": [
         { "label": "1024-8step", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 100 } },
@@ -82,8 +82,8 @@
     },
     {
       "id": "ssd-1b-lightning",
-      "license": "Apache 2.0 (base) + ByteDance Lightning LoRA",
-      "commercial": "yes - unrestricted; combo may fail load if LoRA does not map to pruned UNet",
+      "license": "Apache 2.0 (base) + Open RAIL++-M Lightning LoRA",
+      "commercial": "yes - RAIL use policy applies; combo may fail load if LoRA does not map to pruned UNet",
       "notes": "Experimental SSD-1B + SDXL Lightning LoRA; a failed load is a valid benchmark result (issue #75).",
       "variants": [
         { "label": "1024-8step", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 100 } },

--- a/scripts/benchmark-matrix.json
+++ b/scripts/benchmark-matrix.json
@@ -53,6 +53,45 @@
         { "label": "768-8step", "params": { "width": 768, "height": 768, "steps": 8, "guidance": 1.5, "seed": 200 } },
         { "label": "4-step-alt-seed", "params": { "width": 512, "height": 512, "steps": 4, "guidance": 0, "seed": 300 } }
       ]
+    },
+    {
+      "id": "sdxl-hypersd",
+      "license": "CreativeML Open RAIL++-M (base) + ByteDance Hyper-SD LoRA",
+      "commercial": "yes - no revenue cap; RAIL use restrictions on base weights",
+      "notes": "Hyper-SD 8-step LoRA on SDXL base; euler-trailing scheduler (issue #75).",
+      "variants": [
+        { "label": "1024-8step", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 100 } },
+        { "label": "1024-4step", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 0, "seed": 100 } },
+        { "label": "1024-6step", "params": { "width": 1024, "height": 1024, "steps": 6, "guidance": 0, "seed": 100 } },
+        { "label": "1024-8step-alt-seed", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 200 } },
+        { "label": "1024-8step-guidance1", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 1, "seed": 100 } }
+      ]
+    },
+    {
+      "id": "vega-rt",
+      "license": "Apache 2.0 (Segmind-Vega base + VegaRT LoRA)",
+      "commercial": "yes - unrestricted commercial use",
+      "notes": "Segmind-Vega + VegaRT LCM LoRA; turbo-class candidate with no revenue cap (issue #75).",
+      "variants": [
+        { "label": "512-2step", "params": { "width": 512, "height": 512, "steps": 2, "guidance": 0, "seed": 100 } },
+        { "label": "512-4step", "params": { "width": 512, "height": 512, "steps": 4, "guidance": 0, "seed": 100 } },
+        { "label": "512-8step", "params": { "width": 512, "height": 512, "steps": 8, "guidance": 0, "seed": 100 } },
+        { "label": "1024-4step", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 0, "seed": 100 } },
+        { "label": "1024-8step", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 200 } }
+      ]
+    },
+    {
+      "id": "ssd-1b-lightning",
+      "license": "Apache 2.0 (base) + ByteDance Lightning LoRA",
+      "commercial": "yes - unrestricted; combo may fail load if LoRA does not map to pruned UNet",
+      "notes": "Experimental SSD-1B + SDXL Lightning LoRA; a failed load is a valid benchmark result (issue #75).",
+      "variants": [
+        { "label": "1024-8step", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 100 } },
+        { "label": "1024-4step", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 0, "seed": 100 } },
+        { "label": "1024-6step", "params": { "width": 1024, "height": 1024, "steps": 6, "guidance": 0, "seed": 100 } },
+        { "label": "768-8step", "params": { "width": 768, "height": 768, "steps": 8, "guidance": 0, "seed": 200 } },
+        { "label": "1024-8step-alt-seed", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 300 } }
+      ]
     }
   ],
   "capped_commercial": [

--- a/worker/models/sdxl-hypersd.json
+++ b/worker/models/sdxl-hypersd.json
@@ -7,6 +7,8 @@
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "euler-trailing",
   "lora": "ByteDance/Hyper-SD/Hyper-SDXL-8steps-lora.safetensors",
+  "license_id": "none-declared",
+  "license_url": "https://huggingface.co/ByteDance/Hyper-SD",
   "benchmark_only": true,
   "parameters": {
     "type": "object",

--- a/worker/models/sdxl-hypersd.json
+++ b/worker/models/sdxl-hypersd.json
@@ -1,0 +1,23 @@
+{
+  "id": "sdxl-hypersd",
+  "name": "SDXL Hyper-SD",
+  "capabilities": ["text_to_image"],
+  "min_vram_gb": 10,
+  "source": "stabilityai/stable-diffusion-xl-base-1.0",
+  "vae": "madebyollin/sdxl-vae-fp16-fix",
+  "scheduler": "euler-trailing",
+  "lora": "ByteDance/Hyper-SD/Hyper-SDXL-8steps-lora.safetensors",
+  "benchmark_only": true,
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "prompt": { "type": "string" },
+      "steps": { "type": "integer", "minimum": 4, "maximum": 8, "default": 8 },
+      "guidance": { "type": "number", "minimum": 0, "maximum": 2, "default": 0 },
+      "seed": { "type": "integer" },
+      "width": { "type": "integer", "enum": [1024], "default": 1024 },
+      "height": { "type": "integer", "enum": [1024], "default": 1024 }
+    },
+    "required": ["prompt"]
+  }
+}

--- a/worker/models/ssd-1b-lightning.json
+++ b/worker/models/ssd-1b-lightning.json
@@ -1,25 +1,57 @@
 {
   "id": "ssd-1b-lightning",
   "name": "SSD-1B + Lightning",
-  "capabilities": ["text_to_image"],
+  "capabilities": [
+    "text_to_image"
+  ],
   "min_vram_gb": 8,
   "source": "segmind/SSD-1B",
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "euler-trailing",
   "lora": "ByteDance/SDXL-Lightning/sdxl_lightning_8step_lora.safetensors",
   "benchmark_only": true,
-  "license_id": "apache-2.0",
-  "license_url": "https://huggingface.co/segmind/SSD-1B/blob/main/LICENSE",
+  "license_id": "openrail++",
+  "license_url": "https://huggingface.co/ByteDance/SDXL-Lightning",
   "parameters": {
     "type": "object",
     "properties": {
-      "prompt": { "type": "string" },
-      "steps": { "type": "integer", "minimum": 4, "maximum": 8, "default": 8 },
-      "guidance": { "type": "number", "minimum": 0, "maximum": 2, "default": 0 },
-      "seed": { "type": "integer" },
-      "width": { "type": "integer", "enum": [768, 1024], "default": 1024 },
-      "height": { "type": "integer", "enum": [768, 1024], "default": 1024 }
+      "prompt": {
+        "type": "string"
+      },
+      "steps": {
+        "type": "integer",
+        "minimum": 4,
+        "maximum": 8,
+        "default": 8
+      },
+      "guidance": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 2,
+        "default": 0
+      },
+      "seed": {
+        "type": "integer"
+      },
+      "width": {
+        "type": "integer",
+        "enum": [
+          768,
+          1024
+        ],
+        "default": 1024
+      },
+      "height": {
+        "type": "integer",
+        "enum": [
+          768,
+          1024
+        ],
+        "default": 1024
+      }
     },
-    "required": ["prompt"]
+    "required": [
+      "prompt"
+    ]
   }
 }

--- a/worker/models/ssd-1b-lightning.json
+++ b/worker/models/ssd-1b-lightning.json
@@ -1,0 +1,25 @@
+{
+  "id": "ssd-1b-lightning",
+  "name": "SSD-1B + Lightning",
+  "capabilities": ["text_to_image"],
+  "min_vram_gb": 8,
+  "source": "segmind/SSD-1B",
+  "vae": "madebyollin/sdxl-vae-fp16-fix",
+  "scheduler": "euler-trailing",
+  "lora": "ByteDance/SDXL-Lightning/sdxl_lightning_8step_lora.safetensors",
+  "benchmark_only": true,
+  "license_id": "apache-2.0",
+  "license_url": "https://huggingface.co/segmind/SSD-1B/blob/main/LICENSE",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "prompt": { "type": "string" },
+      "steps": { "type": "integer", "minimum": 4, "maximum": 8, "default": 8 },
+      "guidance": { "type": "number", "minimum": 0, "maximum": 2, "default": 0 },
+      "seed": { "type": "integer" },
+      "width": { "type": "integer", "enum": [768, 1024], "default": 1024 },
+      "height": { "type": "integer", "enum": [768, 1024], "default": 1024 }
+    },
+    "required": ["prompt"]
+  }
+}

--- a/worker/models/vega-rt.json
+++ b/worker/models/vega-rt.json
@@ -1,0 +1,24 @@
+{
+  "id": "vega-rt",
+  "name": "Segmind VegaRT",
+  "capabilities": ["text_to_image"],
+  "min_vram_gb": 8,
+  "source": "segmind/Segmind-Vega",
+  "scheduler": "lcm",
+  "lora": "segmind/Segmind-VegaRT/pytorch_lora_weights.safetensors",
+  "benchmark_only": true,
+  "license_id": "apache-2.0",
+  "license_url": "https://huggingface.co/segmind/Segmind-VegaRT/blob/main/README.md",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "prompt": { "type": "string" },
+      "steps": { "type": "integer", "minimum": 2, "maximum": 8, "default": 4 },
+      "guidance": { "type": "number", "minimum": 0, "maximum": 2, "default": 0 },
+      "seed": { "type": "integer" },
+      "width": { "type": "integer", "enum": [512, 1024], "default": 512 },
+      "height": { "type": "integer", "enum": [512, 1024], "default": 512 }
+    },
+    "required": ["prompt"]
+  }
+}

--- a/worker/tests/test_manifests.py
+++ b/worker/tests/test_manifests.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -34,6 +35,21 @@ def test_duplicate_manifest_ids_are_loud(tmp_path):
     (tmp_path / "b.json").write_text(json.dumps({**SD_TURBO, "name": "Other"}))
     with pytest.raises(ValueError, match="duplicate manifest id"):
         load_manifests(str(tmp_path))
+
+
+def test_shipped_manifests_load():
+    models_dir = Path(__file__).resolve().parents[1] / "models"
+    manifests = load_manifests(str(models_dir))
+    ids = {m.id for m in manifests}
+    assert "sdxl-hypersd" in ids
+    assert "vega-rt" in ids
+    assert "ssd-1b-lightning" in ids
+    hypersd = next(m for m in manifests if m.id == "sdxl-hypersd")
+    assert hypersd.benchmark_only
+    assert hypersd.scheduler == "euler-trailing"
+    vega = next(m for m in manifests if m.id == "vega-rt")
+    assert vega.scheduler == "lcm"
+    assert vega.license_id == "apache-2.0"
 
 
 def test_unknown_manifest_field_is_loud(tmp_path):

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -319,6 +319,12 @@ class DiffusersEngine:
 
             # The documented recipe for Lightning class distillation LoRAs.
             return EulerDiscreteScheduler.from_config(config, timestep_spacing="trailing")
+        if name == "lcm":
+            from diffusers import LCMScheduler
+
+            # LCM-distilled adapters (VegaRT class) sample with the
+            # consistency scheduler.
+            return LCMScheduler.from_config(config)
         raise ValueError(f"unknown scheduler override: {name}")
 
     def loaded_models(self) -> list[str]:


### PR DESCRIPTION
## Summary

- Add three `benchmark_only` manifests: `sdxl-hypersd` (SDXL base + Hyper-SD 8-step LoRA, euler-trailing), `vega-rt` (Segmind-Vega + VegaRT LCM LoRA, `pytorch_lora_weights.safetensors`), and experimental `ssd-1b-lightning`.
- Extend `scripts/benchmark-matrix.json`, `scripts/BENCHMARK.md`, `docs/third-party-models.md`, and `frontend/src/lib/model-specs.ts` with license and parameter metadata.
- Add `test_shipped_manifests_load` to verify the new manifests parse and carry the expected scheduler and license fields.

Closes #75

## Benchmark status

Full GPU benchmark run is **pending**. API/worker stack did not stay connected during this session. Planned command:

```bash
make benchmark BENCHMARK_QUICK=1 BENCHMARK_INCLUDE_CAPPED=1 \
  BENCHMARK_MODELS=sdxl-hypersd,vega-rt,sdxl-fast,ssd-1b,sd-turbo,sdxl-turbo
```

## Blockers / follow-ups

- **vega-rt** manifest sets `scheduler: "lcm"` per the Segmind model card, but `engine._scheduler()` on main only implements `dpmsolver` and `euler-trailing`. A small engine addition (or landing alongside #15) is needed before VegaRT can load. Hyper-SD uses the existing `euler-trailing` path (same as `sdxl-fast`).
- **ssd-1b-lightning** is experimental; a failed LoRA fuse is an expected outcome per the issue.

## Test plan

- [x] `worker/.venv/bin/pytest tests/test_manifests.py`
- [x] `make test` (backend + worker + frontend check)
- [ ] Full benchmark run on RX 7600 (pending tonight)
