### PR TITLE
Promote VegaRT as the license-clean realtime model

### DIFF
--- a/backend/app/model_timings.json
+++ b/backend/app/model_timings.json
@@ -1,5 +1,5 @@
 {
-  "_source": "RX 7600 XT benchmark (frontend/static/benchmark/results.json, 2026-07-12)",
+  "_source": "RX 7600 XT benchmark; vega-rt t2i baseline from issue #75 clean rerun (2026-07-14)",
   "sdxl-base": {
     "gpu_ms": 15274,
     "width": 1024,

--- a/backend/app/model_timings.json
+++ b/backend/app/model_timings.json
@@ -35,5 +35,11 @@
     "width": 512,
     "height": 512,
     "steps": 1
+  },
+  "vega-rt": {
+    "gpu_ms": 381,
+    "width": 512,
+    "height": 512,
+    "steps": 2
   }
 }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -486,6 +486,12 @@ If these models are ever offered in the product, the same $1M annual revenue cap
 
 Rejected alternative: removing capped models entirely. They anchor the realtime speed bar (issue #60) and give honest comparison points on `/benchmark` without taking on product licensing obligations today.
 
+## License-clean realtime model: VegaRT
+
+`vega-rt` is the studio-shippable realtime model. Issue #75 measured median 381 ms gpu_ms at 512/2 on the RX 7600 XT (clean GPU), within turbo-class range of the Stability benchmark anchors, under Apache 2.0 with no revenue cap. The manifest exposes `text_to_image`, `image_to_image`, and `realtime` with an LCM scheduler and fused VegaRT LoRA.
+
+Rejected alternatives: Hyper-SD (sdxl-hypersd) as the fast SDXL path - the Hyper-SD LoRA has no declared license on the card (issue #75); sd-turbo and sdxl-turbo as product models - Stability Community License caps commercial use at USD $1M annual revenue (see "Stability Community License models in the product" above).
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -488,7 +488,7 @@ Rejected alternative: removing capped models entirely. They anchor the realtime 
 
 ## License-clean realtime model: VegaRT
 
-`vega-rt` is the studio-shippable realtime model. Issue #75 measured median 381 ms gpu_ms at 512/2 on the RX 7600 XT (clean GPU), within turbo-class range of the Stability benchmark anchors, under Apache 2.0 with no revenue cap. The manifest exposes `text_to_image`, `image_to_image`, and `realtime` with an LCM scheduler and fused VegaRT LoRA.
+`vega-rt` is the studio-shippable realtime model. Issue #75 measured median 381 ms gpu_ms at 512/2 t2i on the RX 7600 XT (clean GPU), within turbo-class range of the Stability benchmark anchors, under Apache 2.0 with no revenue cap. Issue #84 verified the realtime img2i frame path at warm median 452 ms (~2.2 fps) @ 512 with strength 0.7 on the same hardware. The manifest exposes `text_to_image`, `image_to_image`, and `realtime` with an LCM scheduler and fused VegaRT LoRA.
 
 Rejected alternatives: Hyper-SD (sdxl-hypersd) as the fast SDXL path - the Hyper-SD LoRA has no declared license on the card (issue #75); sd-turbo and sdxl-turbo as product models - Stability Community License caps commercial use at USD $1M annual revenue (see "Stability Community License models in the product" above).
 

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -14,7 +14,6 @@ select them. Reference timings may still appear on `/benchmark`.
 | --- | --- | --- |
 | sd-turbo, sdxl-turbo | Stability AI Community | Benchmark reference |
 | sdxl-hypersd | Open RAIL++-M base + Hyper-SD LoRA with NO declared license | Benchmark reference (issue #75); not promotable until ByteDance declares terms |
-| vega-rt | Apache 2.0 | Benchmark reference (issue #75) |
 | ssd-1b-lightning | Apache 2.0 base + Open RAIL++-M Lightning LoRA | Benchmark reference (issue #75; experimental) |
 
 If you later offer any of these in the product, the obligations below apply.
@@ -46,6 +45,7 @@ requires:
 | sdxl-base, sdxl-fast (base weights) | CreativeML Open RAIL++-M |
 | sdxl-fast (Lightning LoRA) | CreativeML Open RAIL++-M (openrail++ tag on the card) |
 | ssd-1b | Apache 2.0 |
+| vega-rt (base + VegaRT LCM LoRA) | Apache 2.0 |
 | dreamshaper-lcm | CreativeML Open RAIL-M |
 
 Open RAIL licenses impose use restrictions (no illegal or harmful outputs) but

--- a/frontend/src/lib/model-specs.ts
+++ b/frontend/src/lib/model-specs.ts
@@ -122,10 +122,10 @@ export const MODEL_SPECS: ModelSpec[] = [
 		min_vram_gb: 8,
 		resolutions: '512, 1024',
 		step_range: '2-8',
-		capabilities: ['text_to_image'],
+		capabilities: ['text_to_image', 'image_to_image', 'realtime'],
 		license: 'Apache 2.0',
 		commercial: 'Unrestricted',
-		studio: false,
+		studio: true,
 		source: 'segmind/Segmind-Vega'
 	},
 	{

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -16,17 +16,17 @@ No annual revenue cap. Safe to publish on `/benchmark` without qualification.
 | **sdxl-fast** | Open RAIL++-M + Lightning LoRA | ~10 GB | 1024 | Near-SDXL quality, ~4 s |
 | **ssd-1b** | Apache 2.0 | ~8 GB | 768 / 1024 | Speed/quality balance |
 | **dreamshaper-lcm** | Open RAIL-M | ~4-6 GB | 512 / 768 | Illustration, stylized art |
+| **vega-rt** | Apache 2.0 | ~8 GB | 512 / 1024 | Realtime drawing (issue #84) |
 
 ## License-safe turbo candidates (benchmark reference only)
 
-Issue #75: evaluate Hyper-SD and VegaRT against the Stability turbo anchors before
-promoting either to the studio. Manifests set `benchmark_only: true` like
-sd-turbo and sdxl-turbo.
+Issue #75: evaluate Hyper-SD against the Stability turbo anchors. VegaRT was
+promoted to the product in issue #84; the remaining rows stay
+`benchmark_only: true` like sd-turbo and sdxl-turbo.
 
 | Model | License | VRAM | Resolution | Notes |
 | --- | --- | --- | --- | --- |
 | **sdxl-hypersd** | Base Open RAIL++-M; LoRA has NO declared license | ~10 GB | 1024 | 8-step distillation LoRA; euler-trailing; measure only, not promotable as-is |
-| **vega-rt** | Apache 2.0 | ~8 GB | 512 / 1024 | Segmind-Vega + VegaRT LCM LoRA |
 | **ssd-1b-lightning** | Apache 2.0 base + Open RAIL++-M LoRA | ~8 GB | 1024 | Experimental combo; load may fail |
 
 ```bash
@@ -58,23 +58,37 @@ held ~14 GB VRAM; stop competing GPU workloads before benchmarking.
 | --- | ---: | --- | --- |
 | sd-turbo | 345 | 512 / 2 | Benchmark anchor (Stability cap) |
 | sdxl-turbo | 296 | 512 / 1 | Benchmark anchor (Stability cap) |
-| **vega-rt** | **381** | 512 / 2 | **License-clean turbo-class winner** - follow-up PR to promote |
+| **vega-rt** | **381** | 512 / 2 (t2i) | Promoted in #84 (license-clean realtime) |
 | sdxl-fast | 4005 | 1024 / 8 | Open baseline (Lightning) |
 | sdxl-hypersd | 3987 | 1024 / 8 | Benchmark only - LoRA has no declared license |
 | ssd-1b | 10034 | 1024 / 20 | Batch tier, not realtime |
 
-**Conclusion:** No product manifest in #75. VegaRT (Apache 2.0) matches
-turbo-class latency at 512 px (~381 ms median vs ~345 ms sd-turbo) and is the
-candidate for a follow-up promotion PR with `realtime` capability and measured
-`min_vram_gb`. Hyper-SD stays benchmark-only (license gap on the LoRA weights;
-~4 s @ 1024 is on par with Lightning, not a license-clean turbo win). Stability
-Community models remain the capped commercial anchors.
+**Conclusion:** VegaRT (Apache 2.0) matches turbo-class t2i latency at 512 px
+(~381 ms median vs ~345 ms sd-turbo) and was promoted in #84. Hyper-SD stays
+benchmark-only (license gap on the LoRA weights; ~4 s @ 1024 is on par with
+Lightning, not a license-clean turbo win). Stability Community models remain the
+capped commercial anchors.
 
 **ssd-1b-lightning** solo run (`data/benchmark/ssd-1b-lightning-run/`, clean GPU,
 2026-07-14): **load succeeded** - SDXL Lightning LoRA fuses onto the pruned
 SSD-1B UNet. 3/3 @ 1024/8step, median **2777 ms** gpu_ms (vs ~10 s for plain
 ssd-1b @ 1024/20). Faster than Lightning-on-SDXL-base at 1024 but still batch
 tier, not turbo-class; stays `benchmark_only` unless promoted separately.
+
+### Issue #84 realtime frame gate (RX 7600 XT, 2026-07-14)
+
+Clean GPU (~13.4 GB free VRAM). `engine.frame` img2i path @ 512 px, strength
+0.7, after model load:
+
+| Metric | Value |
+| --- | ---: |
+| Frame 1 (warmup) | 669 ms |
+| Frames 2-5 | 454, 452, 444, 442 ms |
+| **Warm median** | **452 ms (~2.2 fps)** |
+
+Within the M3 realtime bar (2-4 fps). `model_timings.json` keeps the t2i
+baseline (381 ms @ 512/2) for job estimates; realtime frames are img2i and run
+slightly slower.
 
 ## Capped commercial models (benchmark reference only)
 

--- a/worker/models/vega-rt.json
+++ b/worker/models/vega-rt.json
@@ -1,19 +1,19 @@
 {
   "id": "vega-rt",
   "name": "Segmind VegaRT",
-  "capabilities": ["text_to_image"],
+  "capabilities": ["text_to_image", "image_to_image", "realtime"],
   "min_vram_gb": 8,
   "source": "segmind/Segmind-Vega",
   "scheduler": "lcm",
   "lora": "segmind/Segmind-VegaRT/pytorch_lora_weights.safetensors",
-  "benchmark_only": true,
   "license_id": "apache-2.0",
   "license_url": "https://huggingface.co/segmind/Segmind-VegaRT/blob/main/README.md",
   "parameters": {
     "type": "object",
     "properties": {
       "prompt": { "type": "string" },
-      "steps": { "type": "integer", "minimum": 2, "maximum": 8, "default": 4 },
+      "strength": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.7 },
+      "steps": { "type": "integer", "minimum": 2, "maximum": 8, "default": 2 },
       "guidance": { "type": "number", "minimum": 0, "maximum": 2, "default": 0 },
       "seed": { "type": "integer" },
       "width": { "type": "integer", "enum": [512, 1024], "default": 512 },

--- a/worker/models/vega-rt.json
+++ b/worker/models/vega-rt.json
@@ -12,7 +12,7 @@
     "type": "object",
     "properties": {
       "prompt": { "type": "string" },
-      "strength": { "type": "number", "minimum": 0, "maximum": 1, "default": 0.7 },
+      "strength": { "type": "number", "minimum": 0.05, "maximum": 1, "default": 0.7 },
       "steps": { "type": "integer", "minimum": 2, "maximum": 8, "default": 2 },
       "guidance": { "type": "number", "minimum": 0, "maximum": 2, "default": 0 },
       "seed": { "type": "integer" },

--- a/worker/tests/test_manifests.py
+++ b/worker/tests/test_manifests.py
@@ -48,8 +48,12 @@ def test_shipped_manifests_load():
     assert hypersd.benchmark_only
     assert hypersd.scheduler == "euler-trailing"
     vega = next(m for m in manifests if m.id == "vega-rt")
+    assert not vega.benchmark_only
     assert vega.scheduler == "lcm"
     assert vega.license_id == "apache-2.0"
+    assert "realtime" in vega.capabilities
+    assert "image_to_image" in vega.capabilities
+    assert "strength" in vega.parameters["properties"]
 
 
 def test_unknown_manifest_field_is_loud(tmp_path):


### PR DESCRIPTION
## Summary

- Promote `vega-rt` from benchmark-only to a studio-shippable realtime model: `image_to_image`, `realtime`, and `strength` in the manifest; default steps 2 @ 512 (issue #75 clean-GPU median 381 ms t2i).
- Add `model_timings.json` baseline and `model-specs.ts` studio entry; move VegaRT to the product table in `third-party-models.md`.
- Record the decision in `decisions.md`: VegaRT as license-clean realtime; Hyper-SD and Stability capped anchors rejected for product use.

Closes #84

## Test plan

- [x] `make verify`
- [x] GPU `engine.frame` img2i on RX 7600 XT (clean GPU): warm median 452 ms @ 512, strength 0.7 (~2.2 fps)
- [x] API smoke: `vega-rt` in `GET /api/v1/models` with `realtime` capability and `estimated_gpu_ms_default=381`; t2i generation @ 512/2 succeeded (~13 s wall)
- [ ] WebSocket realtime relay returns frames end-to-end (API smoke: session opens but frames did not return in automated test; direct `engine.frame` path verified on GPU)
- [ ] Studio model picker + live drawing session (manual)