### PR TITLE
Promote SSD-1B + Lightning for the fast batch tier

### DIFF
--- a/backend/app/model_timings.json
+++ b/backend/app/model_timings.json
@@ -35,5 +35,11 @@
     "width": 512,
     "height": 512,
     "steps": 1
+  },
+  "ssd-1b-lightning": {
+    "gpu_ms": 2777,
+    "width": 1024,
+    "height": 1024,
+    "steps": 8
   }
 }

--- a/backend/tests/test_estimates.py
+++ b/backend/tests/test_estimates.py
@@ -17,6 +17,11 @@ def test_estimate_gpu_ms_at_baseline_params():
     assert estimate_gpu_ms("sdxl-fast", {"width": 1024, "height": 1024, "steps": 8}) == 3736
 
 
+def test_estimate_gpu_ms_ssd_1b_lightning_baseline():
+    assert estimate_gpu_ms(
+        "ssd-1b-lightning", {"width": 1024, "height": 1024, "steps": 8}) == 2777
+
+
 def test_estimate_gpu_ms_scales_linearly_with_steps():
     baseline = estimate_gpu_ms("sdxl-fast", {"width": 1024, "height": 1024, "steps": 8})
     half_steps = estimate_gpu_ms("sdxl-fast", {"width": 1024, "height": 1024, "steps": 4})

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -486,6 +486,12 @@ If these models are ever offered in the product, the same $1M annual revenue cap
 
 Rejected alternative: removing capped models entirely. They anchor the realtime speed bar (issue #60) and give honest comparison points on `/benchmark` without taking on product licensing obligations today.
 
+## Fast batch tier: SSD-1B + Lightning alongside SDXL Fast
+
+`ssd-1b-lightning` is a studio-shippable fast batch model. Issue #85 compared it against `sdxl-fast` on the shared three-prompt photorealistic suite at 1024/8step (clean GPU, RX 7600 XT): median 2777 ms gpu_ms vs 4005 ms for sdxl-fast (~31% faster), with comparable visual quality. Licensing matches the existing fast path (Apache 2.0 pruned base plus the same ByteDance SDXL Lightning LoRA `sdxl-fast` already fuses). It ships alongside `sdxl-fast`, not as a replacement: full SDXL base may retain edge-case quality; SSD-1B + Lightning wins on speed and fits the 8 GB floor.
+
+Rejected alternative: keep `ssd-1b-lightning` benchmark-only after the successful fuse (issue #75 expected failure; the measurement would be lost).
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:

--- a/docs/third-party-models.md
+++ b/docs/third-party-models.md
@@ -15,7 +15,6 @@ select them. Reference timings may still appear on `/benchmark`.
 | sd-turbo, sdxl-turbo | Stability AI Community | Benchmark reference |
 | sdxl-hypersd | Open RAIL++-M base + Hyper-SD LoRA with NO declared license | Benchmark reference (issue #75); not promotable until ByteDance declares terms |
 | vega-rt | Apache 2.0 | Benchmark reference (issue #75) |
-| ssd-1b-lightning | Apache 2.0 base + Open RAIL++-M Lightning LoRA | Benchmark reference (issue #75; experimental) |
 
 If you later offer any of these in the product, the obligations below apply.
 
@@ -46,6 +45,7 @@ requires:
 | sdxl-base, sdxl-fast (base weights) | CreativeML Open RAIL++-M |
 | sdxl-fast (Lightning LoRA) | CreativeML Open RAIL++-M (openrail++ tag on the card) |
 | ssd-1b | Apache 2.0 |
+| ssd-1b-lightning (SSD-1B + SDXL Lightning LoRA) | Apache 2.0 base + CreativeML Open RAIL++-M LoRA |
 | dreamshaper-lcm | CreativeML Open RAIL-M |
 
 Open RAIL licenses impose use restrictions (no illegal or harmful outputs) but

--- a/frontend/src/lib/model-specs.ts
+++ b/frontend/src/lib/model-specs.ts
@@ -131,7 +131,7 @@ export const MODEL_SPECS: ModelSpec[] = [
 	{
 		id: 'ssd-1b-lightning',
 		name: 'SSD-1B + Lightning',
-		architecture: 'SSD-1B + Lightning LoRA (experimental)',
+		architecture: 'SSD-1B + Lightning LoRA',
 		parameters: '~1.3B',
 		min_vram_gb: 8,
 		resolutions: '1024',
@@ -139,7 +139,7 @@ export const MODEL_SPECS: ModelSpec[] = [
 		capabilities: ['text_to_image'],
 		license: 'Apache 2.0 base + Open RAIL++-M LoRA',
 		commercial: 'RAIL use policy applies',
-		studio: false,
+		studio: true,
 		source: 'segmind/SSD-1B'
 	}
 ];

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -15,7 +15,7 @@ No annual revenue cap. Safe to publish on `/benchmark` without qualification.
 | **sdxl-base** | Open RAIL++-M | ~8 GB tight | 768 / 1024 | Highest quality |
 | **sdxl-fast** | Open RAIL++-M + Lightning LoRA | ~10 GB | 1024 | Near-SDXL quality, ~4 s |
 | **ssd-1b** | Apache 2.0 | ~8 GB | 768 / 1024 | Speed/quality balance |
-| **ssd-1b-lightning** | Apache 2.0 + Lightning LoRA | ~8 GB | 1024 | Fast batch @ 1024 (~2.8 s, issue #85) |
+| **ssd-1b-lightning** | Apache 2.0 base + Open RAIL++-M LoRA | ~8 GB | 1024 | Fast batch @ 1024 (~2.8 s, issue #85) |
 | **dreamshaper-lcm** | Open RAIL-M | ~4-6 GB | 512 / 768 | Illustration, stylized art |
 
 ## License-safe turbo candidates (benchmark reference only)
@@ -28,7 +28,6 @@ sd-turbo and sdxl-turbo.
 | --- | --- | --- | --- | --- |
 | **sdxl-hypersd** | Base Open RAIL++-M; LoRA has NO declared license | ~10 GB | 1024 | 8-step distillation LoRA; euler-trailing; measure only, not promotable as-is |
 | **vega-rt** | Apache 2.0 | ~8 GB | 512 / 1024 | Segmind-Vega + VegaRT LCM LoRA |
-| **ssd-1b-lightning** | Apache 2.0 base + Open RAIL++-M LoRA | ~8 GB | 1024 | Experimental combo; promoted in #85 |
 
 ```bash
 # Issue #75 comparison run (smoke: 3 prompts, include Stability anchors)

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -15,6 +15,7 @@ No annual revenue cap. Safe to publish on `/benchmark` without qualification.
 | **sdxl-base** | Open RAIL++-M | ~8 GB tight | 768 / 1024 | Highest quality |
 | **sdxl-fast** | Open RAIL++-M + Lightning LoRA | ~10 GB | 1024 | Near-SDXL quality, ~4 s |
 | **ssd-1b** | Apache 2.0 | ~8 GB | 768 / 1024 | Speed/quality balance |
+| **ssd-1b-lightning** | Apache 2.0 + Lightning LoRA | ~8 GB | 1024 | Fast batch @ 1024 (~2.8 s, issue #85) |
 | **dreamshaper-lcm** | Open RAIL-M | ~4-6 GB | 512 / 768 | Illustration, stylized art |
 
 ## License-safe turbo candidates (benchmark reference only)
@@ -27,7 +28,7 @@ sd-turbo and sdxl-turbo.
 | --- | --- | --- | --- | --- |
 | **sdxl-hypersd** | Base Open RAIL++-M; LoRA has NO declared license | ~10 GB | 1024 | 8-step distillation LoRA; euler-trailing; measure only, not promotable as-is |
 | **vega-rt** | Apache 2.0 | ~8 GB | 512 / 1024 | Segmind-Vega + VegaRT LCM LoRA |
-| **ssd-1b-lightning** | Apache 2.0 base + Open RAIL++-M LoRA | ~8 GB | 1024 | Experimental combo; load may fail |
+| **ssd-1b-lightning** | Apache 2.0 base + Open RAIL++-M LoRA | ~8 GB | 1024 | Experimental combo; promoted in #85 |
 
 ```bash
 # Issue #75 comparison run (smoke: 3 prompts, include Stability anchors)
@@ -73,8 +74,10 @@ Community models remain the capped commercial anchors.
 **ssd-1b-lightning** solo run (`data/benchmark/ssd-1b-lightning-run/`, clean GPU,
 2026-07-14): **load succeeded** - SDXL Lightning LoRA fuses onto the pruned
 SSD-1B UNet. 3/3 @ 1024/8step, median **2777 ms** gpu_ms (vs ~10 s for plain
-ssd-1b @ 1024/20). Faster than Lightning-on-SDXL-base at 1024 but still batch
-tier, not turbo-class; stays `benchmark_only` unless promoted separately.
+ssd-1b @ 1024/20, vs **4005 ms** for sdxl-fast in the #75 clean rerun).
+**Promoted in #85** alongside sdxl-fast: comparable quality on the shared
+three-prompt suite, ~31% faster, same Lightning LoRA licensing as sdxl-fast.
+Batch tier only - not realtime.
 
 ## Capped commercial models (benchmark reference only)
 

--- a/worker/models/ssd-1b-lightning.json
+++ b/worker/models/ssd-1b-lightning.json
@@ -9,7 +9,6 @@
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "euler-trailing",
   "lora": "ByteDance/SDXL-Lightning/sdxl_lightning_8step_lora.safetensors",
-  "benchmark_only": true,
   "license_id": "openrail++",
   "license_url": "https://huggingface.co/ByteDance/SDXL-Lightning",
   "parameters": {

--- a/worker/tests/test_manifests.py
+++ b/worker/tests/test_manifests.py
@@ -50,6 +50,9 @@ def test_shipped_manifests_load():
     vega = next(m for m in manifests if m.id == "vega-rt")
     assert vega.scheduler == "lcm"
     assert vega.license_id == "apache-2.0"
+    lightning = next(m for m in manifests if m.id == "ssd-1b-lightning")
+    assert not lightning.benchmark_only
+    assert lightning.scheduler == "euler-trailing"
 
 
 def test_unknown_manifest_field_is_loud(tmp_path):


### PR DESCRIPTION
## Summary

- Evaluate and promote `ssd-1b-lightning`: median 2777 ms @ 1024/8 vs 4005 ms for `sdxl-fast` on the shared three-prompt suite (clean GPU, RX 7600 XT); comparable visual quality.
- Flip manifest to studio-shippable; add `model_timings.json` baseline, `model-specs.ts` entry, product table in `third-party-models.md`.
- Record decision in `decisions.md` and `BENCHMARK.md`: ships **alongside** sdxl-fast, not as a replacement.

Closes #85

## Test plan

- [x] `make verify`
- [x] Quality comparison on shared benchmark prompts (issue-75-rerun vs ssd-1b-lightning-run)
- [x] API smoke: `ssd-1b-lightning` in `GET /api/v1/models` with `estimated_gpu_ms_default=2777`; 1024/8 generation succeeded (~17 s wall, clean GPU)
- [ ] Studio model picker shows SSD-1B + Lightning with ~2.8 s estimate (manual)