### PR TITLE
Wire measured per-factor upscale estimates to the studio

### DIFF
--- a/backend/app/estimates.py
+++ b/backend/app/estimates.py
@@ -27,26 +27,26 @@ def _load_timings() -> dict[str, dict[str, Any]]:
     for model_id, entry in raw.items():
         if model_id.startswith("_") or not isinstance(entry, dict):
             continue
+        # Upscale baselines are a measured per-factor map; diffusion baselines
+        # need gpu_ms plus steps/width/height for pixel scaling.
+        factors_raw = entry.get("factors")
+        if isinstance(factors_raw, dict):
+            factors: dict[int, int] = {}
+            for key, value in factors_raw.items():
+                try:
+                    factor, ms = int(key), int(value)
+                except (TypeError, ValueError):
+                    continue
+                if factor > 0 and ms > 0:
+                    factors[factor] = ms
+            if factors:
+                timings[model_id] = {"factors": factors}
+            continue
         try:
             gpu_ms = int(entry["gpu_ms"])
         except (KeyError, TypeError, ValueError):
             continue
         if gpu_ms <= 0:
-            continue
-        # Diffusion baselines need steps/width/height for pixel scaling.
-        # Upscale baselines are factor-keyed (flat or scale by factor^2).
-        if "factor" in entry:
-            try:
-                factor = int(entry["factor"])
-            except (TypeError, ValueError):
-                continue
-            if factor <= 0:
-                continue
-            timings[model_id] = {
-                "gpu_ms": gpu_ms,
-                "factor": factor,
-                "flat": bool(entry.get("flat", False)),
-            }
             continue
         try:
             candidate = {
@@ -81,19 +81,16 @@ def estimate_gpu_ms(model_id: str, params: dict[str, Any]) -> int | None:
     if baseline is None:
         return None
 
-    if "factor" in baseline:
-        if baseline.get("flat"):
-            return max(1, int(baseline["gpu_ms"]))
+    factors = baseline.get("factors")
+    if factors is not None:
         if "factor" not in params:
-            return max(1, int(baseline["gpu_ms"]))
+            return max(1, factors[min(factors)])
         try:
             factor = int(params["factor"])
         except (TypeError, ValueError):
             return None
-        if factor <= 0:
-            return None
-        scale = (factor / baseline["factor"]) ** 2
-        return max(1, round(baseline["gpu_ms"] * scale))
+        known = factors.get(factor)
+        return max(1, known) if known is not None else None
 
     if not all(key in params for key in ("steps", "width", "height")):
         return None

--- a/backend/app/model_timings.json
+++ b/backend/app/model_timings.json
@@ -1,5 +1,5 @@
 {
-  "_source": "RX 7600 XT; vega-rt #102; realesrgan x2/x4 measured 2026-07-17; realesrgan-fast x4 1024->4096 = 550 ms flat (native-scale cost, issue #108)",
+  "_source": "RX 7600 XT; vega-rt #102; upscalers measured per factor on a 1024px source 2026-07-17 (fast x2 includes the native-x4 run plus Lanczos down, issue #108)",
   "sdxl-base": {
     "gpu_ms": 15274,
     "width": 1024,
@@ -49,12 +49,9 @@
     "steps": 8
   },
   "realesrgan": {
-    "gpu_ms": 17931,
-    "factor": 2
+    "factors": { "2": 17931, "4": 37853 }
   },
   "realesrgan-fast": {
-    "gpu_ms": 550,
-    "factor": 4,
-    "flat": true
+    "factors": { "2": 759, "4": 555 }
   }
 }

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -49,6 +49,17 @@ async def list_models() -> list[dict]:
         payload = manifest.model_dump()
         defaults = schema_defaults(manifest.parameters)
         payload["estimated_gpu_ms_default"] = estimate_gpu_ms(manifest.id, defaults)
+        if "upscale" in manifest.capabilities:
+            # Measured per-factor numbers for the studio's factor picker; the
+            # default-params estimate cannot express factors with unequal cost.
+            factor_spec = manifest.parameters.get("properties", {}).get("factor", {})
+            by_factor = {
+                str(factor): estimate_gpu_ms(manifest.id, {"factor": factor})
+                for factor in factor_spec.get("enum", [])
+            }
+            payload["estimated_gpu_ms_by_factor"] = {
+                factor: ms for factor, ms in by_factor.items() if ms is not None
+            }
         models.append(payload)
     return models
 

--- a/backend/tests/test_estimates.py
+++ b/backend/tests/test_estimates.py
@@ -56,17 +56,16 @@ def test_estimate_gpu_ms_requires_explicit_params():
     assert estimate_gpu_ms("sdxl-fast", {"steps": 8}) is None
 
 
-def test_estimate_gpu_ms_factor_baseline_scales_with_factor():
+def test_estimate_gpu_ms_upscale_uses_measured_factor_map():
+    # Measured per factor: quadratic scaling overestimated x4 by ~2x, and the
+    # compact net's cost is nearly flat (native x4 run plus Lanczos down).
     assert estimate_gpu_ms("realesrgan", {"factor": 2}) == 17931
-    assert estimate_gpu_ms("realesrgan", {"factor": 4}) == 71724
+    assert estimate_gpu_ms("realesrgan", {"factor": 4}) == 37853
     assert estimate_gpu_ms("realesrgan", {}) == 17931
-
-
-def test_estimate_gpu_ms_flat_factor_baseline_ignores_request_factor():
-    # Compact nets always run at native scale then outscale; cost is flat.
-    assert estimate_gpu_ms("realesrgan-fast", {"factor": 2}) == 550
-    assert estimate_gpu_ms("realesrgan-fast", {"factor": 4}) == 550
-    assert estimate_gpu_ms("realesrgan-fast", {}) == 550
+    assert estimate_gpu_ms("realesrgan-fast", {"factor": 2}) == 759
+    assert estimate_gpu_ms("realesrgan-fast", {"factor": 4}) == 555
+    assert estimate_gpu_ms("realesrgan-fast", {}) == 759
+    assert estimate_gpu_ms("realesrgan", {"factor": 3}) is None
 
 
 def test_load_timings_survives_bad_json(tmp_path, monkeypatch):

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -393,6 +393,38 @@ def test_upscale_dispatch_includes_input_url():
 
 
 @pytest.mark.db
+def test_models_expose_measured_upscale_estimates():
+    fast_manifest = {
+        "id": "realesrgan-fast",
+        "name": "Real-ESRGAN Fast",
+        "capabilities": ["upscale"],
+        "parameters": {
+            "type": "object",
+            "properties": {"factor": {"type": "integer", "enum": [2, 4], "default": 2}},
+            "required": ["factor"],
+        },
+        "min_vram_gb": 1,
+    }
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            worker.send_json({
+                "type": "hello",
+                "protocol_version": PROTOCOL_VERSION,
+                "worker_id": "w-upscale-estimates",
+                "models": [MANIFEST, fast_manifest],
+                "realtime_slots": 1,
+            })
+            assert worker.receive_json()["type"] == "registered"
+
+            models = client.get("/api/v1/models").json()
+            fast = next(m for m in models if m["id"] == "realesrgan-fast")
+            assert fast["estimated_gpu_ms_by_factor"] == {"2": 759, "4": 555}
+            assert fast["estimated_gpu_ms_default"] == 759
+            diffusion = next(m for m in models if m["id"] == "sd-test")
+            assert "estimated_gpu_ms_by_factor" not in diffusion
+
+
+@pytest.mark.db
 def test_upscale_rejects_without_source_asset():
     upscale_manifest = {
         "id": "realesrgan",

--- a/frontend/src/lib/gpu-estimate.ts
+++ b/frontend/src/lib/gpu-estimate.ts
@@ -28,8 +28,13 @@ export function estimateGpuMs(
 }
 
 export function estimateUpscaleGpuMs(model: Model | undefined, factor: number): number | null {
+	if (!Number.isFinite(factor) || factor <= 0) return null;
+	// Measured per-factor numbers from the registry win; factor^2 scaling is
+	// the fallback and is wrong for native-scale models (x4 net serving x2).
+	const measured = model?.estimated_gpu_ms_by_factor?.[String(factor)];
+	if (measured != null && measured > 0) return Math.round(measured);
 	const baseMs = model?.estimated_gpu_ms_default;
-	if (baseMs == null || baseMs <= 0 || !Number.isFinite(factor) || factor <= 0) return null;
+	if (baseMs == null || baseMs <= 0) return null;
 	const defaultFactor = Number(modelProperty(model, 'factor')?.default ?? 2);
 	if (!Number.isFinite(defaultFactor) || defaultFactor <= 0) return Math.max(1, Math.round(baseMs));
 	return Math.max(1, Math.round(baseMs * (factor / defaultFactor) ** 2));

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -7,6 +7,7 @@ export type Model = {
 	capabilities: string[];
 	default: boolean;
 	estimated_gpu_ms_default: number | null;
+	estimated_gpu_ms_by_factor?: Record<string, number>;
 	parameters: {
 		properties?: Record<
 			string,


### PR DESCRIPTION
# Description

Replace the single-baseline upscale timing format (factor plus flat flag) with a measured per-factor map, expose it on GET /api/v1/models as estimated_gpu_ms_by_factor for upscale-capable models, and make the studio's estimate label prefer those measured numbers over factor-squared scaling.

# Motivation

With realesrgan-fast the default tier (PR #119), the studio label was wrong in both tiers: factor-squared scaling showed ~2.2 s for a fast x4 that takes 0.55 s (the compact net always runs at native x4, so its cost is nearly flat), and showed 71.7 s for a quality x4 measured at 37.9 s. The backend knew the flat truth since #113 but the wire only carried estimated_gpu_ms_default, so the frontend had to guess.

# Functionality

- model_timings.json upscale entries become factors maps with measured numbers from the RX 7600 XT acceptance runs: realesrgan 2: 17931 / 4: 37853, realesrgan-fast 2: 759 / 4: 555 (x2 fast includes the native-x4 run plus the Lanczos down).
- estimates.py parses the map and answers exact factors only; the flat special case and quadratic upscale scaling are gone. Missing factor falls back to the smallest measured factor.
- GET /api/v1/models adds estimated_gpu_ms_by_factor for upscale manifests, built from the factor enum.
- estimateUpscaleGpuMs prefers the measured map; the quadratic path stays only as a fallback for upscalers without timing entries.

# Details

Verified: backend ruff, mypy, 63 tests including a new wire test asserting the by-factor payload and its absence on diffusion models; frontend lint, svelte-check, build. Numbers come from the GPU acceptance runs recorded on #104 and #113. Independent of PR #119 but pairs with it: together the Upscale button shows honest sub-second labels for the fast tier.