### PR TITLE
Harden setup and deployment: Python 3.11 guard, ROCm profile, CI through the Makefile

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Appends the DCO sign-off CONTRIBUTING.md requires, unless one is already
+# there. Enable it in your clone with `make dco-hook`.
+NAME=$(git config user.name)
+EMAIL=$(git config user.email)
+if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
+	echo "prepare-commit-msg: set git config user.name and user.email for the DCO sign-off" >&2
+	exit 1
+fi
+grep -qs "^Signed-off-by: " "$1" || printf "\nSigned-off-by: %s <%s>\n" "$NAME" "$EMAIL" >> "$1"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -48,6 +48,6 @@ jobs:
       - uses: actions/checkout@v7
       - run: python3.11 -m venv .venv
       - run: .venv/bin/pip install -e ".[dev]"
-      - run: .venv/bin/ruff check . ../scripts
-      - run: .venv/bin/mypy
-      - run: .venv/bin/pytest
+      # The Makefile target is the single definition of what the job checks.
+      - run: make verify-backend
+        working-directory: .

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+# The deployment artifacts operators actually run: every compose file and
+# profile is validated, then the shipped self-hosted stack is started with the
+# simulated worker, so no GPU is needed (issue #13 keeps one workflow per area).
+name: deploy
+
+on:
+  pull_request:
+    paths:
+      - "deploy/**"
+      - "scripts/compose-smoke.sh"
+      - ".github/workflows/deploy.yml"
+  push:
+    branches: [main]
+    paths:
+      - "deploy/**"
+      - "scripts/compose-smoke.sh"
+      - ".github/workflows/deploy.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    # Self-hosted: docs/self-hosted-runner.md (needs a working docker daemon).
+    runs-on: [self-hosted, Linux, X64, potocolom]
+    steps:
+      - uses: actions/checkout@v7
+      - run: make verify-compose
+      # Builds the api and worker-sim images and drives a real generation
+      # through them; the script cleans up its containers and volumes.
+      - run: scripts/compose-smoke.sh
+        timeout-minutes: 20

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -25,6 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: npm ci
-      - run: npm run lint
-      - run: npm run check
-      - run: npm run build
+      # The Makefile target is the single definition of what the job checks.
+      - run: make verify-frontend
+        working-directory: .

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -1,0 +1,35 @@
+# The contributor onboarding path. Nothing else in CI runs `make setup`, so
+# without this a broken setup only shows up on someone else's machine (issue
+# #13 keeps one workflow per area).
+name: toolchain
+
+on:
+  pull_request:
+    paths:
+      - "Makefile"
+      - "**/pyproject.toml"
+      - "frontend/package.json"
+      - "frontend/.npmrc"
+      - ".github/workflows/toolchain.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Makefile"
+      - "**/pyproject.toml"
+      - "frontend/package.json"
+      - "frontend/.npmrc"
+      - ".github/workflows/toolchain.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  toolchain:
+    # Self-hosted: docs/self-hosted-runner.md
+    runs-on: [self-hosted, Linux, X64, potocolom]
+    steps:
+      - uses: actions/checkout@v7
+      # Fails if a too-old toolchain would be accepted instead of refused.
+      - run: make verify-guards
+      # The documented onboarding path, run as a contributor would run it.
+      - run: make setup

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -26,6 +26,6 @@ jobs:
       - uses: actions/checkout@v7
       - run: python3.11 -m venv .venv
       - run: .venv/bin/pip install -e ".[dev]"
-      - run: .venv/bin/ruff check .
-      - run: .venv/bin/mypy
-      - run: .venv/bin/pytest
+      # The Makefile target is the single definition of what the job checks.
+      - run: make verify-worker
+        working-directory: .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,21 +12,9 @@ Signed-off-by: Your Name <you@example.com>
 
 `git commit -s` adds it for you. The sign-off asserts the [Developer Certificate of Origin](https://developercertificate.org/): you wrote the change or otherwise have the right to submit it under the project license.
 
-To sign off automatically in your clone, add a `prepare-commit-msg` hook:
+To sign off automatically in your clone, run `make dco-hook` once. It points `core.hooksPath` at the versioned [`.githooks/`](.githooks/) directory, whose `prepare-commit-msg` appends the trailer from your `git config user.name` and `user.email` when a message does not already have one. Plain `git commit` is then enough. Undo it with `git config --unset core.hooksPath`.
 
-```sh
-cat > .git/hooks/prepare-commit-msg <<'HOOK'
-#!/bin/sh
-NAME=$(git config user.name)
-EMAIL=$(git config user.email)
-if [ -z "$NAME" ] || [ -z "$EMAIL" ]; then
-	echo "prepare-commit-msg: set git config user.name and user.email for the DCO sign-off" >&2
-	exit 1
-fi
-grep -qs "^Signed-off-by: " "$1" || printf "\nSigned-off-by: %s <%s>\n" "$NAME" "$EMAIL" >> "$1"
-HOOK
-chmod +x .git/hooks/prepare-commit-msg
-```
+Hooks installed this way stay current when you pull, and they do not replace your author identity: set `user.name` and `user.email` correctly first, since the hook only adds the trailer.
 
 Forgot on an existing branch? `git rebase --signoff main` retrofits every commit on it.
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 .PHONY: setup setup-rocm setup-cuda check-python check-worker-venv \
 	deps deps-all deps-down verify verify-backend verify-worker \
-	verify-frontend verify-compose simulate \
+	verify-frontend verify-compose verify-guards simulate \
 	api worker-rocm worker-cuda worker-sim web web-landing \
 	dev-start dev-stop dev-restart dev-status \
 	stack-up stack-down stack-restart cleanup-failed generate \
@@ -87,6 +87,16 @@ verify-frontend:
 	cd frontend && npm run lint && npm run check && npm run build
 
 verify: verify-backend verify-worker verify-frontend ## everything CI runs, locally
+
+verify-guards: ## prove make setup refuses a toolchain without Python 3.11+
+	@tmp=$$(mktemp -d); trap 'rm -rf "$$tmp"' EXIT; \
+	for c in python3 python3.11 python3.12 python3.13; do \
+		printf '#!/bin/sh\nexit 1\n' > "$$tmp/$$c"; chmod +x "$$tmp/$$c"; done; \
+	if PATH="$$tmp:$$PATH" $(MAKE) --no-print-directory check-python >/dev/null 2>&1; then \
+		echo 'error: check-python accepted a PATH with no Python 3.11+ on it.' >&2; \
+		exit 1; \
+	fi; \
+	echo 'setup guards ok: no 3.11+ interpreter is refused, not silently used'
 
 verify-compose: ## validate every compose file and profile (no containers started)
 	cd deploy/compose && test -f .env || cp .env.example .env

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@
 #   make ci-runner-install && make ci-runner-service-install && make ci-runner-start
 # See docs/self-hosted-runner.md
 
-.PHONY: setup setup-rocm setup-cuda deps deps-down lint test build verify simulate \
+.PHONY: setup setup-rocm setup-cuda check-python check-worker-venv \
+	deps deps-all deps-down lint test build verify simulate \
 	api worker-rocm worker-cuda worker-sim web web-landing \
 	dev-start dev-stop dev-restart dev-status \
 	stack-up stack-down stack-restart cleanup-failed generate \
@@ -19,23 +20,55 @@
 	ci-runner-restart ci-runner-status \
 	site-build site-preview site-deploy worker-deploy
 
-setup: ## create virtualenvs and install all dependencies
-	cd backend && python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"
-	cd worker && python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"
+# Interpreter used only to create backend/.venv and worker/.venv. A system
+# python3 of 3.10 creates a venv that sends pip backtracking against
+# requires-python >=3.11, so take the first candidate that is new enough.
+# Project packages install into the venvs only, never system site-packages.
+# Override: make setup PYTHON=/path/to/python3.11
+VENV_OK = -c 'import sys; sys.exit(sys.version_info < (3, 11))'
+PYTHON ?= $(shell for c in python3 python3.13 python3.12 python3.11; do \
+	$$c $(VENV_OK) 2>/dev/null && { echo $$c; break; }; done)
+
+check-python: ## fail fast unless a Python 3.11+ interpreter is on PATH
+	@test -n "$(PYTHON)" || { \
+		echo 'error: Python 3.11 or newer is required for backend/ and worker/.' >&2; \
+		echo 'Install it alongside the system python3 if needed (for example' >&2; \
+		echo 'apt install python3.11 python3.11-venv), or set PYTHON=/path/to/python3.11.' >&2; \
+		exit 1; }
+	@$(PYTHON) $(VENV_OK) 2>/dev/null || { \
+		echo 'error: $(PYTHON) is missing or older than Python 3.11.' >&2; exit 1; }
+	@$(PYTHON) -c 'import sys; print("venvs use %s (%d.%d.%d)" \
+		% ((sys.executable,) + sys.version_info[:3]))'
+
+check-worker-venv:
+	@worker/.venv/bin/python $(VENV_OK) 2>/dev/null || { \
+		echo 'error: worker/.venv is missing or not Python 3.11+; run make setup.' >&2; \
+		exit 1; }
+
+setup: check-python ## create virtualenvs and install all dependencies
+	@for d in backend worker; do \
+		$$d/.venv/bin/python $(VENV_OK) 2>/dev/null \
+			|| $(PYTHON) -m venv --clear $$d/.venv; \
+	done
+	cd backend && .venv/bin/pip install -qU pip && .venv/bin/pip install -e ".[dev]"
+	cd worker && .venv/bin/pip install -qU pip && .venv/bin/pip install -e ".[dev]"
 	cd frontend && npm install
 
-setup-rocm: ## worker inference deps for AMD: ROCm torch wheels, then the extra
+setup-rocm: check-worker-venv ## worker inference deps for AMD: ROCm torch wheels, then the extra
 	cd worker && .venv/bin/pip install --upgrade pip
 	cd worker && .venv/bin/pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm6.3
 	cd worker && .venv/bin/pip install -e ".[inference]"
 
-setup-cuda: ## worker inference deps for NVIDIA: CUDA torch wheels (PyPI default), then the extra
+setup-cuda: check-worker-venv ## worker inference deps for NVIDIA: CUDA torch wheels (PyPI default), then the extra
 	cd worker && .venv/bin/pip install --upgrade pip
 	cd worker && .venv/bin/pip install torch torchvision
 	cd worker && .venv/bin/pip install -e ".[inference]"
 
-deps: ## start development dependencies (PostgreSQL, Redis, MinIO, Mailpit)
+deps: ## start development dependencies (PostgreSQL: all the native dev loop uses)
 	docker compose -f deploy/compose/dev.yml up -d
+
+deps-all: ## also start Redis, MinIO and Mailpit (cloud-sim profile; idle in local dev)
+	docker compose -f deploy/compose/dev.yml --profile cloud-sim up -d
 
 deps-down:
 	docker compose -f deploy/compose/dev.yml down

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 # See docs/self-hosted-runner.md
 
 .PHONY: setup setup-rocm setup-cuda check-python check-worker-venv \
-	deps deps-all deps-down verify verify-backend verify-worker \
+	deps deps-all deps-down dco-hook verify verify-backend verify-worker \
 	verify-frontend verify-compose verify-guards simulate \
 	api worker-rocm worker-cuda worker-sim web web-landing \
 	dev-start dev-stop dev-restart dev-status \
@@ -87,6 +87,11 @@ verify-frontend:
 	cd frontend && npm run lint && npm run check && npm run build
 
 verify: verify-backend verify-worker verify-frontend ## everything CI runs, locally
+
+dco-hook: ## sign off every commit in this clone automatically (CONTRIBUTING.md)
+	git config core.hooksPath .githooks
+	@echo 'hooks now run from .githooks; git commit adds Signed-off-by for you.'
+	@echo 'Undo with: git config --unset core.hooksPath'
 
 verify-guards: ## prove make setup refuses a toolchain without Python 3.11+
 	@tmp=$$(mktemp -d); trap 'rm -rf "$$tmp"' EXIT; \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@
 # See docs/self-hosted-runner.md
 
 .PHONY: setup setup-rocm setup-cuda check-python check-worker-venv \
-	deps deps-all deps-down lint test build verify simulate \
+	deps deps-all deps-down verify verify-backend verify-worker \
+	verify-frontend verify-compose simulate \
 	api worker-rocm worker-cuda worker-sim web web-landing \
 	dev-start dev-stop dev-restart dev-status \
 	stack-up stack-down stack-restart cleanup-failed generate \
@@ -73,20 +74,27 @@ deps-all: ## also start Redis, MinIO and Mailpit (cloud-sim profile; idle in loc
 deps-down:
 	docker compose -f deploy/compose/dev.yml down
 
-lint:
-	cd backend && .venv/bin/ruff check . ../scripts && .venv/bin/mypy
-	cd worker && .venv/bin/ruff check . && .venv/bin/mypy
-	cd frontend && npm run lint
+# One target per component, and the per-component CI workflows run these exact
+# targets, so local verify and CI cannot drift. Installing dependencies is the
+# caller's job: make setup locally, a fresh venv and npm ci in CI.
+verify-backend:
+	cd backend && .venv/bin/ruff check . ../scripts && .venv/bin/mypy && .venv/bin/pytest
 
-test:
-	cd backend && .venv/bin/pytest
-	cd worker && .venv/bin/pytest
-	cd frontend && npm run check
+verify-worker:
+	cd worker && .venv/bin/ruff check . && .venv/bin/mypy && .venv/bin/pytest
 
-build:
-	cd frontend && npm run build
+verify-frontend:
+	cd frontend && npm run lint && npm run check && npm run build
 
-verify: lint test build ## everything CI runs, locally
+verify: verify-backend verify-worker verify-frontend ## everything CI runs, locally
+
+verify-compose: ## validate every compose file and profile (no containers started)
+	cd deploy/compose && test -f .env || cp .env.example .env
+	cd deploy/compose && for p in gpu rocm smoke; do \
+		docker compose -f compose.yml --profile $$p config -q || exit 1; done
+	cd deploy/compose && docker compose -f dev.yml config -q \
+		&& docker compose -f dev.yml --profile cloud-sim config -q \
+		&& docker compose -f compose.smoke.yml config -q
 
 simulate: ## live connection-handling demo (docs/connection-handling.md)
 	backend/.venv/bin/python scripts/simulate.py

--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ Pre-alpha, under active development in the open. The architecture, protocols and
 - Models without releases: drop a model manifest and the interface adapts to its parameters.
 - Private by default: no public gallery, signed URLs, self-serve GDPR export and deletion.
 
+## Requirements
+
+To run potocolom on your own machine. Contributing to it instead needs a different set, under [Development](#development).
+
+| What | Needed | Notes |
+|---|---|---|
+| OS | Linux | What the project is developed, tested and released on. Docker Desktop hosts are untested. |
+| Docker | Engine with Compose v2 | Everything ships as containers; nothing is installed on the host. |
+| GPU | NVIDIA or AMD, or none | NVIDIA needs the [Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html); AMD needs the ROCm kernel driver, so `/dev/kfd` and `/dev/dri` exist. Without a GPU the stack still runs against the simulated worker. |
+| VRAM | 6 GB minimum, 12-16 GB comfortable | 6 GB covers SD-class models at 512 px, 12-16 GB covers SDXL-class at 1024 px. Each model manifest declares its own floor. |
+| RAM | 8 GB, 16 GB comfortable | |
+| Disk | 20 GB free, 50 GB+ comfortable | Model weights are 2-7 GB each, plus your generated images. |
+| Network | Port 8080 free, outbound HTTPS | The studio is served on 8080; weights download from Hugging Face on first use of each model. |
+
+No account, no API key and no telemetry endpoint are required. [docs/self-hosting.md](docs/self-hosting.md) has the full breakdown, including GPU passthrough and what persists in which volume.
+
 ## Self-hosting
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The repository is a monorepo: `frontend/` (SvelteKit SPA), `backend/` (FastAPI A
 
 - Docker with Compose v2, for the development dependencies.
 - Python 3.11 or newer, for the backend and the worker. `make setup` uses `python3` when it is new enough and otherwise falls back to `python3.13` / `python3.12` / `python3.11` on PATH, so the system default may stay at 3.10; project packages install into `backend/.venv` and `worker/.venv` only.
-- Node.js 24 or newer, for the frontend.
+- Node.js 24 or newer, for the frontend. `frontend/package.json` declares it and `engine-strict` is on, so npm refuses to install on an older Node rather than failing later in the build.
 - A GPU is optional until inference lands (issue #15). Both NVIDIA (CUDA) and AMD Radeon (ROCm) are supported worker targets; machines without a supported GPU run the worker on CPU. Machine specific setup, including AMD desktops, is documented in [Local development and testing](docs/local-development.md).
 
 ### Common tasks

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The repository is a monorepo: `frontend/` (SvelteKit SPA), `backend/` (FastAPI A
 ### Prerequisites
 
 - Docker with Compose v2, for the development dependencies.
-- Python 3.11 or newer, for the backend and the worker. `make setup` uses `python3` when it is new enough and otherwise falls back to a versioned `python3.11`/`3.12`/`3.13` on PATH, so the system default may stay at 3.10; project packages install into `backend/.venv` and `worker/.venv` only.
+- Python 3.11 or newer, for the backend and the worker. `make setup` uses `python3` when it is new enough and otherwise falls back to `python3.13` / `python3.12` / `python3.11` on PATH, so the system default may stay at 3.10; project packages install into `backend/.venv` and `worker/.venv` only.
 - Node.js 24 or newer, for the frontend.
 - A GPU is optional until inference lands (issue #15). Both NVIDIA (CUDA) and AMD Radeon (ROCm) are supported worker targets; machines without a supported GPU run the worker on CPU. Machine specific setup, including AMD desktops, is documented in [Local development and testing](docs/local-development.md).
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Pre-alpha, under active development in the open. The architecture, protocols and
 cp deploy/compose/.env.example deploy/compose/.env
 # edit POSTGRES_PASSWORD
 docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
+# AMD card: use --profile rocm instead of --profile gpu
 ```
 
 Open http://localhost:8080. Hardware requirements, NVIDIA and AMD GPU passthrough, first-run notes and what persists in which volume are covered in [docs/self-hosting.md](docs/self-hosting.md). The fleet WebSocket (`/api/v1/fleet`) is unauthenticated in this profile - treat the host as a trusted LAN until fleet auth is implemented. Validate the stack without a GPU: `scripts/compose-smoke.sh` (uses port 18080 by default; override with `COMPOSE_SMOKE_PORT`).
@@ -54,7 +55,7 @@ The repository is a monorepo: `frontend/` (SvelteKit SPA), `backend/` (FastAPI A
 ### Prerequisites
 
 - Docker with Compose v2, for the development dependencies.
-- Python 3.11 or newer, for the backend and the worker.
+- Python 3.11 or newer, for the backend and the worker. `make setup` uses `python3` when it is new enough and otherwise falls back to a versioned `python3.11`/`3.12`/`3.13` on PATH, so the system default may stay at 3.10; project packages install into `backend/.venv` and `worker/.venv` only.
 - Node.js 24 or newer, for the frontend.
 - A GPU is optional until inference lands (issue #15). Both NVIDIA (CUDA) and AMD Radeon (ROCm) are supported worker targets; machines without a supported GPU run the worker on CPU. Machine specific setup, including AMD desktops, is documented in [Local development and testing](docs/local-development.md).
 
@@ -62,7 +63,7 @@ The repository is a monorepo: `frontend/` (SvelteKit SPA), `backend/` (FastAPI A
 
 ```
 make setup      # create virtualenvs, install all dependencies
-make deps       # start PostgreSQL, Redis, MinIO and Mailpit
+make deps       # start PostgreSQL; make deps-all adds the cloud-sim containers
 make verify     # lint, test and build all components: exactly what CI runs
 make simulate   # live connection handling demo (API + workers + simulated browser)
 ```

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -56,6 +56,28 @@ services:
     depends_on:
       - api
 
+  # AMD worker (docker compose --profile rocm). Same volumes as the NVIDIA
+  # worker: run one profile or the other, not both.
+  worker-rocm:
+    profiles: ["rocm"]
+    build:
+      context: ../..
+      dockerfile: deploy/docker/Dockerfile.worker-rocm
+    environment:
+      DEVICE: rocm
+      API_URL: ws://api:8080/api/v1/fleet
+      MODELS_DIR: /models
+    volumes:
+      - models:/models
+      - hf-cache:/root/.cache/huggingface
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+    depends_on:
+      - api
+
   # Simulated worker for smoke tests (docker compose --profile smoke).
   worker-sim:
     profiles: ["smoke"]

--- a/deploy/compose/dev.yml
+++ b/deploy/compose/dev.yml
@@ -5,7 +5,9 @@ services:
   postgres:
     image: postgres:16
     ports:
-      - "5432:5432"
+      # Override when 5432 is taken by another PostgreSQL on the host, and set
+      # DATABASE_URL to the same port for the backend and the tests.
+      - "${DEV_POSTGRES_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: potocolom
       POSTGRES_PASSWORD: potocolom

--- a/deploy/compose/dev.yml
+++ b/deploy/compose/dev.yml
@@ -13,7 +13,11 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  # Redis, MinIO and Mailpit are cloud-profile substitutes: nothing in the
+  # native dev loop connects to them (storage_backend defaults to local, the
+  # job queue and relay are in-process). Opt in with --profile cloud-sim.
   redis:
+    profiles: ["cloud-sim"]
     image: redis:7
     ports:
       - "6379:6379"
@@ -21,6 +25,7 @@ services:
   # Host ports are offset from the defaults (9000, 9001, 1025, 8025) because
   # development machines often run other services on them.
   minio:
+    profiles: ["cloud-sim"]
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     ports:
@@ -33,6 +38,7 @@ services:
       - miniodata:/data
 
   mailpit:
+    profiles: ["cloud-sim"]
     # Pinned by digest: the image publishes no version tag label.
     image: axllent/mailpit@sha256:3bd7c2f2696deb35a4780d152b404dceec99cb041b942c0877b3b22384714f85
     ports:

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -286,7 +286,7 @@ Rejected alternatives: CUDA only (the primary development machine could then nev
 
 ## Development loop: dependencies in containers, applications native
 
-PostgreSQL, Redis, MinIO and Mailpit run from a dev compose file; the API server, frontend dev server and worker run natively with hot reload and debugger access. The containerized applications are still exercised by the cloud simulation, CI image builds and pre-release runs of the shipped compose file.
+PostgreSQL, Redis, MinIO and Mailpit run from a dev compose file; the API server, frontend dev server and worker run natively with hot reload and debugger access. Only PostgreSQL starts by default, since the native loop keeps its queue and relay in process and stores assets locally; the other three are cloud-profile substitutes behind `--profile cloud-sim`. The containerized applications are still exercised by the cloud simulation, CI image builds and pre-release runs of the shipped compose file.
 
 Rejected alternatives: everything in containers (closest to what ships, but slower iteration and clumsier debugging every single day); everything native (host setups drift and version differences surface as mystery bugs).
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -42,7 +42,7 @@ The NVIDIA variant (`:v0.x-cuda`) uses the `deploy.resources.reservations.device
 Dependencies run in containers; the three applications run natively for instant reload and debugger access:
 
 ```
-deploy/compose/dev.yml        # postgres, redis, minio, mailpit; nothing else
+deploy/compose/dev.yml        # postgres; redis, minio and mailpit behind --profile cloud-sim
 backend:  uvicorn app:app --reload          # against the dev containers
 frontend: npm run dev                        # Vite dev server, proxies /api to backend
 worker:   python -m worker --device rocm     # dials ws://localhost:8000/api/v1/fleet
@@ -75,11 +75,14 @@ The containerized applications are still exercised constantly: by the cloud simu
 ### Running each component
 
 ```
-# dependencies (PostgreSQL, Redis, MinIO, Mailpit)
+# dependencies: PostgreSQL is the only one the native loop uses. Redis, MinIO
+# and Mailpit are cloud-profile substitutes; add --profile cloud-sim for them.
 docker compose -f deploy/compose/dev.yml up -d
 
+# Prefer `make setup` (picks a 3.11+ interpreter, installs into .venv only).
+# Manual equivalent - the interpreter must be 3.11+, not a system python3 of 3.10:
 # backend, from backend/
-python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"
+python3.11 -m venv .venv && .venv/bin/pip install -U pip && .venv/bin/pip install -e ".[dev]"
 .venv/bin/uvicorn app.main:app --reload          # http://localhost:8000/api/v1/health
 .venv/bin/ruff check . && .venv/bin/pytest       # lint and tests
 
@@ -89,7 +92,7 @@ npm run dev                                      # http://localhost:5173
 npm run lint && npm run check                    # format check and type check
 
 # worker, from worker/
-python3 -m venv .venv && .venv/bin/pip install -e ".[dev]"
+python3.11 -m venv .venv && .venv/bin/pip install -U pip && .venv/bin/pip install -e ".[dev]"
 .venv/bin/python -m worker                       # dials the API and retries until one
                                                  # is running; Ctrl+C to stop
 .venv/bin/ruff check . && .venv/bin/pytest

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -161,10 +161,11 @@ GitHub Actions runs lint and tests on every pull request (issue #13). By default
 
 Per component, no GPU:
 
-1. Lint and unit tests per component (frontend, backend, worker), on every pull request.
-2. Worker integration test with `DEVICE=cpu` and the tiny model: manifest loading, dispatch, frame streaming, safety checker, end to end in minutes.
-3. Backend integration tests against postgres and redis service containers, including the Lua scripts and the leader election.
-4. On main: build all images (cuda and rocm worker variants), push to GHCR, then run the cloud-sim compose against the built images as a smoke test.
+1. Lint and unit tests per component (frontend, backend, worker), on every pull request. Each job runs the matching `make verify-<component>` target, so what CI checks and what `make verify` checks are the same lines.
+2. On changes under `deploy/`: `make verify-compose` validates every compose file and profile, then `scripts/compose-smoke.sh` builds the shipped stack and drives one generation through it with the simulated worker, no GPU needed.
+3. Worker integration test with `DEVICE=cpu` and the tiny model: manifest loading, dispatch, frame streaming, safety checker, end to end in minutes.
+4. Backend integration tests against postgres and redis service containers, including the Lua scripts and the leader election.
+5. On main: build all images (cuda and rocm worker variants), push to GHCR, then run the cloud-sim compose against the built images as a smoke test.
 
 ```mermaid
 flowchart LR

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -48,6 +48,8 @@ frontend: npm run dev                        # Vite dev server, proxies /api to 
 worker:   python -m worker --device rocm     # dials ws://localhost:8000/api/v1/fleet
 ```
 
+Default native loop (what `make deps` starts). Redis, MinIO and Mailpit only appear when you add `--profile cloud-sim` / `make deps-all`; see the cloud simulation section below.
+
 ```mermaid
 flowchart LR
     subgraph NATIVE["Native processes, hot reload and debugger"]
@@ -55,19 +57,13 @@ flowchart LR
         BE["FastAPI<br>uvicorn --reload"]
         WK["Worker<br>--device rocm"]
     end
-    subgraph DEPS["Containers, deploy/compose/dev.yml"]
+    subgraph DEPS["Containers, make deps"]
         P[("PostgreSQL")]
-        R[("Redis")]
-        M[("MinIO")]
-        MP["Mailpit"]
     end
     B["Browser"] --> FE
     FE -->|"proxies /api"| BE
     WK -->|"dials the fleet endpoint"| BE
     BE --> P
-    BE --> R
-    BE --> M
-    BE -->|"SMTP"| MP
 ```
 
 The containerized applications are still exercised constantly: by the cloud simulation below, by CI image builds, and by running the shipped compose file before every release.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -73,6 +73,8 @@ The containerized applications are still exercised constantly: by the cloud simu
 ```
 # dependencies: PostgreSQL is the only one the native loop uses. Redis, MinIO
 # and Mailpit are cloud-profile substitutes; add --profile cloud-sim for them.
+# Host 5432 already taken? DEV_POSTGRES_PORT=5433 docker compose ... up -d, and
+# point DATABASE_URL at the same port for the backend and the tests.
 docker compose -f deploy/compose/dev.yml up -d
 
 # Prefer `make setup` (picks a 3.11+ interpreter, installs into .venv only).
@@ -162,10 +164,11 @@ GitHub Actions runs lint and tests on every pull request (issue #13). By default
 Per component, no GPU:
 
 1. Lint and unit tests per component (frontend, backend, worker), on every pull request. Each job runs the matching `make verify-<component>` target, so what CI checks and what `make verify` checks are the same lines.
-2. On changes under `deploy/`: `make verify-compose` validates every compose file and profile, then `scripts/compose-smoke.sh` builds the shipped stack and drives one generation through it with the simulated worker, no GPU needed.
-3. Worker integration test with `DEVICE=cpu` and the tiny model: manifest loading, dispatch, frame streaming, safety checker, end to end in minutes.
-4. Backend integration tests against postgres and redis service containers, including the Lua scripts and the leader election.
-5. On main: build all images (cuda and rocm worker variants), push to GHCR, then run the cloud-sim compose against the built images as a smoke test.
+2. On changes to the `Makefile` or a dependency manifest: `make verify-guards` proves the setup guards still refuse a toolchain without Python 3.11+, then `make setup` runs the onboarding path end to end, so a broken `make setup` fails here instead of on a new contributor's machine.
+3. On changes under `deploy/`: `make verify-compose` validates every compose file and profile, then `scripts/compose-smoke.sh` builds the shipped stack and drives one generation through it with the simulated worker, no GPU needed.
+4. Worker integration test with `DEVICE=cpu` and the tiny model: manifest loading, dispatch, frame streaming, safety checker, end to end in minutes.
+5. Backend integration tests against postgres and redis service containers, including the Lua scripts and the leader election.
+6. On main: build all images (cuda and rocm worker variants), push to GHCR, then run the cloud-sim compose against the built images as a smoke test.
 
 ```mermaid
 flowchart LR

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -31,21 +31,19 @@ NVIDIA (default images):
 
 AMD (ROCm):
 
-1. In `deploy/compose/compose.yml`, point the worker's `dockerfile` at
-   `deploy/docker/Dockerfile.worker-rocm`, set `DEVICE: rocm`, and replace the
-   NVIDIA device reservation with:
-
-   ```yaml
-   devices:
-     - /dev/kfd
-     - /dev/dri
-   group_add:
-     - video
-   ```
-
-2. RDNA3 consumer cards (gfx1102 class, RX 7600 XT and similar) are supported
+1. Install the ROCm kernel driver on the host so `/dev/kfd` and `/dev/dri`
+   exist, and add your user to the `video` (and on some distributions
+   `render`) group.
+2. `docker compose -f deploy/compose/compose.yml --profile rocm up -d --build`
+   builds `deploy/docker/Dockerfile.worker-rocm` and passes the devices
+   through; no editing of the compose file is needed.
+3. RDNA3 consumer cards (gfx1102 class, RX 7600 XT and similar) are supported
    natively by the torch ROCm 6.3+ wheels the image installs; do not set
    `HSA_OVERRIDE_GFX_VERSION`.
+4. Verify: `docker compose -f deploy/compose/compose.yml --profile rocm exec worker-rocm python -c "import torch; print(torch.cuda.is_available())"`.
+
+The `gpu` profile is the NVIDIA worker and the `rocm` profile is the AMD one;
+run one or the other, never both, since they share the model volumes.
 
 ## First run
 
@@ -107,6 +105,7 @@ references. `hf-cache` and `models` are reproducible.
 ```bash
 git pull
 docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
+# AMD: --profile rocm, the same profile you first started with
 ```
 
 Database migrations run automatically at API startup (docs/decisions.md,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,9 @@
 	"private": true,
 	"version": "0.0.1",
 	"type": "module",
+	"engines": {
+		"node": ">=24"
+	},
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build && node scripts/verify-csp.mjs",


### PR DESCRIPTION
make setup picks the first interpreter that is 3.11 or newer, falling back from python3 to a versioned binary, and fails with one clear message when none exists. It recreates a venv only when that venv is missing or too old, so re-running no longer discards two working virtualenvs.

Self-hosting on AMD no longer requires hand-editing the compose file: a worker-rocm service behind --profile rocm builds Dockerfile.worker-rocm and passes /dev/kfd and /dev/dri through, mirroring the NVIDIA steps.

Redis, MinIO and Mailpit move behind --profile cloud-sim in the dev compose file. Nothing in the native dev loop connects to them, since the queue and relay are in process and storage_backend defaults to local, so make deps starts PostgreSQL alone and make deps-all starts the full set.

The per-component workflows re-implemented what the Makefile already ran, so nothing stopped the two from drifting apart even though CONTRIBUTING promises they match. Each job now runs make verify-backend, verify-worker or verify-frontend, and those targets hold the only copy of the commands. Installing dependencies stays with the caller, since CI wants a fresh venv and npm ci while a contributor wants make setup.

The shipped compose stack had no automated coverage at all: scripts/compose-smoke.sh is the documented way to validate it and no workflow ran it. A deploy workflow, filtered to changes under deploy/, now validates every compose file and profile through make verify-compose and then runs the smoke script, which needs no GPU.

The toolchain versions are guarded rather than assumed. frontend/.npmrc already set engine-strict, so every dependency's engine range was enforced while the project's own was not; engines.node >=24 makes npm refuse an older Node with a clear message. make verify-guards proves the Python guard still refuses a toolchain with no 3.11+ interpreter, using stub interpreters on PATH so no old interpreter has to be installed. A toolchain workflow runs that guard and then make setup itself, which is the one path CI never took and the reason a 3.10 host reached a contributor before it reached CI.

Smaller items: a requirements table in the README for people who want to run potocolom rather than work on it, DEV_POSTGRES_PORT for hosts that already run PostgreSQL, and the DCO prepare-commit-msg hook moved into a versioned .githooks directory installed by make dco-hook.

Verified locally: make verify (backend 72 passed, worker 61 passed, frontend build and CSP check), make verify-compose, make verify-guards, and scripts/compose-smoke.sh end to end.