### PR TITLE
Fix flaky metrics dispatch timestamp test on main

### DIFF
--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -146,7 +146,16 @@ def test_job_dispatch_and_finish_timestamps():
                 async with db.session_factory() as session:
                     return await session.get(Job, job_id)
 
-            job = asyncio.run(read_job())
+            # Dispatch sends the websocket message before committing
+            # dispatched_at (jobs.dispatch); wait for the row to catch up.
+            job = None
+            deadline = time.monotonic() + 3.0
+            while time.monotonic() < deadline:
+                job = asyncio.run(read_job())
+                assert job is not None
+                if job.dispatched_at is not None and job.state == "running":
+                    break
+                time.sleep(0.05)
             assert job is not None
             assert job.dispatched_at is not None
             assert job.state == "running"


### PR DESCRIPTION
## Summary
- Main backend CI failed on `test_job_dispatch_and_finish_timestamps` after #112: `dispatched_at` was still null right after the worker received `dispatch_job`.
- `jobs.dispatch` sends the fleet websocket message before committing `dispatched_at` / `running` (by design for disconnect bookkeeping). The test now polls until that commit is visible, matching the existing finish wait.

## Test plan
- [x] `pytest tests/test_metrics.py::test_job_dispatch_and_finish_timestamps` x20 locally against Postgres
- [x] CI green on this PR