### PR TITLE
Evict poisoned pipelines after generation errors

### DIFF
--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -156,14 +156,17 @@ def test_evict_cold_removes_oldest_first():
 
 
 def _poison_engine(model_id: str = "m") -> DiffusersEngine:
-    import torch
-
     from worker.engine import GeneratedImage
 
+    # CI worker venv has no torch; only OutOfMemoryError must be a real type
+    # so `except self.torch.OutOfMemoryError` stays valid.
+    torch_stub = MagicMock()
+    torch_stub.OutOfMemoryError = type("OutOfMemoryError", (Exception,), {})
+
     engine = DiffusersEngine.__new__(DiffusersEngine)
-    engine.torch = torch
+    engine.torch = torch_stub
     engine.device = "cpu"
-    engine.dtype = torch.float32
+    engine.dtype = object()
     engine.memory_mode = "full"
     engine.models_dir = ""
     engine._pipelines = {(model_id, "t2i"): object()}

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -153,3 +153,89 @@ def test_evict_cold_removes_oldest_first():
     assert ("a", "t2i") in engine._pipelines
     assert ("b", "t2i") not in engine._pipelines
     assert "b" not in engine._rungs
+
+
+def _poison_engine(model_id: str = "m") -> DiffusersEngine:
+    import torch
+
+    from worker.engine import GeneratedImage
+
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = torch
+    engine.device = "cpu"
+    engine.dtype = torch.float32
+    engine.memory_mode = "full"
+    engine.models_dir = ""
+    engine._pipelines = {(model_id, "t2i"): object()}
+    engine._rungs = {model_id: "full"}
+    engine._last_used = {model_id: 1.0}
+    engine._poison_evicted_at = {}
+    engine._poison_evict_count = {}
+    engine._gpu = asyncio.Lock()
+    engine._free_gpu_cache = MagicMock()
+    engine._ok = GeneratedImage(b"webp", 64, 64, 1, 0)
+    return engine
+
+
+def test_evict_poisoned_drops_resident_and_counts():
+    engine = _poison_engine()
+    assert engine._evict_poisoned("m") is True
+    assert engine._pipelines == {}
+    assert engine._poison_evict_count["m"] == 1
+
+
+def test_evict_poisoned_respects_cooldown():
+    engine = _poison_engine()
+    assert engine._evict_poisoned("m") is True
+    engine._pipelines[("m", "t2i")] = object()  # simulate a reload that failed again
+    assert engine._evict_poisoned("m") is False
+    assert ("m", "t2i") in engine._pipelines
+    assert engine._poison_evict_count["m"] == 1
+
+
+def test_generate_fails_once_then_succeeds_after_poison_evict():
+    """Non-OOM error drops the resident; the next job can complete (issue #103)."""
+    engine = _poison_engine()
+    manifest = Manifest(id="m", name="M", capabilities=["text_to_image"])
+
+    def boom(*_args, **_kwargs):
+        raise RuntimeError("Input type c10::Half and bias type float")
+
+    async def scenario():
+        with patch("asyncio.to_thread", side_effect=boom):
+            try:
+                await engine.generate(manifest, {"prompt": "x"}, lambda _: None)
+            except RuntimeError as error:
+                assert "c10::Half" in str(error)
+            else:
+                raise AssertionError("expected RuntimeError")
+        assert engine._pipelines == {}
+        assert engine._poison_evict_count["m"] == 1
+        # Reload would re-populate; simulate that and a clean second pass.
+        engine._pipelines[("m", "t2i")] = object()
+        with patch("asyncio.to_thread", return_value=engine._ok):
+            result = await engine.generate(manifest, {"prompt": "x"}, lambda _: None)
+        assert result is engine._ok
+
+    asyncio.run(scenario())
+
+
+def test_generate_value_error_does_not_evict():
+    engine = _poison_engine()
+    manifest = Manifest(id="m", name="M", capabilities=["text_to_image"])
+
+    def bad_request(*_args, **_kwargs):
+        raise ValueError("bad params")
+
+    async def scenario():
+        with patch("asyncio.to_thread", side_effect=bad_request):
+            try:
+                await engine.generate(manifest, {"prompt": "x"}, lambda _: None)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError("expected ValueError")
+
+    asyncio.run(scenario())
+    assert ("m", "t2i") in engine._pipelines
+    assert engine._poison_evict_count == {}

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -13,6 +13,7 @@ import io
 import math
 import os
 import time
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from hashlib import sha256
@@ -31,9 +32,14 @@ from worker.memory_ladder import (
     select_rung,
 )
 
+logger = logging.getLogger("potocolom.worker")
+
 ProgressFn = Callable[[float], None]
 
 REALTIME_SIZE = 512  # the realtime bar is 512 px (docs/decisions.md)
+# After a non-OOM generation error, drop the resident model at most this often
+# so a permanently broken weight set cannot thrash load/unload (issue #103).
+POISON_EVICT_COOLDOWN_S = 30.0
 
 
 @dataclass
@@ -203,6 +209,8 @@ class DiffusersEngine:
         self._pipelines: dict[tuple[str, str], Any] = {}
         self._rungs: dict[str, MemoryRung] = {}
         self._last_used: dict[str, float] = {}
+        self._poison_evicted_at: dict[str, float] = {}
+        self._poison_evict_count: dict[str, int] = {}
         self._gpu = asyncio.Lock()
 
     def _free_vram_bytes(self) -> int:
@@ -401,6 +409,29 @@ class DiffusersEngine:
         self._last_used.pop(model_id, None)
         self._free_gpu_cache()
 
+    def _evict_poisoned(self, model_id: str) -> bool:
+        """Drop a model left corrupt by a non-OOM generation error (issue #103).
+
+        Returns True when an eviction ran. Cooldown prevents load/unload thrash
+        when every subsequent job keeps failing the same way.
+        """
+        if not any(key[0] == model_id for key in self._pipelines):
+            return False
+        now = time.monotonic()
+        last = self._poison_evicted_at.get(model_id, 0.0)
+        if now - last < POISON_EVICT_COOLDOWN_S:
+            logger.warning(
+                "poisoned pipeline for %s; cooldown %.0fs active (evictions=%d), not reloading",
+                model_id, POISON_EVICT_COOLDOWN_S, self._poison_evict_count.get(model_id, 0),
+            )
+            return False
+        self._evict_model(model_id)
+        self._poison_evicted_at[model_id] = now
+        count = self._poison_evict_count.get(model_id, 0) + 1
+        self._poison_evict_count[model_id] = count
+        logger.warning("evicted poisoned pipeline for %s (count=%d)", model_id, count)
+        return True
+
     def _evict_all(self) -> None:
         self._pipelines.clear()
         self._rungs.clear()
@@ -482,6 +513,13 @@ class DiffusersEngine:
                                                progress, loop, input_image)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
+            except (ValueError, TypeError):
+                raise  # request/validation errors, not a corrupt resident
+            except Exception:
+                # Dtype mismatches and similar leave mixed-precision state in
+                # the resident pipeline; drop it so the next job reloads clean.
+                self._evict_poisoned(manifest.id)
+                raise
             # Two resident models plus activations can exceed a 16 GB card
             # mid-denoise; free the others and run once more.
             self._evict_except(manifest.id)
@@ -599,6 +637,11 @@ class DiffusersEngine:
                 return await asyncio.to_thread(self._frame, manifest, dict(params), payload)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
+            except (ValueError, TypeError):
+                raise
+            except Exception:
+                self._evict_poisoned(manifest.id)
+                raise
             self._evict_except(manifest.id)
             return await asyncio.to_thread(self._frame, manifest, dict(params), payload)
 


### PR DESCRIPTION
## Summary
- After a non-OOM generation or frame error, drop the resident model so the next job reloads clean (OOM still uses the existing evict-and-retry path).
- Cooldown (30s) and eviction counts avoid silent load/unload thrash; ValueError/TypeError stay as request errors without eviction.
- Regression coverage: fail once, succeed after reload; cooldown; validation errors do not evict.

Closes #103.

## Test plan
- [x] `make verify`
- [x] CI green on self-hosted runner
- [x] Optional live check: covered by unit regression reproducing the c10::Half signature from the #102 incident (review: no code changes needed)