### PR TITLE
Pipeline overlap: dispatch depth 2 per worker

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -273,11 +273,21 @@ async def generation_events(
     )
 
 
+def job_dispatch_depth(worker: realtime.Worker) -> int:
+    # Sessions-first: while a realtime slot is live, do not stack a second
+    # queued job behind the one already waiting on the GPU lock.
+    if worker.slots_in_use > 0:
+        return 1
+    return JOB_DISPATCH_DEPTH
+
+
 def pick_job_worker(model_id: str) -> realtime.Worker | None:
-    for worker in realtime.workers.values():
-        if model_id in worker.models and worker.jobs_in_flight < JOB_DISPATCH_DEPTH:
-            return worker
-    return None
+    candidates = [
+        worker for worker in realtime.workers.values()
+        if model_id in worker.models
+        and worker.jobs_in_flight < job_dispatch_depth(worker)
+    ]
+    return min(candidates, key=lambda worker: worker.jobs_in_flight, default=None)
 
 
 def release_job_slot(worker: realtime.Worker) -> None:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -40,6 +40,7 @@ router = APIRouter()
 JOB_QUEUE = "queue:jobs"
 TIER_DEFAULT = 1  # 0 resuming, 1 paid, 2 trial; one tier until billing exists
 DISPATCH_INTERVAL = 0.1  # the scheduler step cadence (docs/blueprint.md)
+JOB_DISPATCH_DEPTH = 2  # queued jobs per worker; overlap encode/upload with denoise
 
 TERMINAL_STATES = ("succeeded", "failed")
 THUMBNAIL_MAX_EDGE = 384  # thumbnail rendition size (issue #56)
@@ -274,9 +275,13 @@ async def generation_events(
 
 def pick_job_worker(model_id: str) -> realtime.Worker | None:
     for worker in realtime.workers.values():
-        if model_id in worker.models and not worker.job_busy:
+        if model_id in worker.models and worker.jobs_in_flight < JOB_DISPATCH_DEPTH:
             return worker
     return None
+
+
+def release_job_slot(worker: realtime.Worker) -> None:
+    worker.jobs_in_flight = max(0, worker.jobs_in_flight - 1)
 
 
 async def dispatch_loop() -> None:
@@ -303,7 +308,7 @@ async def sweep_stalled_jobs() -> None:
             continue
         live_progress.pop(job_id, None)
         last_progress_at.pop(job_id, None)
-        entry.worker.job_busy = False
+        release_job_slot(entry.worker)
         try:
             await requeue_or_fail(job_id, f"no progress for {stall:.0f}s")
         except Exception:
@@ -366,7 +371,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
         thumb_target = await get_storage().upload_target(thumb_storage_key)
         # Bookkeeping before the send: if the worker dies from here on, its
         # disconnect handler finds the inflight entry and requeues the job.
-        worker.job_busy = True
+        worker.jobs_in_flight += 1
         inflight[job.id] = InFlight(worker=worker, storage_key=storage_key,
                                     thumb_storage_key=thumb_storage_key, user_id=job.user_id)
         last_progress_at[job_id] = time.monotonic()
@@ -384,7 +389,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
             source = await session.get(Asset, job.source_asset_id)
             if source is None:
                 inflight.pop(job.id, None)
-                worker.job_busy = False
+                release_job_slot(worker)
                 job.state = "failed"
                 await session.commit()
                 publish(job_id, {"state": "failed", "reason": "source asset not found"})
@@ -401,7 +406,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
             if inflight.pop(job.id, None) is None:
                 return True  # the disconnect handler beat us to it and requeued
             last_progress_at.pop(job.id, None)
-            worker.job_busy = False
+            release_job_slot(worker)
             return False  # session rolls back, the job stays queued
         await session.commit()
     publish(job_id, {"state": "running"})
@@ -426,7 +431,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     last_progress_at.pop(job_id, None)
     if entry is None:
         return  # finished concurrently
-    worker.job_busy = False
+    release_job_slot(worker)
     if db.session_factory is None:
         logger.warning("job %s finished on the worker but the database is unavailable",
                        job_id)

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -94,7 +94,7 @@ class Worker:
     manifests: list[Manifest]
     realtime_slots: int
     slots_in_use: int = 0
-    job_busy: bool = False  # queued jobs fill idle capacity, one at a time
+    jobs_in_flight: int = 0  # queued jobs; capped at JOB_DISPATCH_DEPTH in jobs.py
     last_seen: float = field(default_factory=time.monotonic)
 
     @property

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -32,6 +32,11 @@ MANIFEST_T2I_ONLY = {
     "capabilities": ["text_to_image"],
 }
 
+MANIFEST_WITH_RT = {
+    **MANIFEST,
+    "capabilities": ["text_to_image", "image_to_image", "realtime"],
+}
+
 
 def fleet_hello(ws, worker_id, manifest=MANIFEST):
     ws.send_json({"type": "hello", "protocol_version": PROTOCOL_VERSION,
@@ -454,3 +459,73 @@ def test_dispatch_depth_blocks_third_until_slot_frees(monkeypatch):
 
             _finish_job(client, worker, d2)
             _finish_job(client, worker, d3)
+
+
+def test_pick_job_worker_prefers_least_loaded():
+    from unittest.mock import MagicMock
+
+    from app import jobs, realtime
+    from app.manifests import Manifest
+
+    manifest = Manifest(id="sd-test", name="SD Test", capabilities=["text_to_image"],
+                        parameters={})
+    busy = realtime.Worker(id="w-busy", ws=MagicMock(), manifests=[manifest],
+                           realtime_slots=1, jobs_in_flight=1)
+    idle = realtime.Worker(id="w-idle", ws=MagicMock(), manifests=[manifest],
+                           realtime_slots=1, jobs_in_flight=0)
+    saved = dict(realtime.workers)
+    try:
+        realtime.workers.clear()
+        realtime.workers["w-busy"] = busy
+        realtime.workers["w-idle"] = idle
+        assert jobs.pick_job_worker("sd-test") is idle
+    finally:
+        realtime.workers.clear()
+        realtime.workers.update(saved)
+
+
+def test_job_dispatch_depth_one_while_realtime_live():
+    from unittest.mock import MagicMock
+
+    from app import jobs, realtime
+    from app.manifests import Manifest
+
+    manifest = Manifest(id="sd-test", name="SD Test", capabilities=["text_to_image"],
+                        parameters={})
+    drawing = realtime.Worker(id="w-drawing", ws=MagicMock(), manifests=[manifest],
+                              realtime_slots=1, slots_in_use=1, jobs_in_flight=1)
+    idle = realtime.Worker(id="w-idle", ws=MagicMock(), manifests=[manifest],
+                           realtime_slots=1, jobs_in_flight=0)
+    saved = dict(realtime.workers)
+    try:
+        realtime.workers.clear()
+        realtime.workers["w-drawing"] = drawing
+        realtime.workers["w-idle"] = idle
+        assert jobs.job_dispatch_depth(drawing) == 1
+        assert jobs.pick_job_worker("sd-test") is idle
+    finally:
+        realtime.workers.clear()
+        realtime.workers.update(saved)
+
+
+@pytest.mark.db
+def test_dispatch_depth_one_while_realtime_session_open(monkeypatch):
+    """Sessions-first: depth drops to 1 while a drawing slot is live."""
+    _stall_safe(monkeypatch)
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-session-jobs", manifest=MANIFEST_WITH_RT)
+
+            with client.websocket_connect("/api/v1/realtime") as browser:
+                browser.send_json({"type": "open", "model_id": "sd-test"})
+                opened = worker.receive_json()
+                assert opened["type"] == "open_session"
+                worker.send_json({"type": "session_ready", "session_id": opened["session_id"]})
+                assert browser.receive_json()["type"] == "ready"
+
+                first_id = _post_generation(client, "during-session-1")
+                second_id = _post_generation(client, "during-session-2")
+                time.sleep(0.35)
+                first = _wait_for_dispatch(worker, {first_id})
+                assert client.get(f"/api/v1/generations/{second_id}").json()["state"] == "queued"
+                _finish_job(client, worker, first)

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -517,7 +517,8 @@ def test_dispatch_depth_one_while_realtime_session_open(monkeypatch):
             fleet_hello(worker, "w-session-jobs", manifest=MANIFEST_WITH_RT)
 
             with client.websocket_connect("/api/v1/realtime") as browser:
-                browser.send_json({"type": "open", "model_id": "sd-test"})
+                browser.send_json({"type": "open", "model_id": "sd-test",
+                                   "params": {"prompt": "live drawing"}})
                 opened = worker.receive_json()
                 assert opened["type"] == "open_session"
                 worker.send_json({"type": "session_ready", "session_id": opened["session_id"]})

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -367,3 +367,62 @@ def test_job_failure_reason_persisted():
             job = poll_until(client, job_id, "failed")
             assert job["failure_reason"] == "CUDA OOM"
             assert job["finished_at"] is not None
+
+
+def _post_generation(client, prompt: str) -> str:
+    created = client.post("/api/v1/generations",
+                          json={"model_id": "sd-test", "params": {"prompt": prompt}})
+    assert created.status_code == 202
+    return created.json()["job_id"]
+
+
+def _wait_for_dispatch(worker, timeout=5.0) -> dict:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        msg = worker.receive_json()
+        if msg["type"] == "dispatch_job":
+            return msg
+        time.sleep(0.01)
+    raise AssertionError("timed out waiting for dispatch_job")
+
+
+@pytest.mark.db
+def test_dispatch_depth_two_before_job_done():
+    """Depth 2: API dispatches a second job while the first is still uploading."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-depth2")
+
+            first_id = _post_generation(client, "one")
+            second_id = _post_generation(client, "two")
+            time.sleep(0.35)
+
+            first = _wait_for_dispatch(worker)
+            second = _wait_for_dispatch(worker)
+            assert {first["job_id"], second["job_id"]} == {first_id, second_id}
+
+
+@pytest.mark.db
+def test_dispatch_depth_blocks_third_until_slot_frees():
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-depth-cap")
+
+            _post_generation(client, "a")
+            _post_generation(client, "b")
+            time.sleep(0.35)
+            d1 = _wait_for_dispatch(worker)
+            _wait_for_dispatch(worker)
+
+            third_id = _post_generation(client, "c")
+            time.sleep(0.35)
+
+            upload_path = urlsplit(d1["upload"]["url"]).path
+            assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+            worker.send_json({"type": "job_done", "job_id": d1["job_id"],
+                              "gpu_ms": 1, "width": 512, "height": 512})
+            poll_until(client, d1["job_id"], "succeeded")
+
+            time.sleep(0.35)
+            d3 = _wait_for_dispatch(worker)
+            assert d3["job_id"] == third_id

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -202,19 +202,23 @@ def test_stalled_job_requeues_once(monkeypatch):
     monkeypatch.setenv("JOB_STALL_SECONDS", "0.05")
     from app.settings import get_settings
     get_settings.cache_clear()
-    with TestClient(app) as client:
-        with client.websocket_connect("/api/v1/fleet") as worker:
-            fleet_hello(worker, "w-stall")
-            job_id = client.post("/api/v1/generations",
-                                 json={"model_id": "sd-test",
-                                       "params": {"prompt": "stall"}}).json()["job_id"]
-            assert worker.receive_json()["job_id"] == job_id
-            # Worker stays connected but sends no progress; stall requeues once
-            # and the retry is dispatched back to the same connected worker.
-            poll_until_attempt(client, job_id, 2, timeout=3.0)
-            redispatch = worker.receive_json()
-            assert redispatch["type"] == "dispatch_job"
-            assert redispatch["job_id"] == job_id
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-stall")
+                job_id = client.post("/api/v1/generations",
+                                     json={"model_id": "sd-test",
+                                           "params": {"prompt": "stall"}}).json()["job_id"]
+                assert worker.receive_json()["job_id"] == job_id
+                # Worker stays connected but sends no progress; stall requeues once
+                # and the retry is dispatched back to the same connected worker.
+                poll_until_attempt(client, job_id, 2, timeout=3.0)
+                redispatch = worker.receive_json()
+                assert redispatch["type"] == "dispatch_job"
+                assert redispatch["job_id"] == job_id
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
 
 
 @pytest.mark.db
@@ -376,53 +380,77 @@ def _post_generation(client, prompt: str) -> str:
     return created.json()["job_id"]
 
 
-def _wait_for_dispatch(worker, timeout=5.0) -> dict:
+def _stall_safe(monkeypatch) -> None:
+    monkeypatch.setenv("JOB_STALL_SECONDS", "600")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+
+
+def _wait_for_dispatch(worker, expected: set[str], timeout=5.0) -> dict:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         msg = worker.receive_json()
-        if msg["type"] == "dispatch_job":
+        if msg["type"] == "dispatch_job" and msg["job_id"] in expected:
             return msg
         time.sleep(0.01)
-    raise AssertionError("timed out waiting for dispatch_job")
+    raise AssertionError(f"timed out waiting for dispatch_job in {expected}")
+
+
+def _finish_job(client, worker, dispatch: dict) -> None:
+    upload_path = urlsplit(dispatch["upload"]["url"]).path
+    assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+    worker.send_json({"type": "job_done", "job_id": dispatch["job_id"],
+                      "gpu_ms": 1, "width": 512, "height": 512})
+    poll_until(client, dispatch["job_id"], "succeeded")
 
 
 @pytest.mark.db
-def test_dispatch_depth_two_before_job_done():
+def test_dispatch_depth_two_before_job_done(monkeypatch):
     """Depth 2: API dispatches a second job while the first is still uploading."""
+    _stall_safe(monkeypatch)
     with TestClient(app) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
             fleet_hello(worker, "w-depth2")
 
             first_id = _post_generation(client, "one")
             second_id = _post_generation(client, "two")
+            expected = {first_id, second_id}
             time.sleep(0.35)
 
-            first = _wait_for_dispatch(worker)
-            second = _wait_for_dispatch(worker)
-            assert {first["job_id"], second["job_id"]} == {first_id, second_id}
+            first = _wait_for_dispatch(worker, expected)
+            second = _wait_for_dispatch(worker, expected - {first["job_id"]})
+            assert {first["job_id"], second["job_id"]} == expected
+
+            # Leave no running jobs for the next test.
+            _finish_job(client, worker, first)
+            _finish_job(client, worker, second)
 
 
 @pytest.mark.db
-def test_dispatch_depth_blocks_third_until_slot_frees():
+def test_dispatch_depth_blocks_third_until_slot_frees(monkeypatch):
+    _stall_safe(monkeypatch)
     with TestClient(app) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
             fleet_hello(worker, "w-depth-cap")
 
-            _post_generation(client, "a")
-            _post_generation(client, "b")
+            id_a = _post_generation(client, "a")
+            id_b = _post_generation(client, "b")
+            expected = {id_a, id_b}
             time.sleep(0.35)
-            d1 = _wait_for_dispatch(worker)
-            _wait_for_dispatch(worker)
+            d1 = _wait_for_dispatch(worker, expected)
+            d2 = _wait_for_dispatch(worker, expected - {d1["job_id"]})
+            worker.send_json({"type": "job_progress", "job_id": d1["job_id"], "progress": 0.5})
+            worker.send_json({"type": "job_progress", "job_id": d2["job_id"], "progress": 0.5})
 
             third_id = _post_generation(client, "c")
             time.sleep(0.35)
+            assert client.get(f"/api/v1/generations/{third_id}").json()["state"] == "queued"
 
-            upload_path = urlsplit(d1["upload"]["url"]).path
-            assert client.put(upload_path, content=b"webp-bytes").status_code == 200
-            worker.send_json({"type": "job_done", "job_id": d1["job_id"],
-                              "gpu_ms": 1, "width": 512, "height": 512})
-            poll_until(client, d1["job_id"], "succeeded")
+            _finish_job(client, worker, d1)
 
             time.sleep(0.35)
-            d3 = _wait_for_dispatch(worker)
+            d3 = _wait_for_dispatch(worker, {third_id})
             assert d3["job_id"] == third_id
+
+            _finish_job(client, worker, d2)
+            _finish_job(client, worker, d3)


### PR DESCRIPTION
## Summary
- Replace `job_busy` boolean with bounded `jobs_in_flight` counter (limit 2) on each worker.
- `pick_job_worker` selects workers below the depth cap so job N+1 dispatches while job N encodes/uploads.
- Worker and wire protocol unchanged; per-job inflight bookkeeping, watchdog, and retry paths unchanged.

Closes #97

## Test plan
- [ ] `make simulate` - post 10 turbo jobs; Session GPU utilization tile should reach >=90% (was ~55-65%)
- [ ] Confirm realtime slot accounting unaffected