### PR TITLE
Add aligned security response headers for Pages and FastAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ data/
 prompt.md
 CLAUDE.md
 .local/
+docs/guide/
+docs/internals/
 
 # Local agent/editor tooling
 .mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,6 @@ data/
 prompt.md
 CLAUDE.md
 .local/
-docs/guide/
-docs/internals/
 
 # Local agent/editor tooling
 .mcp.json

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,7 +40,15 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await db.dispose()
 
 
-app = FastAPI(title="potocolom", lifespan=lifespan)
+app = FastAPI(
+    title="potocolom",
+    lifespan=lifespan,
+    # Swagger UI / ReDoc load JS and CSS from cdn.jsdelivr.net; that violates
+    # script-src/style-src 'self'. Interactive docs are not a supported
+    # production endpoint - keep /openapi.json for tooling.
+    docs_url=None,
+    redoc_url=None,
+)
 # User middleware covers API, static, SPA fallbacks, and handled HTTP errors.
 # Unhandled 500s are emitted by ServerErrorMiddleware outside that stack, so
 # they get headers from the Exception handler below instead.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.metrics import router as metrics_router
 from app.realtime import reap_dead_workers
 from app.realtime import router as realtime_router
 from app.registry import router as registry_router
+from app.security import SecurityHeadersMiddleware, unhandled_exception_response
 from app.settings import get_settings
 from app.studio import router as studio_router
 
@@ -40,6 +41,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(title="potocolom", lifespan=lifespan)
+# User middleware covers API, static, SPA fallbacks, and handled HTTP errors.
+# Unhandled 500s are emitted by ServerErrorMiddleware outside that stack, so
+# they get headers from the Exception handler below instead.
+app.add_middleware(SecurityHeadersMiddleware)
+app.add_exception_handler(Exception, unhandled_exception_response)
 app.include_router(realtime_router)
 if get_settings().benchmark_api:
     app.include_router(benchmark_router)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,0 +1,77 @@
+"""Canonical HTTP security headers for every non-WebSocket response.
+
+The same header map is mirrored in frontend/static/_headers for Cloudflare
+Pages. Keep the two byte-for-byte aligned; tests assert the match.
+"""
+
+from starlette.datastructures import MutableHeaders
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# HTTP CSP permits inline scripts as a compatibility envelope for any response
+# that is not a prerendered SvelteKit document. The generated CSP meta tag in
+# each prerendered page supplies the per-build SHA-256 script hash and is the
+# effective script-execution restriction for the SPA.
+CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; "
+    "base-uri 'self'; "
+    "object-src 'none'; "
+    "frame-ancestors 'none'; "
+    "form-action 'self'; "
+    "frame-src 'self'; "
+    "connect-src 'self'; "
+    "font-src 'self'; "
+    "img-src 'self' https:; "
+    "script-src 'self' 'unsafe-inline'; "
+    "style-src 'self' 'unsafe-inline'"
+)
+
+SECURITY_HEADERS: dict[str, str] = {
+    "Content-Security-Policy": CONTENT_SECURITY_POLICY,
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    # No includeSubDomains / preload: self-hosted operators may serve
+    # unrelated subdomains from the same certificate or host.
+    "Strict-Transport-Security": "max-age=31536000",
+    "Permissions-Policy": (
+        "accelerometer=(), camera=(), geolocation=(), gyroscope=(), "
+        "magnetometer=(), microphone=(), payment=(), usb=()"
+    ),
+}
+
+
+def unhandled_exception_response(request: Request, exc: Exception) -> Response:
+    """500 body for ServerErrorMiddleware; must carry SECURITY_HEADERS itself.
+
+    Starlette places ServerErrorMiddleware outside user middleware, so responses
+    from this handler never pass through SecurityHeadersMiddleware.
+    """
+    del request, exc  # signature fixed by Starlette ExceptionHandler
+    return PlainTextResponse(
+        "Internal Server Error",
+        status_code=500,
+        headers=SECURITY_HEADERS,
+    )
+
+
+class SecurityHeadersMiddleware:
+    """Attach SECURITY_HEADERS to every HTTP response; leave WebSockets alone."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                for name, value in SECURITY_HEADERS.items():
+                    headers[name] = value
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -14,8 +14,9 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 # each prerendered page supplies the per-build SHA-256 script hash and is the
 # effective script-execution restriction for the SPA.
 # img-src includes http: so MinIO / S3-compatible endpoints on another origin
-# (e.g. http://localhost:9100) remain loadable; HTTPS pages still block HTTP
-# images as mixed content.
+# (e.g. http://localhost:9100) remain allowable under CSP; browser mixed-content
+# processing still applies, so secure pages may upgrade or block insecure image
+# requests.
 CONTENT_SECURITY_POLICY = (
     "default-src 'self'; "
     "base-uri 'self'; "

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -13,6 +13,9 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 # that is not a prerendered SvelteKit document. The generated CSP meta tag in
 # each prerendered page supplies the per-build SHA-256 script hash and is the
 # effective script-execution restriction for the SPA.
+# img-src includes http: so MinIO / S3-compatible endpoints on another origin
+# (e.g. http://localhost:9100) remain loadable; HTTPS pages still block HTTP
+# images as mixed content.
 CONTENT_SECURITY_POLICY = (
     "default-src 'self'; "
     "base-uri 'self'; "
@@ -22,7 +25,7 @@ CONTENT_SECURITY_POLICY = (
     "frame-src 'self'; "
     "connect-src 'self'; "
     "font-src 'self'; "
-    "img-src 'self' https:; "
+    "img-src 'self' https: http:; "
     "script-src 'self' 'unsafe-inline'; "
     "style-src 'self' 'unsafe-inline'"
 )

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,134 @@
+"""Security response headers on API, static, SPA fallback, and error paths."""
+
+import asyncio
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.main import SPAStaticFiles, app
+from app.security import (
+    SECURITY_HEADERS,
+    SecurityHeadersMiddleware,
+    unhandled_exception_response,
+)
+
+client = TestClient(app)
+
+# Repo-root-relative path to the Cloudflare Pages header file that must stay
+# byte-for-byte aligned with SECURITY_HEADERS.
+_HEADERS_FILE = (
+    Path(__file__).resolve().parents[2] / "frontend" / "static" / "_headers"
+)
+
+
+def _assert_security_headers(response) -> None:
+    for name, value in SECURITY_HEADERS.items():
+        assert response.headers.get(name) == value, (
+            f"{name}: expected {value!r}, got {response.headers.get(name)!r}"
+        )
+
+
+def test_security_headers_on_health():
+    response = client.get("/api/v1/health")
+    assert response.status_code == 200
+    _assert_security_headers(response)
+
+
+def test_security_headers_on_api_404():
+    response = client.get("/api/v1/no-such-endpoint")
+    assert response.status_code == 404
+    _assert_security_headers(response)
+
+
+def test_security_headers_on_unhandled_500():
+    """ServerErrorMiddleware is outside user middleware; the Exception handler covers 500s."""
+    # Production wiring: if main.py drops the handler, this fails even when a
+    # miniature app below is configured correctly.
+    assert app.exception_handlers.get(Exception) is unhandled_exception_response
+
+    inner = FastAPI()
+    inner.add_middleware(SecurityHeadersMiddleware)
+    inner.add_exception_handler(Exception, unhandled_exception_response)
+
+    @inner.get("/boom")
+    async def boom() -> None:
+        raise RuntimeError("boom")
+
+    with TestClient(inner, raise_server_exceptions=False) as boom_client:
+        response = boom_client.get("/boom")
+        assert response.status_code == 500
+        _assert_security_headers(response)
+
+
+def test_security_headers_on_static_and_spa_fallback(tmp_path: Path):
+    dist = tmp_path / "static"
+    dist.mkdir()
+    (dist / "index.html").write_text("<!doctype html><title>potocolom</title>")
+    (dist / "asset.txt").write_text("ok")
+
+    spa = FastAPI()
+    spa.add_middleware(SecurityHeadersMiddleware)
+    spa.mount("/", SPAStaticFiles(directory=dist, html=True), name="frontend")
+
+    with TestClient(spa) as spa_client:
+        static = spa_client.get("/asset.txt")
+        assert static.status_code == 200
+        assert static.text == "ok"
+        _assert_security_headers(static)
+
+        fallback = spa_client.get("/app/generate")
+        assert fallback.status_code == 200
+        assert "potocolom" in fallback.text
+        _assert_security_headers(fallback)
+
+
+def test_security_headers_skip_websocket():
+    """Middleware must not wrap WebSocket scopes (no HTTP response headers)."""
+    seen: list[str] = []
+
+    async def raw_app(scope, receive, send):
+        seen.append(scope["type"])
+        if scope["type"] == "websocket":
+            await send({"type": "websocket.accept"})
+            await send({"type": "websocket.close", "code": 1000})
+
+    wrapped = SecurityHeadersMiddleware(raw_app)
+
+    async def receive():
+        return {"type": "websocket.connect"}
+
+    messages: list[dict] = []
+
+    async def send(message):
+        messages.append(message)
+
+    asyncio.run(
+        wrapped(
+            {"type": "websocket", "path": "/api/v1/fleet", "headers": []},
+            receive,
+            send,
+        )
+    )
+    assert seen == ["websocket"]
+    assert all(m["type"].startswith("websocket.") for m in messages)
+
+
+def test_cloudflare_headers_byte_for_byte_aligned():
+    text = _HEADERS_FILE.read_text()
+    # Parse the /* block only; /images/* keeps its own cache rule.
+    block: dict[str, str] = {}
+    in_star = False
+    for line in text.splitlines():
+        if line.strip() == "/*":
+            in_star = True
+            continue
+        if in_star:
+            if not line.startswith("  ") or not line.strip() or line.lstrip().startswith("#"):
+                if block:
+                    break
+                continue
+            name, _, value = line.strip().partition(": ")
+            block[name] = value
+
+    assert block == SECURITY_HEADERS

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -35,6 +35,16 @@ def test_security_headers_on_health():
     _assert_security_headers(response)
 
 
+def test_interactive_api_docs_disabled():
+    """CDN-backed /docs and /redoc are off; OpenAPI JSON stays available."""
+    assert client.get("/docs").status_code == 404
+    assert client.get("/redoc").status_code == 404
+    openapi = client.get("/openapi.json")
+    assert openapi.status_code == 200
+    assert "openapi" in openapi.json()
+    _assert_security_headers(openapi)
+
+
 def test_security_headers_on_api_404():
     response = client.get("/api/v1/no-such-endpoint")
     assert response.status_code == 404

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -142,3 +142,14 @@ def test_cloudflare_headers_byte_for_byte_aligned():
             block[name] = value
 
     assert block == SECURITY_HEADERS
+
+
+def test_csp_img_src_allows_http_object_store():
+    """S3-compatible stores (MinIO on :9100) may be http on another origin."""
+    img_src = next(
+        part.strip()
+        for part in SECURITY_HEADERS["Content-Security-Policy"].split(";")
+        if part.strip().startswith("img-src ")
+    )
+    tokens = img_src.split()[1:]
+    assert tokens == ["'self'", "https:", "http:"]

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -145,7 +145,11 @@ def test_cloudflare_headers_byte_for_byte_aligned():
 
 
 def test_csp_img_src_allows_http_object_store():
-    """S3-compatible stores (MinIO on :9100) may be http on another origin."""
+    """S3-compatible stores (MinIO on :9100) may be http on another origin.
+
+    https: is kept beside http: for readability even though http: also matches
+    HTTPS via CSP scheme upgrading.
+    """
     img_src = next(
         part.strip()
         for part in SECURITY_HEADERS["Content-Security-Policy"].split(";")

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -4,7 +4,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.security import SECURITY_HEADERS
 from app.settings import Settings
 from app.storage import LocalStorage, S3Storage, get_storage
 
@@ -34,14 +33,11 @@ def test_s3_storage_presigns_offline():
     assert "u/j.webp" in target.url
     assert "X-Amz-Signature" in target.url
     assert target.headers == {"Content-Type": "image/webp"}
-    # Cross-origin MinIO URLs are not same-origin with the SPA; CSP img-src
-    # must allow http: so one-build local/cloud-sim profiles keep working.
-    img_src = next(
-        part.strip()
-        for part in SECURITY_HEADERS["Content-Security-Policy"].split(";")
-        if part.strip().startswith("img-src ")
-    )
-    assert "http:" in img_src.split()
+    # Browser-facing image URL (SPA <img src>), not the worker upload target.
+    view = asyncio.run(storage.url("u/j.webp"))
+    assert view.startswith("http://localhost:9100/")
+    assert "u/j.webp" in view
+    assert "X-Amz-Signature" in view
 
 
 def test_files_get_after_direct_write():

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.security import SECURITY_HEADERS
 from app.settings import Settings
 from app.storage import LocalStorage, S3Storage, get_storage
 
@@ -29,9 +30,18 @@ def test_s3_storage_presigns_offline():
                                  storage_s3_access_key="key",
                                  storage_s3_secret_key="secret"))
     target = asyncio.run(storage.upload_target("u/j.webp"))
+    assert target.url.startswith("http://localhost:9100/")
     assert "u/j.webp" in target.url
     assert "X-Amz-Signature" in target.url
     assert target.headers == {"Content-Type": "image/webp"}
+    # Cross-origin MinIO URLs are not same-origin with the SPA; CSP img-src
+    # must allow http: so one-build local/cloud-sim profiles keep working.
+    img_src = next(
+        part.strip()
+        for part in SECURITY_HEADERS["Content-Security-Policy"].split(";")
+        if part.strip().startswith("img-src ")
+    )
+    assert "http:" in img_src.split()
 
 
 def test_files_get_after_direct_write():

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -82,6 +82,10 @@ upgrade an initial plain-HTTP connection.
 - HSTS is emitted without `includeSubDomains` or `preload` so self-hosted
   operators can serve unrelated subdomains from the same host without pinning
   them to HTTPS via this header.
+- The SPA CSP allows `img-src http:` so S3-compatible stores such as MinIO
+  (`http://localhost:9100` in the cloud-sim profile) can serve presigned
+  images cross-origin. On an HTTPS page, browsers still block HTTP images as
+  mixed content.
 
 ## What persists where
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -66,6 +66,23 @@ docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
   rebuild the image) and restart the worker; see
   [third-party-models.md](third-party-models.md) for licensing notes.
 
+## TLS and HSTS
+
+The API emits `Strict-Transport-Security: max-age=31536000` on every HTTP
+response (aligned with Cloudflare Pages via `frontend/static/_headers`). HSTS
+is honored by browsers **only over HTTPS**; it does not itself provide TLS or
+upgrade an initial plain-HTTP connection.
+
+- The shipped localhost/LAN compose profile remains plain HTTP for development
+  (`http://localhost:8080`). That is intentional.
+- Any public deployment must terminate TLS in front of the API (reverse proxy,
+  load balancer, or similar) and redirect HTTP to HTTPS before exposing the
+  service. Without that, clients never see a secure context and HSTS has no
+  effect.
+- HSTS is emitted without `includeSubDomains` or `preload` so self-hosted
+  operators can serve unrelated subdomains from the same host without pinning
+  them to HTTPS via this header.
+
 ## What persists where
 
 | Volume | Contents | Losing it means |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -82,10 +82,12 @@ upgrade an initial plain-HTTP connection.
 - HSTS is emitted without `includeSubDomains` or `preload` so self-hosted
   operators can serve unrelated subdomains from the same host without pinning
   them to HTTPS via this header.
-- The SPA CSP allows `img-src http:` so S3-compatible stores such as MinIO
+- The SPA CSP allows `img-src http:` (and `https:`, kept explicitly for
+  readability) so S3-compatible stores such as MinIO
   (`http://localhost:9100` in the cloud-sim profile) can serve presigned
-  images cross-origin. On an HTTPS page, browsers still block HTTP images as
-  mixed content.
+  images cross-origin. CSP permits the source; browser mixed-content
+  processing still applies, so secure pages may upgrade or block insecure
+  image requests.
 
 ## What persists where
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build",
+		"build": "vite build && node scripts/verify-csp.mjs",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/frontend/scripts/verify-csp.mjs
+++ b/frontend/scripts/verify-csp.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Post-build check: every prerendered HTML document must carry a hash CSP meta
+ * policy whose script-src is exactly 'self' plus SHA-256 hashes of that
+ * document's inline scripts (no unsafe-inline, no extra sources).
+ * Dependency-free; invoked by `npm run build`.
+ */
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const buildDir = join(root, 'build');
+
+function walkHtml(dir) {
+	const out = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const path = join(dir, entry.name);
+		if (entry.isDirectory()) out.push(...walkHtml(path));
+		else if (entry.name.endsWith('.html')) out.push(path);
+	}
+	return out;
+}
+
+function scriptHash(body) {
+	return `'sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}'`;
+}
+
+function fail(message) {
+	console.error(`verify-csp: ${message}`);
+	process.exit(1);
+}
+
+let htmlFiles;
+try {
+	htmlFiles = walkHtml(buildDir);
+} catch (err) {
+	fail(`cannot read ${buildDir}: ${err.message}`);
+}
+
+if (htmlFiles.length === 0) {
+	fail('no HTML files under build/');
+}
+
+for (const filePath of htmlFiles) {
+	const rel = relative(buildDir, filePath);
+	const html = readFileSync(filePath, 'utf8');
+
+	// Attribute values use double quotes; the policy itself contains single quotes.
+	const metaMatch = html.match(
+		/<meta\s+http-equiv=["']content-security-policy["']\s+content=(["'])([\s\S]*?)\1/i
+	);
+	if (!metaMatch) {
+		fail(`${rel}: missing Content-Security-Policy meta tag`);
+	}
+
+	const policy = metaMatch[2];
+	const scriptSrc = policy
+		.split(';')
+		.map((part) => part.trim())
+		.find((part) => part.toLowerCase().startsWith('script-src '));
+
+	if (!scriptSrc) {
+		fail(`${rel}: CSP meta policy has no script-src directive`);
+	}
+
+	if (/'unsafe-inline'/.test(scriptSrc)) {
+		fail(`${rel}: script-src must not allow 'unsafe-inline':\n  ${scriptSrc}`);
+	}
+
+	const tokens = scriptSrc.slice('script-src '.length).trim().split(/\s+/).filter(Boolean);
+	const expected = new Set(["'self'"]);
+
+	// Inline scripts only (no src=). Match body exactly for CSP hashing.
+	const inlineRe = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
+	let match;
+	while ((match = inlineRe.exec(html)) !== null) {
+		expected.add(scriptHash(match[1]));
+	}
+
+	if (expected.size === 1) {
+		fail(`${rel}: expected at least one inline bootstrap script to hash`);
+	}
+
+	const actual = new Set(tokens);
+	const missing = [...expected].filter((t) => !actual.has(t));
+	const extra = [...actual].filter((t) => !expected.has(t));
+	if (missing.length || extra.length) {
+		fail(
+			`${rel}: script-src must be exactly 'self' plus hashes of inline scripts.\n` +
+				`  policy:  ${scriptSrc}\n` +
+				`  missing: ${missing.join(' ') || '(none)'}\n` +
+				`  extra:   ${extra.join(' ') || '(none)'}`
+		);
+	}
+}
+
+console.log(
+	`verify-csp: ok (${htmlFiles.length} HTML file(s); script-src is 'self' + matching SHA-256 hashes)`
+);

--- a/frontend/scripts/verify-csp.mjs
+++ b/frontend/scripts/verify-csp.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 /**
  * Post-build check: every prerendered HTML document must carry a hash CSP meta
- * policy whose script-src is exactly 'self' plus SHA-256 hashes of that
- * document's inline scripts (no unsafe-inline, no extra sources).
+ * policy whose non-script directives match the configured baseline and whose
+ * script-src is exactly 'self' plus SHA-256 hashes of that document's inline
+ * scripts (no unsafe-inline, no extra sources).
  * Dependency-free; invoked by `npm run build`.
  */
 import { createHash } from 'node:crypto';
@@ -12,6 +13,21 @@ import { fileURLToPath } from 'node:url';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const buildDir = join(root, 'build');
+
+// Matches frontend/vite.config.ts csp.directives except script-src (hashed per
+// file) and frame-ancestors (SvelteKit omits it from meta CSP; browsers ignore
+// frame-ancestors in meta anyway).
+const EXPECTED_DIRECTIVES = {
+	'default-src': ["'self'"],
+	'base-uri': ["'self'"],
+	'object-src': ["'none'"],
+	'form-action': ["'self'"],
+	'frame-src': ["'self'"],
+	'connect-src': ["'self'"],
+	'font-src': ["'self'"],
+	'img-src': ["'self'", 'https:'],
+	'style-src': ["'self'", "'unsafe-inline'"]
+};
 
 function walkHtml(dir) {
 	const out = [];
@@ -25,6 +41,25 @@ function walkHtml(dir) {
 
 function scriptHash(body) {
 	return `'sha256-${createHash('sha256').update(body, 'utf8').digest('base64')}'`;
+}
+
+function parsePolicy(policy) {
+	/** @type {Record<string, string[]>} */
+	const directives = {};
+	for (const part of policy.split(';')) {
+		const trimmed = part.trim();
+		if (!trimmed) continue;
+		const [name, ...values] = trimmed.split(/\s+/);
+		directives[name.toLowerCase()] = values;
+	}
+	return directives;
+}
+
+function sameTokens(actual, expected) {
+	if (actual.length !== expected.length) return false;
+	const a = [...actual].sort();
+	const e = [...expected].sort();
+	return a.every((token, i) => token === e[i]);
 }
 
 function fail(message) {
@@ -55,47 +90,62 @@ for (const filePath of htmlFiles) {
 		fail(`${rel}: missing Content-Security-Policy meta tag`);
 	}
 
-	const policy = metaMatch[2];
-	const scriptSrc = policy
-		.split(';')
-		.map((part) => part.trim())
-		.find((part) => part.toLowerCase().startsWith('script-src '));
+	const directives = parsePolicy(metaMatch[2]);
 
+	for (const [name, expected] of Object.entries(EXPECTED_DIRECTIVES)) {
+		const actual = directives[name];
+		if (!actual) {
+			fail(`${rel}: CSP meta policy missing ${name}`);
+		}
+		if (!sameTokens(actual, expected)) {
+			fail(
+				`${rel}: ${name} mismatch.\n` +
+					`  expected: ${expected.join(' ')}\n` +
+					`  actual:   ${actual.join(' ')}`
+			);
+		}
+	}
+
+	const scriptSrc = directives['script-src'];
 	if (!scriptSrc) {
 		fail(`${rel}: CSP meta policy has no script-src directive`);
 	}
-
-	if (/'unsafe-inline'/.test(scriptSrc)) {
-		fail(`${rel}: script-src must not allow 'unsafe-inline':\n  ${scriptSrc}`);
+	if (scriptSrc.includes("'unsafe-inline'")) {
+		fail(`${rel}: script-src must not allow 'unsafe-inline':\n  script-src ${scriptSrc.join(' ')}`);
 	}
 
-	const tokens = scriptSrc.slice('script-src '.length).trim().split(/\s+/).filter(Boolean);
-	const expected = new Set(["'self'"]);
-
-	// Inline scripts only (no src=). Match body exactly for CSP hashing.
+	const expectedScript = new Set(["'self'"]);
 	const inlineRe = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
 	let match;
 	while ((match = inlineRe.exec(html)) !== null) {
-		expected.add(scriptHash(match[1]));
+		expectedScript.add(scriptHash(match[1]));
 	}
-
-	if (expected.size === 1) {
+	if (expectedScript.size === 1) {
 		fail(`${rel}: expected at least one inline bootstrap script to hash`);
 	}
 
-	const actual = new Set(tokens);
-	const missing = [...expected].filter((t) => !actual.has(t));
-	const extra = [...actual].filter((t) => !expected.has(t));
+	const actualScript = new Set(scriptSrc);
+	const missing = [...expectedScript].filter((t) => !actualScript.has(t));
+	const extra = [...actualScript].filter((t) => !expectedScript.has(t));
 	if (missing.length || extra.length) {
 		fail(
 			`${rel}: script-src must be exactly 'self' plus hashes of inline scripts.\n` +
-				`  policy:  ${scriptSrc}\n` +
+				`  policy:  script-src ${scriptSrc.join(' ')}\n` +
 				`  missing: ${missing.join(' ') || '(none)'}\n` +
 				`  extra:   ${extra.join(' ') || '(none)'}`
 		);
 	}
+
+	// frame-ancestors is ignored in meta CSP; allow absence or presence, but
+	// reject any other unexpected directive that would widen the policy.
+	for (const name of Object.keys(directives)) {
+		if (name === 'script-src' || name === 'frame-ancestors') continue;
+		if (!(name in EXPECTED_DIRECTIVES)) {
+			fail(`${rel}: unexpected CSP directive ${name}`);
+		}
+	}
 }
 
 console.log(
-	`verify-csp: ok (${htmlFiles.length} HTML file(s); script-src is 'self' + matching SHA-256 hashes)`
+	`verify-csp: ok (${htmlFiles.length} HTML file(s); meta CSP directives and script hashes match)`
 );

--- a/frontend/scripts/verify-csp.mjs
+++ b/frontend/scripts/verify-csp.mjs
@@ -25,7 +25,7 @@ const EXPECTED_DIRECTIVES = {
 	'frame-src': ["'self'"],
 	'connect-src': ["'self'"],
 	'font-src': ["'self'"],
-	'img-src': ["'self'", 'https:'],
+	'img-src': ["'self'", 'https:', 'http:'],
 	'style-src': ["'self'", "'unsafe-inline'"]
 };
 

--- a/frontend/src/routes/collage-preview/+page.svelte
+++ b/frontend/src/routes/collage-preview/+page.svelte
@@ -1,7 +1,19 @@
 <script lang="ts">
-	import { collagePreviewList } from '$lib/collage-variants';
+	import CollageGraph from '$lib/components/collage/CollageGraph.svelte';
+	import CollageMasonry from '$lib/components/collage/CollageMasonry.svelte';
+	import {
+		collagePreviewList,
+		masonryCollageVariants,
+		type CollagePreviewVariantId
+	} from '$lib/collage-variants';
 
 	const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+
+	function masonryConfig(id: CollagePreviewVariantId) {
+		return id in masonryCollageVariants
+			? masonryCollageVariants[id as keyof typeof masonryCollageVariants]
+			: null;
+	}
 </script>
 
 <svelte:head>
@@ -16,13 +28,16 @@
 		<h1 class="mt-1 text-3xl font-semibold">Masonry directions</h1>
 		<p class="text-muted-foreground mt-2 max-w-3xl text-sm leading-relaxed">
 			Seven masonry layouts that keep each image at its natural aspect ratio, plus a tighter graph
-			layout. Run <code class="text-foreground/80">npm run compare:collages</code> to open dedicated dev
-			servers for side-by-side review.
+			layout. Previews render inline (no iframes) so the global
+			<code class="text-foreground/80">frame-ancestors 'none'</code> / X-Frame-Options DENY policy
+			stays intact. Run <code class="text-foreground/80">npm run compare:collages</code> to open dedicated
+			dev servers for side-by-side review.
 		</p>
 	</header>
 
 	<div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
 		{#each collagePreviewList as variant (variant.id)}
+			{@const config = masonryConfig(variant.id)}
 			<section class="border-border/60 overflow-hidden rounded-xl border">
 				<div class="border-border/60 flex items-center justify-between gap-3 border-b px-4 py-3">
 					<div>
@@ -40,12 +55,18 @@
 						Open full
 					</a>
 				</div>
-				<iframe
-					title={variant.title}
-					src="/collage-preview/{variant.id}"
-					class="bg-background h-[28rem] w-full"
-					loading="lazy"
-				></iframe>
+				<div class="bg-background h-[28rem] overflow-auto p-3">
+					{#if config}
+						<CollageMasonry
+							columnsClass={config.columnsClass}
+							columnGap={config.columnGap}
+							tileMargin={config.tileMargin}
+							radius={config.radius}
+						/>
+					{:else}
+						<CollageGraph />
+					{/if}
+				</div>
 			</section>
 		{/each}
 	</div>

--- a/frontend/src/routes/collage-preview/+page.svelte
+++ b/frontend/src/routes/collage-preview/+page.svelte
@@ -6,13 +6,36 @@
 		masonryCollageVariants,
 		type CollagePreviewVariantId
 	} from '$lib/collage-variants';
+	import { SvelteSet } from 'svelte/reactivity';
 
 	const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
+
+	// Mount each preview only when its pane nears the viewport so the hub does
+	// not instantiate every masonry/graph DOM tree up front.
+	const mountedIds = new SvelteSet<string>();
 
 	function masonryConfig(id: CollagePreviewVariantId) {
 		return id in masonryCollageVariants
 			? masonryCollageVariants[id as keyof typeof masonryCollageVariants]
 			: null;
+	}
+
+	function nearViewport(node: HTMLElement, id: string) {
+		if (typeof IntersectionObserver === 'undefined') {
+			mountedIds.add(id);
+			return {};
+		}
+		const io = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((entry) => entry.isIntersecting)) {
+					mountedIds.add(id);
+					io.disconnect();
+				}
+			},
+			{ rootMargin: '200px 0px' }
+		);
+		io.observe(node);
+		return { destroy: () => io.disconnect() };
 	}
 </script>
 
@@ -30,8 +53,9 @@
 			Seven masonry layouts that keep each image at its natural aspect ratio, plus a tighter graph
 			layout. Previews render inline (no iframes) so the global
 			<code class="text-foreground/80">frame-ancestors 'none'</code> / X-Frame-Options DENY policy
-			stays intact. Run <code class="text-foreground/80">npm run compare:collages</code> to open dedicated
-			dev servers for side-by-side review.
+			stays intact; each tile mounts when it nears the viewport. Run
+			<code class="text-foreground/80">npm run compare:collages</code> to open dedicated dev servers for
+			side-by-side review.
 		</p>
 	</header>
 
@@ -55,16 +79,18 @@
 						Open full
 					</a>
 				</div>
-				<div class="bg-background h-[28rem] overflow-auto p-3">
-					{#if config}
-						<CollageMasonry
-							columnsClass={config.columnsClass}
-							columnGap={config.columnGap}
-							tileMargin={config.tileMargin}
-							radius={config.radius}
-						/>
-					{:else}
-						<CollageGraph />
+				<div class="bg-background h-[28rem] overflow-auto p-3" use:nearViewport={variant.id}>
+					{#if mountedIds.has(variant.id)}
+						{#if config}
+							<CollageMasonry
+								columnsClass={config.columnsClass}
+								columnGap={config.columnGap}
+								tileMargin={config.tileMargin}
+								radius={config.radius}
+							/>
+						{:else}
+							<CollageGraph />
+						{/if}
 					{/if}
 				</div>
 			</section>

--- a/frontend/static/_headers
+++ b/frontend/static/_headers
@@ -1,3 +1,13 @@
+# Security headers for every path. Values must stay byte-for-byte aligned with
+# backend/app/security.py SECURITY_HEADERS (asserted by backend tests).
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self' https:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Strict-Transport-Security: max-age=31536000
+  Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
+
 # Long-cache static image assets. Filenames are stable slugs; regenerate under a
 # new slug (or purge) when replacing an image in place.
 /images/*

--- a/frontend/static/_headers
+++ b/frontend/static/_headers
@@ -1,7 +1,7 @@
 # Security headers for every path. Values must stay byte-for-byte aligned with
 # backend/app/security.py SECURITY_HEADERS (asserted by backend tests).
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self' https:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; frame-src 'self'; connect-src 'self'; font-src 'self'; img-src 'self' https: http:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -32,8 +32,8 @@ export default defineConfig({
 			// emit a looser script-src (with 'unsafe-inline') as a compatibility
 			// envelope; the meta policy is the effective script restriction.
 			// style-src keeps 'unsafe-inline' for inline style attributes and
-			// runtime chart styles. Aligned with backend/app/security.py except
-			// script-src (docs/internals/08-security-production.md).
+			// runtime chart styles. Source lists match backend/app/security.py
+			// except script-src, which stays 'self' here so hashes can be added.
 			csp: {
 				mode: 'hash',
 				directives: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,7 +25,31 @@ export default defineConfig({
 
 			// Static SPA build: one artifact for every deployment, served by the API
 			// when self-hosted and by a CDN in the cloud (docs/architecture.md).
-			adapter: adapter({ fallback: 'index.html' })
+			adapter: adapter({ fallback: 'index.html' }),
+
+			// Hash-mode CSP for prerendered pages: SvelteKit injects a SHA-256
+			// script-src hash for its inline bootstrap. HTTP responses still
+			// emit a looser script-src (with 'unsafe-inline') as a compatibility
+			// envelope; the meta policy is the effective script restriction.
+			// style-src keeps 'unsafe-inline' for inline style attributes and
+			// runtime chart styles. Aligned with backend/app/security.py except
+			// script-src (docs/internals/08-security-production.md).
+			csp: {
+				mode: 'hash',
+				directives: {
+					'default-src': ['self'],
+					'base-uri': ['self'],
+					'object-src': ['none'],
+					'frame-ancestors': ['none'],
+					'form-action': ['self'],
+					'frame-src': ['self'],
+					'connect-src': ['self'],
+					'font-src': ['self'],
+					'img-src': ['self', 'https:'],
+					'script-src': ['self'],
+					'style-src': ['self', 'unsafe-inline']
+				}
+			}
 		})
 	]
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
 					'frame-src': ['self'],
 					'connect-src': ['self'],
 					'font-src': ['self'],
-					'img-src': ['self', 'https:'],
+					'img-src': ['self', 'https:', 'http:'],
 					'script-src': ['self'],
 					'style-src': ['self', 'unsafe-inline']
 				}


### PR DESCRIPTION
## Summary
- Ship one HTTP security-header baseline (CSP, XCTO, XFO, Referrer-Policy, HSTS, Permissions-Policy) on both Cloudflare Pages (`frontend/static/_headers`) and the self-hosted FastAPI app (`SecurityHeadersMiddleware` + Exception handler for unhandled 500s).
- Enable SvelteKit hash-mode CSP so prerendered pages get a SHA-256 script-src hash; `npm run build` verifies hashes against inline scripts.
- Keep global anti-framing intact by rendering collage-preview variants inline instead of iframes; document HSTS/TLS expectations for self-hosted operators.

## Test plan
- [x] `backend/.venv/bin/pytest tests/test_security.py -q`
- [x] `make verify` (backend/worker lint+mypy+pytest, frontend lint/check/build)
- [x] `curl` GET against a self-hosted API with SPA mount: all six headers on `/api/v1/health`, `/`, `/app`, `/collage-preview`, and 404s
- [x] Collage-preview hub has no iframes; tiles mount near viewport; anti-framing headers intact
- [x] Self-hosted runner Idle/online; backend, frontend, simulation, and DCO checks green
- [x] MinIO presigned image over `http://127.0.0.1:9100` loads under the built CSP meta (`img-src 'self' https: http:`)