### PR TITLE
Record usage events and report anonymous daily telemetry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ WORKER ?= rocm
 
 api: ## API server on :8000; assets under ./data (make deps first)
 	cd backend && STORAGE_LOCAL_PATH=$(CURDIR)/data \
-		BENCHMARK_API=1 .venv/bin/uvicorn app.main:app --port 8000
+		BENCHMARK_API=1 TELEMETRY=false .venv/bin/uvicorn app.main:app --port 8000
 
 worker-rocm: ## inference worker on the AMD GPU (make setup-rocm once)
 	cd worker && MODELS_DIR=models DEVICE=rocm \

--- a/backend/app/gpu_samples.py
+++ b/backend/app/gpu_samples.py
@@ -12,12 +12,13 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db
-from app.tables import GpuSample, GpuSampleRollup
+from app.tables import GpuSample, GpuSampleRollup, WorkerIdentity
 
 logger = logging.getLogger("potocolom.gpu_samples")
 
 RAW_RETENTION = timedelta(hours=48)
 ROLLUP_RETENTION = timedelta(days=30)
+WORKER_RETENTION = timedelta(days=30)
 ROLLUP_BUCKET = timedelta(minutes=5)
 MAINTAIN_INTERVAL = 300.0  # seconds
 
@@ -61,7 +62,64 @@ def _loaded_models(control: dict) -> list[str] | None:
     return [str(model) for model in models]
 
 
-async def record_heartbeat(worker_id: str, control: dict) -> None:
+def _worker_upsert(
+    worker_id: str,
+    device: str | None,
+    memory_mode: str | None,
+    last_seen: datetime,
+):
+    statement = insert(WorkerIdentity).values(
+        worker_id=worker_id,
+        device=device,
+        memory_mode=memory_mode,
+        last_seen=last_seen,
+    )
+    return statement.on_conflict_do_update(
+        index_elements=[WorkerIdentity.worker_id],
+        set_={
+            "device": func.coalesce(statement.excluded.device, WorkerIdentity.device),
+            "memory_mode": func.coalesce(
+                statement.excluded.memory_mode, WorkerIdentity.memory_mode
+            ),
+            "last_seen": func.greatest(
+                statement.excluded.last_seen, WorkerIdentity.last_seen
+            ),
+        },
+    )
+
+
+async def record_worker_identity(
+    worker_id: str,
+    device: str | None,
+    memory_mode: str | None,
+) -> None:
+    """Upsert static worker facts without delaying the fleet registration path."""
+    if db.session_factory is None:
+        return
+    try:
+        async with db.session_factory() as session:
+            await session.execute(
+                _worker_upsert(worker_id, device, memory_mode, _utcnow())
+            )
+            await session.commit()
+    except Exception as error:
+        logger.warning("worker identity persistence skipped: %s", error)
+
+
+def schedule_worker_identity(
+    worker_id: str,
+    device: str | None,
+    memory_mode: str | None,
+) -> None:
+    asyncio.create_task(record_worker_identity(worker_id, device, memory_mode))
+
+
+async def record_heartbeat(
+    worker_id: str,
+    control: dict,
+    device: str | None = None,
+    memory_mode: str | None = None,
+) -> None:
     """Insert one row from a worker heartbeat; no-op when the database is down."""
     if db.session_factory is None:
         return
@@ -77,16 +135,27 @@ async def record_heartbeat(worker_id: str, control: dict) -> None:
         power_w=_float_or_none(gpu.get("power_w")),
         loaded_models=_loaded_models(control),
     )
-    async with db.session_factory() as session:
-        session.add(row)
-        await session.commit()
+    try:
+        async with db.session_factory() as session:
+            session.add(row)
+            await session.execute(
+                _worker_upsert(worker_id, device, memory_mode, sampled_at)
+            )
+            await session.commit()
+    except Exception as error:
+        logger.warning("GPU heartbeat persistence skipped: %s", error)
 
 
-def schedule_heartbeat_sample(worker_id: str, control: dict) -> None:
+def schedule_heartbeat_sample(
+    worker_id: str,
+    control: dict,
+    device: str | None = None,
+    memory_mode: str | None = None,
+) -> None:
     """Fire-and-forget persistence so the fleet socket loop stays responsive."""
     if control.get("type") != "heartbeat":
         return
-    asyncio.create_task(record_heartbeat(worker_id, control))
+    asyncio.create_task(record_heartbeat(worker_id, control, device, memory_mode))
 
 
 RollupMode = Literal["auto", "raw", "5m"]
@@ -190,11 +259,15 @@ async def maintain_once() -> None:
     now = _utcnow()
     raw_cutoff = now - RAW_RETENTION
     rollup_cutoff = now - ROLLUP_RETENTION
+    worker_cutoff = now - WORKER_RETENTION
     async with db.session_factory() as session:
         await _rebuild_rollups(session, raw_cutoff, now)
         await session.execute(delete(GpuSample).where(GpuSample.sampled_at < raw_cutoff))
         await session.execute(
             delete(GpuSampleRollup).where(GpuSampleRollup.bucket_start < rollup_cutoff)
+        )
+        await session.execute(
+            delete(WorkerIdentity).where(WorkerIdentity.last_seen < worker_cutoff)
         )
         await session.commit()
 

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -574,6 +574,8 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         url = await get_storage().url(entry.storage_key)
         publish(job_id, {"state": "succeeded", "url": url})
         logger.info("job %s succeeded, gpu_ms=%s", job_id, control.get("gpu_ms"))
+        from app import usage_events
+        usage_events.schedule_job(job_id, control)
     else:
         reason = str(control.get("reason", "worker reported failure"))
         await mark_failed(job_id, reason)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -21,17 +22,31 @@ from app.registry import router as registry_router
 from app.security import SecurityHeadersMiddleware, unhandled_exception_response
 from app.settings import get_settings
 from app.studio import router as studio_router
+from app.telemetry import DESTINATION, telemetry_loop
+from app.telemetry import router as telemetry_router
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    setup_logging(get_settings().log_format)
+    settings = get_settings()
+    setup_logging(settings.log_format)
+    if settings.telemetry:
+        logging.getLogger("potocolom.telemetry").info(
+            "anonymous daily telemetry destination=%s payload=aggregate usage counts and "
+            "worker device/memory mode; set TELEMETRY=false to disable",
+            DESTINATION,
+        )
+    else:
+        logging.getLogger("potocolom.telemetry").info(
+            "anonymous daily telemetry disabled by TELEMETRY=false"
+        )
     if await db.connect():
         await jobs.recover()
     tasks = [
         asyncio.create_task(reap_dead_workers()),
         asyncio.create_task(jobs.dispatch_loop()),
         asyncio.create_task(maintain_loop()),
+        asyncio.create_task(telemetry_loop()),
     ]
     yield
     for task in tasks:
@@ -64,6 +79,7 @@ app.include_router(jobs_router)
 app.include_router(files_router)
 app.include_router(studio_router)
 app.include_router(metrics_router)
+app.include_router(telemetry_router)
 
 
 @app.get("/api/v1/health")

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -21,11 +21,12 @@ from fastapi import APIRouter, HTTPException, WebSocket
 from starlette.websockets import WebSocketDisconnect, WebSocketState
 
 from app.manifests import Manifest, parse_manifests, validate_params
+from app import db
 
 logger = logging.getLogger("potocolom.realtime")
 
 # Wire constants; keep in sync with worker/worker/client.py.
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
 MIN_SUPPORTED_VERSION = PROTOCOL_VERSION - 1
 
 CANVAS_FRAME = 0x01
@@ -93,6 +94,8 @@ class Worker:
     ws: WebSocket
     manifests: list[Manifest]
     realtime_slots: int
+    device: str | None = None
+    memory_mode: str | None = None
     slots_in_use: int = 0
     jobs_in_flight: int = 0  # queued jobs; capped at JOB_DISPATCH_DEPTH in jobs.py
     last_seen: float = field(default_factory=time.monotonic)
@@ -112,6 +115,7 @@ class Session:
     model_id: str
     browser: WebSocket
     params: dict = field(default_factory=dict)
+    user_id: uuid.UUID | None = None
     worker: Worker | None = None
     ready: asyncio.Event = field(default_factory=asyncio.Event)
 
@@ -124,6 +128,7 @@ class Session:
 workers: dict[str, Worker] = {}
 sessions: dict[uuid.UUID, Session] = {}
 gpu_requests: dict[str, asyncio.Future] = {}
+closing_sessions: dict[uuid.UUID, tuple[uuid.UUID, str, Worker]] = {}
 
 
 def pick_any_worker() -> Worker | None:
@@ -263,9 +268,13 @@ async def fleet(ws: WebSocket) -> None:
         except ValueError as error:
             raise ProtocolError(str(error)) from error
         worker = Worker(id=hello["worker_id"], ws=ws, manifests=worker_manifests,
-                        realtime_slots=hello["realtime_slots"])
+                        realtime_slots=hello["realtime_slots"],
+                        device=hello.get("device"),
+                        memory_mode=hello.get("memory_mode"))
         if not (isinstance(version, int) and isinstance(worker.id, str)
-                and isinstance(worker.realtime_slots, int)):
+                and isinstance(worker.realtime_slots, int)
+                and (worker.device is None or isinstance(worker.device, str))
+                and (worker.memory_mode is None or isinstance(worker.memory_mode, str))):
             raise ProtocolError("hello fields have wrong types")
     except (ProtocolError, KeyError):
         await ws.close(code=CLOSE_PROTOCOL_VIOLATION)
@@ -282,6 +291,7 @@ async def fleet(ws: WebSocket) -> None:
                 worker.id, worker.models, worker.realtime_slots)
     await ws.send_json({"type": "registered"})
     from app import gpu_samples, registry  # late import; registry reads this module's state
+    gpu_samples.schedule_worker_identity(worker.id, worker.device, worker.memory_mode)
     await registry.persist_manifests(worker.manifests)
     try:
         while True:
@@ -304,11 +314,28 @@ async def fleet(ws: WebSocket) -> None:
                     elif control["type"] in ("job_progress", "job_done", "job_failed"):
                         from app import jobs  # late import; jobs reads this module's state
                         await jobs.on_worker_message(worker, control)
+                    elif control["type"] == "session_closed":
+                        session_id = uuid.UUID(control["session_id"])
+                        owner = closing_sessions.pop(session_id, None)
+                        if owner is not None:
+                            from app import usage_events
+                            usage_events.schedule_realtime(owner[0], owner[1], control)
                     elif control["type"] in ("gpu_status", "model_loaded",
                                              "model_unloaded", "gpu_error"):
                         resolve_gpu_request(control)
                     elif control["type"] == "heartbeat":
-                        gpu_samples.schedule_heartbeat_sample(worker.id, control)
+                        gpu = control.get("gpu")
+                        if worker.device is None and isinstance(gpu, dict):
+                            device = gpu.get("device")
+                            if isinstance(device, str):
+                                worker.device = device
+                        if worker.memory_mode is None:
+                            memory_mode = control.get("memory_mode")
+                            if isinstance(memory_mode, str):
+                                worker.memory_mode = memory_mode
+                        gpu_samples.schedule_heartbeat_sample(
+                            worker.id, control, worker.device, worker.memory_mode
+                        )
                     # Heartbeats refresh last_seen only; slot accounting has
                     # one writer (assign/release), so self-reported counts
                     # are deliberately not written back.
@@ -319,6 +346,9 @@ async def fleet(ws: WebSocket) -> None:
     finally:
         if workers.get(worker.id) is worker:
             del workers[worker.id]
+        for session_id, owner in list(closing_sessions.items()):
+            if owner[2] is worker:
+                closing_sessions.pop(session_id, None)
         from app import jobs
         jobs.on_worker_lost(worker)
         orphaned = [s for s in sessions.values() if s.worker is worker]
@@ -357,7 +387,11 @@ async def realtime(ws: WebSocket) -> None:
     if worker is None:
         await refuse(ws, CLOSE_NO_CAPACITY, "no worker capacity")
         return
-    session = Session(id=uuid.uuid4(), model_id=model_id, browser=ws, params=params)
+    session = Session(
+        id=uuid.uuid4(), model_id=model_id, browser=ws, params=params,
+        # WebSocket identity is not derived from current_user until upgrade auth
+        # gains a session cookie or one-time ticket.
+        user_id=db.local_user_id)
     sessions[session.id] = session
     try:
         if not await assign(session, worker):
@@ -385,4 +419,12 @@ async def realtime(ws: WebSocket) -> None:
                 break
     finally:
         sessions.pop(session.id, None)
+        worker = session.worker
+        if (
+            worker is not None
+            and session.user_id is not None
+            and workers.get(worker.id) is worker
+        ):
+            closing_sessions[session.id] = (
+                session.user_id, session.model_id, worker)
         await release(session)

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -32,6 +32,7 @@ class Settings(BaseSettings):
     storage_s3_secret_key: str = ""
 
     benchmark_api: bool = False  # expose /api/v1/benchmark/* for scripts/benchmark.py
+    telemetry: bool = True
 
     # When set, the API serves the built SPA from this directory (self-hosted
     # profile; docs/blueprint.md).

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -5,9 +5,11 @@ rebuilt from these rows (docs/blueprint.md, Redis layout).
 """
 
 import uuid
-from datetime import datetime
+from datetime import date, datetime
 
-from sqlalchemy import BigInteger, DateTime, Float, ForeignKey, Integer, SmallInteger, Text, text
+from sqlalchemy import (
+    BigInteger, Date, DateTime, Float, ForeignKey, Integer, SmallInteger, Text, text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -143,3 +145,37 @@ class BenchmarkMeasurement(Base):
     job_id: Mapped[str | None] = mapped_column(Text)
     file: Mapped[str | None] = mapped_column(Text)
     error: Mapped[str | None] = mapped_column(Text)
+
+
+class UsageEvent(Base):
+    __tablename__ = "usage_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    kind: Mapped[str] = mapped_column(Text)
+    action: Mapped[str] = mapped_column(Text)
+    model_id: Mapped[str] = mapped_column(Text)
+    tier: Mapped[str | None] = mapped_column(Text)
+    category: Mapped[str] = mapped_column(Text)
+    category_score: Mapped[float | None] = mapped_column(Float)
+    gpu_ms: Mapped[int | None]
+    duration_ms: Mapped[int | None]
+    frames: Mapped[int | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class TelemetryState(Base):
+    __tablename__ = "telemetry_state"
+
+    id: Mapped[int] = mapped_column(SmallInteger, primary_key=True)
+    install_id: Mapped[uuid.UUID] = mapped_column(default=uuid.uuid4)
+    last_report_day: Mapped[date | None] = mapped_column(Date)
+
+
+class WorkerIdentity(Base):
+    __tablename__ = "workers"
+
+    worker_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    device: Mapped[str | None] = mapped_column(Text)
+    memory_mode: Mapped[str | None] = mapped_column(Text)
+    last_seen: Mapped[datetime]

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -1,0 +1,140 @@
+"""Anonymous self-hosted daily aggregate and its exact preview."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import date, datetime, time, timedelta, timezone
+from importlib.metadata import PackageNotFoundError, version
+from urllib.request import Request, urlopen
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import db
+from app.auth import current_user
+from app.settings import get_settings
+from app.tables import TelemetryState, UsageEvent, User, WorkerIdentity
+
+logger = logging.getLogger("potocolom.telemetry")
+router = APIRouter()
+DESTINATION = "https://telemetry.potocolom.com/v1/report"
+
+
+def _version() -> str:
+    try:
+        return version("potocolom-backend")
+    except PackageNotFoundError:
+        return "0.0.1"
+
+
+async def _state(session: AsyncSession) -> TelemetryState:
+    state = await session.get(TelemetryState, 1)
+    if state is None:
+        state = TelemetryState(id=1)
+        session.add(state)
+        await session.flush()
+    return state
+
+
+def _counts(values: list[str]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for value in values:
+        result[value] = result.get(value, 0) + 1
+    return result
+
+
+async def payload_for_day(session: AsyncSession, day: date) -> dict:
+    start = datetime.combine(day, time.min, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    events = (
+        await session.execute(
+            select(UsageEvent).where(
+                UsageEvent.created_at >= start,
+                UsageEvent.created_at < end,
+            )
+        )
+    ).scalars().all()
+    workers = (
+        await session.execute(
+            select(WorkerIdentity)
+            .where(WorkerIdentity.last_seen >= start)
+            .order_by(WorkerIdentity.worker_id)
+        )
+    ).scalars().all()
+    state = await _state(session)
+    await session.commit()
+    return {
+        "install_id": str(state.install_id),
+        "version": _version(),
+        "day": day.isoformat(),
+        "active_users": len({event.user_id for event in events}),
+        "events": _counts([event.kind for event in events]),
+        "by_action": _counts([event.action for event in events]),
+        "by_category": _counts([event.category for event in events]),
+        "by_tier": _counts([event.tier for event in events if event.tier is not None]),
+        "realtime_minutes": round(
+            sum((event.duration_ms or 0) for event in events if event.kind == "realtime")
+            / 60_000
+        ),
+        "workers": [
+            {"device": worker.device, "memory_mode": worker.memory_mode}
+            for worker in workers
+            if worker.device is not None and worker.memory_mode is not None
+        ],
+    }
+
+
+@router.get("/api/v1/telemetry/preview")
+async def telemetry_preview(
+    _user: User = Depends(current_user),
+    session: AsyncSession = Depends(db.get_session),
+) -> dict:
+    return await payload_for_day(session, datetime.now(timezone.utc).date() - timedelta(days=1))
+
+
+def _post(url: str, payload: dict) -> None:
+    request = Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urlopen(request, timeout=10) as response:
+        if not 200 <= response.status < 300:
+            raise RuntimeError(f"telemetry destination returned {response.status}")
+
+
+async def send_once() -> None:
+    settings = get_settings()
+    if not settings.telemetry or db.session_factory is None:
+        return
+    day = datetime.now(timezone.utc).date() - timedelta(days=1)
+    async with db.session_factory() as session:
+        state = await _state(session)
+        if state.last_report_day == day:
+            return
+        payload = await payload_for_day(session, day)
+        # Mark before the network call: failures are deliberately dropped, never queued.
+        state = await _state(session)
+        state.last_report_day = day
+        await session.commit()
+    logger.info(
+        "telemetry daily summary day=%s active_users=%s events=%s",
+        day, payload["active_users"], sum(payload["events"].values()),
+    )
+    try:
+        await asyncio.to_thread(_post, DESTINATION, payload)
+    except Exception as error:
+        logger.warning("telemetry send dropped: %s", error)
+
+
+async def telemetry_loop() -> None:
+    while True:
+        try:
+            await send_once()
+        except Exception:
+            logger.exception("telemetry aggregation failed")
+        await asyncio.sleep(3600)

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -10,7 +10,7 @@ from importlib.metadata import PackageNotFoundError, version
 from urllib.request import Request, urlopen
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db
@@ -39,24 +39,32 @@ async def _state(session: AsyncSession) -> TelemetryState:
     return state
 
 
-def _counts(values: list[str]) -> dict[str, int]:
-    result: dict[str, int] = {}
-    for value in values:
-        result[value] = result.get(value, 0) + 1
-    return result
+async def _counts_by(session: AsyncSession, column, start: datetime, end: datetime) -> dict[str, int]:
+    """One GROUP BY per dimension, so a busy day never lands in memory."""
+    rows = await session.execute(
+        select(column, func.count())
+        .where(UsageEvent.created_at >= start, UsageEvent.created_at < end,
+               column.is_not(None))
+        .group_by(column)
+    )
+    return {str(value): int(total) for value, total in rows.all()}
 
 
 async def payload_for_day(session: AsyncSession, day: date) -> dict:
     start = datetime.combine(day, time.min, tzinfo=timezone.utc)
     end = start + timedelta(days=1)
-    events = (
-        await session.execute(
-            select(UsageEvent).where(
-                UsageEvent.created_at >= start,
-                UsageEvent.created_at < end,
-            )
-        )
-    ).scalars().all()
+    in_day = (UsageEvent.created_at >= start, UsageEvent.created_at < end)
+    active_users = await session.scalar(
+        select(func.count(func.distinct(UsageEvent.user_id))).where(*in_day)
+    )
+    realtime_ms = await session.scalar(
+        select(func.coalesce(func.sum(UsageEvent.duration_ms), 0))
+        .where(*in_day, UsageEvent.kind == "realtime")
+    )
+    by_kind = await _counts_by(session, UsageEvent.kind, start, end)
+    by_action = await _counts_by(session, UsageEvent.action, start, end)
+    by_category = await _counts_by(session, UsageEvent.category, start, end)
+    by_tier = await _counts_by(session, UsageEvent.tier, start, end)
     workers = (
         await session.execute(
             select(WorkerIdentity)
@@ -70,15 +78,12 @@ async def payload_for_day(session: AsyncSession, day: date) -> dict:
         "install_id": str(state.install_id),
         "version": _version(),
         "day": day.isoformat(),
-        "active_users": len({event.user_id for event in events}),
-        "events": _counts([event.kind for event in events]),
-        "by_action": _counts([event.action for event in events]),
-        "by_category": _counts([event.category for event in events]),
-        "by_tier": _counts([event.tier for event in events if event.tier is not None]),
-        "realtime_minutes": round(
-            sum((event.duration_ms or 0) for event in events if event.kind == "realtime")
-            / 60_000
-        ),
+        "active_users": int(active_users or 0),
+        "events": by_kind,
+        "by_action": by_action,
+        "by_category": by_category,
+        "by_tier": by_tier,
+        "realtime_minutes": round(int(realtime_ms or 0) / 60_000),
         "workers": [
             {"device": worker.device, "memory_mode": worker.memory_mode}
             for worker in workers

--- a/backend/app/usage_events.py
+++ b/backend/app/usage_events.py
@@ -19,8 +19,7 @@ def _category(control: dict) -> tuple[str, float | None]:
     category = control.get("category")
     if category not in LABELS:
         category = "other"
-    score = control.get("category_score")
-    return category, float(score) if isinstance(score, (int, float)) else None
+    return category, _optional_float(control.get("category_score"))
 
 
 async def record_job(job_id: uuid.UUID, control: dict) -> None:
@@ -39,7 +38,6 @@ async def record_job(job_id: uuid.UUID, control: dict) -> None:
                 "edit"
             )
             category, score = _category(control)
-            duration = control.get("duration_ms")
             session.add(UsageEvent(
                 user_id=job.user_id,
                 kind="job",
@@ -50,7 +48,7 @@ async def record_job(job_id: uuid.UUID, control: dict) -> None:
                 category=category,
                 category_score=score,
                 gpu_ms=job.gpu_ms,
-                duration_ms=int(duration) if duration is not None else None,
+                duration_ms=_optional_int(control.get("duration_ms")),
                 frames=1,
             ))
             await session.commit()
@@ -83,8 +81,17 @@ async def record_realtime(
         logger.exception("usage event write failed for realtime session")
 
 
+def _numeric(value: Any) -> bool:
+    """bool is a subclass of int, and these values arrive from the worker."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 def _optional_int(value: Any) -> int | None:
-    return int(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+    return int(value) if _numeric(value) else None
+
+
+def _optional_float(value: Any) -> float | None:
+    return float(value) if _numeric(value) else None
 
 
 def schedule_job(job_id: uuid.UUID, control: dict) -> None:

--- a/backend/app/usage_events.py
+++ b/backend/app/usage_events.py
@@ -1,0 +1,95 @@
+"""Completion-side persistence for privacy-bounded product usage events."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from typing import Any
+
+from app import db
+from app.tables import Job, Model, UsageEvent
+
+logger = logging.getLogger("potocolom.usage_events")
+
+LABELS = ("art", "photo_edit", "design", "character", "nsfw", "other")
+
+
+def _category(control: dict) -> tuple[str, float | None]:
+    category = control.get("category")
+    if category not in LABELS:
+        category = "other"
+    score = control.get("category_score")
+    return category, float(score) if isinstance(score, (int, float)) else None
+
+
+async def record_job(job_id: uuid.UUID, control: dict) -> None:
+    if db.session_factory is None:
+        return
+    try:
+        async with db.session_factory() as session:
+            job = await session.get(Job, job_id)
+            if job is None:
+                return
+            model = await session.get(Model, job.model_id)
+            capabilities = set(model.capabilities) if model is not None else set()
+            action = (
+                "generate" if job.source_asset_id is None else
+                "enhance" if "upscale" in capabilities else
+                "edit"
+            )
+            category, score = _category(control)
+            duration = control.get("duration_ms")
+            session.add(UsageEvent(
+                user_id=job.user_id,
+                kind="job",
+                action=action,
+                model_id=job.model_id,
+                # Model tier routing is not shipped yet, so there is no honest value.
+                tier=None,
+                category=category,
+                category_score=score,
+                gpu_ms=job.gpu_ms,
+                duration_ms=int(duration) if duration is not None else None,
+                frames=1,
+            ))
+            await session.commit()
+    except Exception:
+        logger.exception("usage event write failed for job %s", job_id)
+
+
+async def record_realtime(
+    user_id: uuid.UUID, model_id: str, control: dict,
+) -> None:
+    if db.session_factory is None:
+        return
+    try:
+        category, score = _category(control)
+        async with db.session_factory() as session:
+            session.add(UsageEvent(
+                user_id=user_id,
+                kind="realtime",
+                action="draw",
+                model_id=model_id,
+                tier=None,
+                category=category,
+                category_score=score,
+                gpu_ms=_optional_int(control.get("gpu_ms")),
+                duration_ms=_optional_int(control.get("duration_ms")),
+                frames=_optional_int(control.get("frames")),
+            ))
+            await session.commit()
+    except Exception:
+        logger.exception("usage event write failed for realtime session")
+
+
+def _optional_int(value: Any) -> int | None:
+    return int(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else None
+
+
+def schedule_job(job_id: uuid.UUID, control: dict) -> None:
+    asyncio.create_task(record_job(job_id, dict(control)))
+
+
+def schedule_realtime(user_id: uuid.UUID, model_id: str, control: dict) -> None:
+    asyncio.create_task(record_realtime(user_id, model_id, dict(control)))

--- a/backend/migrations/versions/0007_usage_events.py
+++ b/backend/migrations/versions/0007_usage_events.py
@@ -1,0 +1,49 @@
+"""usage events and telemetry state
+
+Revision ID: 0007
+Revises: 0006
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "usage_events",
+        sa.Column("id", sa.Uuid(), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"),
+                  nullable=False),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("model_id", sa.Text(), nullable=False),
+        sa.Column("tier", sa.Text(), nullable=True),
+        sa.Column("category", sa.Text(), nullable=False),
+        sa.Column("category_score", sa.Float(), nullable=True),
+        sa.Column("gpu_ms", sa.Integer(), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column("frames", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True),
+                  server_default=sa.text("now()"), nullable=False),
+    )
+    # Serves daily telemetry range scans and aggregate grouping.
+    op.create_index("usage_events_created_at", "usage_events", ["created_at"])
+    op.create_table(
+        "telemetry_state",
+        sa.Column("id", sa.SmallInteger(), primary_key=True),
+        sa.Column("install_id", sa.Uuid(), nullable=False,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("last_report_day", sa.Date(), nullable=True),
+    )
+    op.execute("INSERT INTO telemetry_state (id) VALUES (1)")
+
+
+def downgrade() -> None:
+    op.drop_table("telemetry_state")
+    op.drop_index("usage_events_created_at", table_name="usage_events")
+    op.drop_table("usage_events")

--- a/backend/migrations/versions/0008_worker_identity.py
+++ b/backend/migrations/versions/0008_worker_identity.py
@@ -1,0 +1,26 @@
+"""persistent worker identity
+
+Revision ID: 0008
+Revises: 0007
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workers",
+        sa.Column("worker_id", sa.Text(), primary_key=True),
+        sa.Column("device", sa.Text(), nullable=True),
+        sa.Column("memory_mode", sa.Text(), nullable=True),
+        sa.Column("last_seen", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("workers")

--- a/backend/migrations/versions/0009_worker_last_seen_index.py
+++ b/backend/migrations/versions/0009_worker_last_seen_index.py
@@ -1,0 +1,20 @@
+"""index worker activity
+
+Revision ID: 0009
+Revises: 0008
+"""
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Serves daily telemetry selection and stale worker pruning.
+    op.create_index("workers_last_seen", "workers", ["last_seen"])
+
+
+def downgrade() -> None:
+    op.drop_index("workers_last_seen", table_name="workers")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,7 @@ import pytest
 
 os.environ.setdefault("DATABASE_URL",
                       "postgresql://potocolom:potocolom@localhost:5432/potocolom_test")
+os.environ.setdefault("TELEMETRY", "false")
 _storage_root = tempfile.mkdtemp(prefix="potocolom-test-")
 os.environ.setdefault("STORAGE_LOCAL_PATH", _storage_root)
 atexit.register(shutil.rmtree, _storage_root, ignore_errors=True)
@@ -44,12 +45,10 @@ def _prepare_database() -> bool:
                                      user=url.username, password=url.password,
                                      database=database, timeout=3)
         try:
-            # Truncate per table that exists: one missing name must not skip the
-            # rest, or a run against a database from before the newest migration
-            # leaves stale rows behind in the tables that are already there.
             candidates = (
-                "benchmark_measurements", "benchmark_sessions",
-                "gpu_samples", "gpu_sample_rollups", "assets", "jobs",
+                "telemetry_state", "usage_events", "benchmark_measurements",
+                "benchmark_sessions", "workers", "gpu_samples", "gpu_sample_rollups",
+                "assets", "jobs",
             )
             existing = [
                 name for name in candidates

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -35,3 +35,9 @@ def test_auth_methods_by_mode():
         "google",
         "github",
     ]
+
+
+def test_telemetry_setting():
+    assert Settings.model_fields["telemetry"].default is True
+    assert Settings(telemetry=True).telemetry is True
+    assert Settings(telemetry=False).telemetry is False

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -9,10 +9,10 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import delete, select
 
-from app import db
+from app import db, gpu_samples
 from app.main import app
 from app.realtime import PROTOCOL_VERSION
-from app.tables import GpuSample, GpuSampleRollup, Job
+from app.tables import GpuSample, GpuSampleRollup, Job, WorkerIdentity
 
 MANIFEST = {
     "id": "sd-metrics",
@@ -30,6 +30,8 @@ def fleet_hello(ws, worker_id="w-metrics"):
         "worker_id": worker_id,
         "models": [MANIFEST],
         "realtime_slots": 1,
+        "device": "rocm",
+        "memory_mode": "model_offload",
     })
     assert ws.receive_json()["type"] == "registered"
 
@@ -52,6 +54,58 @@ async def _wait_for_samples(count: int = 1, timeout: float = 3.0) -> list[GpuSam
                 return rows
         await asyncio.sleep(0.05)
     return []
+
+
+async def _wait_for_worker(worker_id: str, timeout: float = 3.0) -> WorkerIdentity | None:
+    assert db.session_factory is not None
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        async with db.session_factory() as session:
+            row = await session.get(WorkerIdentity, worker_id)
+            if row is not None:
+                return row
+        await asyncio.sleep(0.05)
+    return None
+
+
+@pytest.mark.db
+def test_registration_persists_worker_identity():
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-identity")
+            identity = asyncio.run(_wait_for_worker("w-identity"))
+            assert identity is not None
+            assert identity.device == "rocm"
+            assert identity.memory_mode == "model_offload"
+
+
+@pytest.mark.db
+def test_maintenance_prunes_stale_worker_identities():
+    now = datetime.now(timezone.utc)
+
+    async def exercise() -> tuple[WorkerIdentity | None, WorkerIdentity | None]:
+        assert db.session_factory is not None
+        async with db.session_factory() as session:
+            session.add(WorkerIdentity(
+                worker_id="w-retention-stale",
+                last_seen=now - gpu_samples.WORKER_RETENTION - timedelta(seconds=1),
+            ))
+            session.add(WorkerIdentity(
+                worker_id="w-retention-recent",
+                last_seen=now,
+            ))
+            await session.commit()
+        await gpu_samples.maintain_once()
+        async with db.session_factory() as session:
+            return (
+                await session.get(WorkerIdentity, "w-retention-stale"),
+                await session.get(WorkerIdentity, "w-retention-recent"),
+            )
+
+    with TestClient(app):
+        stale, recent = asyncio.run(exercise())
+        assert stale is None
+        assert recent is not None
 
 
 @pytest.mark.db
@@ -79,6 +133,17 @@ def test_heartbeat_persists_gpu_sample():
             assert row.worker_id == "w-metrics"
             assert row.util_pct == 42
             assert row.loaded_models == ["sd-metrics"]
+
+            async def read_worker() -> WorkerIdentity | None:
+                assert db.session_factory is not None
+                async with db.session_factory() as session:
+                    return await session.get(WorkerIdentity, "w-metrics")
+
+            identity = asyncio.run(read_worker())
+            assert identity is not None
+            assert identity.device == "rocm"
+            assert identity.memory_mode == "model_offload"
+            assert identity.last_seen >= row.sampled_at
 
 
 @pytest.mark.db

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -4,12 +4,14 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 from starlette.websockets import WebSocketDisconnect
 
-from app import realtime
+from app import db, realtime
 from app.main import app
 from app.manifests import Manifest
 from app.realtime import CANVAS_FRAME, GENERATED_FRAME, MIN_SUPPORTED_VERSION, PROTOCOL_VERSION
+from app.tables import UsageEvent
 
 client = TestClient(app)
 
@@ -87,6 +89,73 @@ def test_session_and_frame_relay_both_directions():
             generated = bytes([GENERATED_FRAME]) + session.bytes + b"generated-payload"
             worker_ws.send_bytes(generated)
             assert browser_ws.receive_bytes() == generated
+
+
+@pytest.mark.db
+def test_closed_session_persists_usage_event():
+    with TestClient(app) as db_client:
+        with db_client.websocket_connect("/api/v1/fleet") as worker_ws:
+            worker_ws.send_json(hello(worker_id="w-usage"))
+            assert worker_ws.receive_json()["type"] == "registered"
+            with db_client.websocket_connect("/api/v1/realtime") as browser_ws:
+                browser_ws.send_json({"type": "open", "model_id": "sd-sim"})
+                opened = worker_ws.receive_json()
+                worker_ws.send_json({
+                    "type": "session_ready",
+                    "session_id": opened["session_id"],
+                })
+                assert browser_ws.receive_json()["type"] == "ready"
+                browser_ws.send_json({"type": "close"})
+            closed = worker_ws.receive_json()
+            assert closed["type"] == "close_session"
+            worker_ws.send_json({
+                "type": "session_closed",
+                "session_id": opened["session_id"],
+                "frames": 3,
+                "gpu_ms": 90,
+                "duration_ms": 2000,
+                "category": "other",
+            })
+
+            async def persisted() -> bool:
+                assert db.session_factory is not None
+                async with db.session_factory() as session:
+                    row = (
+                        await session.execute(
+                            select(UsageEvent).where(
+                                UsageEvent.kind == "realtime",
+                                UsageEvent.model_id == "sd-sim",
+                            ).order_by(UsageEvent.created_at.desc()).limit(1)
+                        )
+                    ).scalar_one_or_none()
+                    return row is not None and row.frames == 3 and row.action == "draw"
+
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline and not asyncio.run(persisted()):
+                time.sleep(0.05)
+            assert asyncio.run(persisted())
+
+
+@pytest.mark.db
+def test_closing_session_is_removed_when_worker_is_lost():
+    with TestClient(app) as db_client:
+        with db_client.websocket_connect("/api/v1/fleet") as worker_ws:
+            worker_ws.send_json(hello(worker_id="w-closing"))
+            assert worker_ws.receive_json()["type"] == "registered"
+            with db_client.websocket_connect("/api/v1/realtime") as browser_ws:
+                browser_ws.send_json({"type": "open", "model_id": "sd-sim"})
+                opened = worker_ws.receive_json()
+                worker_ws.send_json({
+                    "type": "session_ready",
+                    "session_id": opened["session_id"],
+                })
+                assert browser_ws.receive_json()["type"] == "ready"
+                browser_ws.send_json({"type": "close"})
+            assert worker_ws.receive_json()["type"] == "close_session"
+            session_id = uuid.UUID(opened["session_id"])
+            assert session_id in realtime.closing_sessions
+
+        assert session_id not in realtime.closing_sessions
 
 
 def test_malformed_hello_closes_with_protocol_violation():

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -1,0 +1,129 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import delete
+
+from app import db, telemetry
+from app.main import app
+from app.tables import TelemetryState, UsageEvent, User, WorkerIdentity
+
+
+@pytest.mark.db
+def test_telemetry_preview_is_exact_daily_aggregate():
+    async def seed() -> None:
+        assert db.session_factory is not None
+        assert db.local_user_id is not None
+        reported_day = datetime.now(timezone.utc).date() - timedelta(days=1)
+        start = datetime.combine(reported_day, datetime.min.time(), tzinfo=timezone.utc)
+        end = start + timedelta(days=1)
+        async with db.session_factory() as session:
+            # This test asserts the exact reported period, so isolate that shared state.
+            await session.execute(delete(UsageEvent).where(
+                UsageEvent.created_at >= start,
+                UsageEvent.created_at < end,
+            ))
+            await session.execute(delete(WorkerIdentity))
+            session.add(UsageEvent(
+                user_id=db.local_user_id,
+                kind="realtime",
+                action="draw",
+                model_id="sd-test",
+                tier=None,
+                category="other",
+                category_score=None,
+                gpu_ms=100,
+                duration_ms=120_000,
+                frames=3,
+                created_at=start + timedelta(hours=12),
+            ))
+            session.add(WorkerIdentity(
+                worker_id="w-preview",
+                device="rocm",
+                memory_mode="model_offload",
+                last_seen=start + timedelta(hours=12),
+            ))
+            session.add(WorkerIdentity(
+                worker_id="w-stale",
+                device="cuda",
+                memory_mode="full",
+                last_seen=start - timedelta(seconds=1),
+            ))
+            await session.commit()
+
+    with TestClient(app) as client:
+        asyncio.run(seed())
+        response = client.get("/api/v1/telemetry/preview")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["active_users"] == 1
+        assert payload["events"] == {"realtime": 1}
+        assert payload["by_action"] == {"draw": 1}
+        assert payload["by_category"] == {"other": 1}
+        assert payload["by_tier"] == {}
+        assert payload["realtime_minutes"] == 2
+        assert payload["workers"] == [{"device": "rocm", "memory_mode": "model_offload"}]
+
+
+@pytest.mark.db
+def test_failed_telemetry_send_is_marked_and_dropped(monkeypatch):
+    def fail(_url: str, _payload: dict) -> None:
+        raise OSError("offline")
+
+    monkeypatch.setattr(telemetry, "_post", fail)
+    monkeypatch.setattr(
+        telemetry, "get_settings", lambda: SimpleNamespace(telemetry=True))
+
+    async def exercise() -> None:
+        assert db.session_factory is not None
+        async with db.session_factory() as session:
+            state = await session.get(TelemetryState, 1)
+            assert state is not None
+            state.last_report_day = None
+            await session.commit()
+        await telemetry.send_once()
+        async with db.session_factory() as session:
+            state = await session.get(TelemetryState, 1)
+            assert state is not None
+            expected = datetime.now(timezone.utc).date() - timedelta(days=1)
+            assert state.last_report_day == expected
+
+    with TestClient(app):
+        asyncio.run(exercise())
+
+
+@pytest.mark.db
+def test_usage_events_are_hard_deleted_with_user():
+    async def exercise() -> None:
+        assert db.session_factory is not None
+        user_id = uuid.uuid4()
+        event_id = uuid.uuid4()
+        async with db.session_factory() as session:
+            session.add(User(id=user_id, email=f"{user_id}@example.test"))
+            # Flush the owner first: there is no ORM relationship between these
+            # tables, so the unit of work has no dependency to sort inserts by.
+            await session.flush()
+            session.add(UsageEvent(
+                id=event_id,
+                user_id=user_id,
+                kind="job",
+                action="generate",
+                model_id="sd-test",
+                tier=None,
+                category="other",
+                category_score=None,
+                gpu_ms=1,
+                duration_ms=2,
+                frames=1,
+            ))
+            await session.commit()
+            await session.execute(delete(User).where(User.id == user_id))
+            await session.commit()
+        async with db.session_factory() as session:
+            assert await session.get(UsageEvent, event_id) is None
+
+    with TestClient(app):
+        asyncio.run(exercise())

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -1,1 +1,2 @@
 POSTGRES_PASSWORD=change-me
+TELEMETRY=true

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -13,6 +13,7 @@ services:
       STORAGE_BACKEND: local
       PUBLIC_URL: http://localhost:8080
       INTERNAL_URL: http://api:8080
+      TELEMETRY: ${TELEMETRY:-true}
     volumes:
       - assets:/data/assets
     depends_on:

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,7 +45,7 @@ Every call a customer's browser makes, from first page load to account deletion.
 | POST `/api/v1/assets/{id}/share` | issue #17 | mint a public share token |
 | DELETE `/api/v1/assets/{id}/share` | issue #17 | revoke the share token |
 | GET `/shared/{token}` | issue #17 | public share link target (CDN path in the cloud) |
-| GET `/api/v1/telemetry/preview` | issue #29 | the exact telemetry payload that would be sent, see [metrics.md](metrics.md) |
+| GET `/api/v1/telemetry/preview` | implemented (#29) | the exact telemetry payload that would be sent, see [metrics.md](metrics.md) |
 
 ## Implemented endpoints
 
@@ -162,6 +162,8 @@ GET  /api/v1/benchmark/sessions       200 newest-first install-scoped session su
                                         session id as ?cursor to read the next page
 GET  /api/v1/benchmark/sessions/{id}  200 full report in the existing results.json shape;
                                         404 for a missing session
+GET  /api/v1/telemetry/preview        200 exact previous UTC day's anonymous aggregate payload;
+                                        503 when the database is unavailable
 PUT  /api/v1/files/{key}               local-storage upload target (self-hosted, non-S3); a PUT is
                                         authorized only for a storage key the API minted in-flight
 GET  /api/v1/files/{key}               serve a stored object (self-hosted, non-S3)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -439,6 +439,8 @@ erDiagram
     users ||--o{ realtime_sessions : opens
     users ||--o{ metering_events : accrues
     users ||--o{ usage_events : generates
+    users ||--o{ benchmark_sessions : runs
+    benchmark_sessions ||--o{ benchmark_measurements : contains
     models ||--o{ jobs : runs
     models ||--o{ realtime_sessions : powers
     workers ||--o{ realtime_sessions : hosts
@@ -474,10 +476,9 @@ erDiagram
         int min_vram_gb
     }
     workers {
-        text id PK
-        jsonb model_ids
-        int realtime_slots
-        int protocol_version
+        text worker_id PK
+        text device
+        text memory_mode
         timestamptz last_seen
     }
     jobs {
@@ -487,6 +488,7 @@ erDiagram
         jsonb params
         text state "queued, running, succeeded, failed"
         int gpu_ms
+        timestamptz starred_at "null unless favorited"
         timestamptz created_at
     }
     assets {
@@ -526,9 +528,37 @@ erDiagram
         text model_id
         text tier
         text category "CLIP zero-shot on the output"
+        float category_score
         int gpu_ms
         int duration_ms
+        int frames
         timestamptz created_at
+    }
+    benchmark_sessions {
+        uuid id PK
+        uuid user_id FK
+        timestamptz created_at
+        jsonb models
+        int total_jobs
+        int succeeded
+        int failed
+    }
+    benchmark_measurements {
+        uuid session_id PK,FK
+        int position PK
+        int prompt_id
+        text model_id
+        text variant
+        jsonb params
+        int model_load_ms
+        int gpu_ms
+        float wall_s
+        text state
+    }
+    telemetry_state {
+        int id PK
+        uuid install_id
+        date last_report_day
     }
 ```
 

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -28,12 +28,12 @@ Fleet connection, worker to API:
 
 | type | Fields | Notes |
 |---|---|---|
-| `hello` | `protocol_version`, `worker_id`, `models`, `realtime_slots` | first message after connect; `models` is the manifest list with capabilities as measured (the memory ladder in [architecture.md](architecture.md) may drop `realtime` on low VRAM workers) |
-| `heartbeat` | `slots_in_use`, `loaded_models`, `gpu` (util, VRAM, temperature, power) | every 30 seconds. Corrected 2026-07-23: the wire also carries `loaded_models` and a `gpu` sample |
+| `hello` | `protocol_version`, `worker_id`, `models`, `realtime_slots`, `device`, `memory_mode` | first message after connect; `models` is the manifest list with capabilities as measured (the memory ladder in [architecture.md](architecture.md) may drop `realtime` on low VRAM workers). `device` and `memory_mode` are static worker identity fields; the API accepts an N-1 worker that omits them |
+| `heartbeat` | `slots_in_use`, `loaded_models`, `gpu` (device, util, VRAM, temperature, power) | every 30 seconds. Corrected 2026-07-23: the wire also carries `loaded_models` and a `gpu` sample. An N-1 worker may still send `memory_mode` here |
 | `session_ready` | `session_id` | slot acquired, model warm |
-| `session_closed` | `session_id`, `frames` | worker side accounting |
+| `session_closed` | `session_id`, `frames`, `gpu_ms`, `duration_ms`, `category`, optional `category_score` | worker side accounting and completion-side usage event |
 | `job_progress` | `job_id`, `progress` | fraction of denoising steps done |
-| `job_done` | `job_id`, `gpu_ms`, `width`, `height`, `input_fetch_ms` (optional), `load_ms` (optional), `postprocess_ms` (optional) | sent after the result uploaded to the dispatch target |
+| `job_done` | `job_id`, `gpu_ms`, `duration_ms`, `category`, optional `category_score`, `width`, `height`, `input_fetch_ms` (optional), `load_ms` (optional), `postprocess_ms` (optional) | sent after the result uploaded to the dispatch target |
 | `job_failed` | `job_id`, `reason` | the job fails visibly; only worker death triggers the one retry |
 
 Fleet connection, API to worker:
@@ -71,7 +71,7 @@ sequenceDiagram
     participant W as Worker
     participant A as API server
     W->>A: WS connect /api/v1/fleet
-    W->>A: hello (protocol_version, worker_id, models, realtime_slots)
+    W->>A: hello (protocol_version, worker_id, models, realtime_slots, device, memory_mode)
     alt version supported
         A-->>W: registered
         Note over W,A: worker is dispatchable; heartbeats begin

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -41,6 +41,8 @@ The NVIDIA variant (`:v0.x-cuda`) uses the `deploy.resources.reservations.device
 
 Dependencies run in containers; the three applications run natively for instant reload and debugger access:
 
+The `make api` target sets `TELEMETRY=false`, so the native development loop never reports telemetry.
+
 ```
 deploy/compose/dev.yml        # postgres; redis, minio and mailpit behind --profile cloud-sim
 backend:  uvicorn app:app --reload          # against the dev containers

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -98,6 +98,12 @@ POST https://telemetry.potocolom.com/v1/report
 }
 ```
 
+The `workers` field includes identities whose `last_seen` is at or after the
+start of the reported UTC day. A continuously connected worker remains included,
+while workers gone before that day drop out. A worker first seen on the following
+day can be included in the previous day's report; this small over-inclusion avoids
+an unbounded identity history without adding a per-day activity log.
+
 A failed send is dropped, never queued: telemetry must never affect the install that emits it.
 
 ## Operational metrics: planes and export paths
@@ -118,7 +124,7 @@ The worker samples its card once per heartbeat - GPU utilization, VRAM used and 
 
 A multi-GPU machine runs one worker process per GPU, pinned by device index, so every GPU is one connection, one heartbeat stream and one set of slots - the fleet view lists them all individually with no special casing. The admin area is the live many-GPU console; CloudWatch is for trends and alarms; Logs Insights is for the post-mortem on one specific worker.
 
-The studio's own usage panel has a fourth consumer: each heartbeat's GPU sample is also written to the deployment's PostgreSQL (`gpu_samples`, raw rows kept 48 hours) and rolled into five-minute buckets (`gpu_sample_rollups`, kept 30 days) by a maintenance loop in the API. `GET /api/v1/metrics/gpu/history` serves both: raw rows for windows up to an hour, rollups beyond. This is per-install history for the user's own hardware; the CloudWatch plane above stays aggregate-only.
+The studio's own usage panel has a fourth consumer: each heartbeat's GPU sample is also written to the deployment's PostgreSQL (`gpu_samples`, raw rows kept 48 hours) and rolled into five-minute buckets (`gpu_sample_rollups`, kept 30 days) by a maintenance loop in the API. Static `device` and `memory_mode` facts live once per worker in `workers`, refreshed at registration and heartbeat, instead of being repeated on every sample. `GET /api/v1/metrics/gpu/history` serves raw and rolled-up samples: raw rows for windows up to an hour, rollups beyond. This is per-install history for the user's own hardware; the CloudWatch plane above stays aggregate-only.
 
 ## Frame loop metrics
 

--- a/worker/tests/test_categorize.py
+++ b/worker/tests/test_categorize.py
@@ -1,0 +1,6 @@
+from worker.categorize import LABELS, categorize_output
+
+
+def test_categorizer_noop_uses_fixed_other_label_without_fake_score():
+    assert LABELS == ("art", "photo_edit", "design", "character", "nsfw", "other")
+    assert categorize_output(None) == ("other", None)

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -41,6 +41,7 @@ def test_latest_input_wins():
 
     runner = asyncio.run(scenario())
     assert runner.dropped == 2
+    assert not hasattr(runner, "last_output")
     assert len(socket.sent) == 1
     assert socket.sent[0][FRAME_HEADER_BYTES:] == b"third"
 
@@ -94,6 +95,8 @@ def test_hello_carries_manifests():
     assert manifest["id"] == "sd-sim"
     assert "realtime" in manifest["capabilities"]
     assert "source" not in manifest  # weight locations stay worker side
+    assert hello["device"] == "cpu"
+    assert hello["memory_mode"] == "auto"
 
 
 def test_rejected_registration_raises_cleanly():
@@ -194,6 +197,9 @@ def test_run_job_generates_uploads_and_reports(monkeypatch):
     assert done["input_fetch_ms"] >= 0
     assert done["load_ms"] >= 0
     assert done["postprocess_ms"] >= 0
+    assert done["duration_ms"] >= 0
+    assert done["category"] == "other"
+    assert "category_score" not in done
     assert done["has_thumbnail"] is True
 
 

--- a/worker/worker/categorize.py
+++ b/worker/worker/categorize.py
@@ -7,6 +7,11 @@ this pass: adding a second CLIP model would require an unapproved model download
 LABELS = ("art", "photo_edit", "design", "character", "nsfw", "other")
 
 
-def categorize_output(_image: bytes | None) -> tuple[str, None]:
+def categorize_output(_image: bytes | None) -> tuple[str, float | None]:
+    """Return the label and its confidence; the score is None while this is a stub.
+
+    Typed optional rather than None so callers testing `score is not None`
+    describe the protocol seam instead of a branch that cannot be taken.
+    """
     # A real CLIP categorizer will need the final realtime frame passed here.
     return "other", None

--- a/worker/worker/categorize.py
+++ b/worker/worker/categorize.py
@@ -1,0 +1,12 @@
+"""Output categorization protocol seam for usage metrics.
+
+The fixed labels are wired now, but classification is deliberately a no-op in
+this pass: adding a second CLIP model would require an unapproved model download.
+"""
+
+LABELS = ("art", "photo_edit", "design", "character", "nsfw", "other")
+
+
+def categorize_output(_image: bytes | None) -> tuple[str, None]:
+    # A real CLIP categorizer will need the final realtime frame passed here.
+    return "other", None

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -224,14 +224,16 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
                           "input_fetch_ms": input_fetch_ms,
                           "load_ms": result.load_ms,
                           "postprocess_ms": postprocess_ms,
-                          "width": result.width, "height": result.height,
-                          "duration_ms": int((time.monotonic() - job_started) * 1000)}
+                          "width": result.width, "height": result.height}
         category, score = categorize_output(result.data)
         done_msg["category"] = category
         if score is not None:
             done_msg["category_score"] = score
         if has_thumbnail:
             done_msg["has_thumbnail"] = True
+        # Stamped last so it covers every step the user waits through, including
+        # categorization once that stops being a stub.
+        done_msg["duration_ms"] = int((time.monotonic() - job_started) * 1000)
         await ws.send(json.dumps(done_msg))
         logger.info("job %s done in %d gpu_ms", job_id, result.gpu_ms)
     except asyncio.CancelledError:

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -18,6 +18,7 @@ import httpx
 import websockets
 
 from worker.engine import Engine, SimulatedEngine, make_thumbnail_webp
+from worker.categorize import categorize_output
 from worker.manifests import SIMULATED_MANIFEST, Manifest, load_manifests
 from worker.gpu_metrics import sample_gpu
 from worker.settings import Settings, get_settings
@@ -25,7 +26,7 @@ from worker.settings import Settings, get_settings
 logger = logging.getLogger("potocolom.worker")
 
 # Wire constants; keep in sync with backend/app/realtime.py.
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
 GENERATED_FRAME = 0x02
 FRAME_HEADER_BYTES = 17
 CLOSE_PROTOCOL_VIOLATION = 4000
@@ -110,6 +111,8 @@ class SessionRunner:
         self.arrived = asyncio.Event()
         self.dropped = 0
         self.frames = 0
+        self.gpu_ms = 0
+        self.started_at = time.monotonic()
         self._task = asyncio.create_task(self._run(ws, engine, manifest, params))
 
     def submit(self, payload: bytes) -> None:
@@ -134,8 +137,10 @@ class SessionRunner:
                                  self.session_id)
                 continue
             self.frames += 1
+            self.gpu_ms += generated.gpu_ms
             try:
-                await ws.send(bytes([GENERATED_FRAME]) + self.session_id.bytes + generated)
+                await ws.send(
+                    bytes([GENERATED_FRAME]) + self.session_id.bytes + generated.data)
             except websockets.WebSocketException:
                 logger.warning("session %s lost the connection while sending a frame",
                                self.session_id)
@@ -149,6 +154,7 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
     """One queued job: generate, upload to the given target, report the result.
     Failures are reported, never raised: the connection outlives the job."""
     job_id = control["job_id"]
+    job_started = time.monotonic()
     progress_tasks: list[asyncio.Task[None]] = []
     last_fraction = 0.0
 
@@ -218,7 +224,12 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
                           "input_fetch_ms": input_fetch_ms,
                           "load_ms": result.load_ms,
                           "postprocess_ms": postprocess_ms,
-                          "width": result.width, "height": result.height}
+                          "width": result.width, "height": result.height,
+                          "duration_ms": int((time.monotonic() - job_started) * 1000)}
+        category, score = categorize_output(result.data)
+        done_msg["category"] = category
+        if score is not None:
+            done_msg["category_score"] = score
         if has_thumbnail:
             done_msg["has_thumbnail"] = True
         await ws.send(json.dumps(done_msg))
@@ -294,6 +305,8 @@ async def serve_connection(ws, settings: Settings, manifests: list[Manifest],
         "models": wire_manifests,
         "realtime_slots": engine.effective_realtime_slots(wire_manifests,
                                                            settings.realtime_slots),
+        "device": settings.device,
+        "memory_mode": settings.memory_mode,
     }))
     try:
         response = json.loads(await ws.recv())
@@ -350,9 +363,19 @@ async def serve_connection(ws, settings: Settings, manifests: list[Manifest],
                         runner = runners.pop(uuid.UUID(control["session_id"]), None)
                         if runner is not None:
                             runner.close()
-                            await ws.send(json.dumps({"type": "session_closed",
-                                                      "session_id": control["session_id"],
-                                                      "frames": runner.frames}))
+                            category, score = categorize_output(None)
+                            closed = {
+                                "type": "session_closed",
+                                "session_id": control["session_id"],
+                                "frames": runner.frames,
+                                "gpu_ms": runner.gpu_ms,
+                                "duration_ms": int(
+                                    (time.monotonic() - runner.started_at) * 1000),
+                                "category": category,
+                            }
+                            if score is not None:
+                                closed["category_score"] = score
+                            await ws.send(json.dumps(closed))
                     elif control["type"] == "dispatch_job":
                         task = asyncio.create_task(run_job(
                             ws, engine, by_id[control["model_id"]], control))

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -56,13 +56,19 @@ class GeneratedImage:
     load_ms: int = 0
 
 
+@dataclass
+class GeneratedFrame:
+    data: bytes
+    gpu_ms: int
+
+
 class Engine(Protocol):
     async def generate(
         self, manifest: Manifest, params: dict, progress: ProgressFn,
         *, input_image: bytes | None = None,
     ) -> GeneratedImage: ...
 
-    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes: ...
+    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame: ...
 
     def loaded_models(self) -> list[str]: ...
 
@@ -203,9 +209,10 @@ class SimulatedEngine:
         gpu_ms = int((time.monotonic() - start) * 1000)
         return GeneratedImage(encode_webp(image), width, height, gpu_ms, load_ms)
 
-    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes:
+    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame:
+        started = time.monotonic()
         await asyncio.sleep(self.inference_seconds)
-        return payload
+        return GeneratedFrame(payload, int((time.monotonic() - started) * 1000))
 
 
 class DiffusersEngine:
@@ -836,10 +843,12 @@ class DiffusersEngine:
         loop.call_soon_threadsafe(progress, 1.0)
         return GeneratedImage(encode_webp(image), image.width, image.height, gpu_ms, load_ms)
 
-    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes:
+    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame:
         async with self._gpu:
             try:
-                return await asyncio.to_thread(self._frame, manifest, dict(params), payload)
+                data, gpu_ms = await asyncio.to_thread(
+                    self._frame, manifest, dict(params), payload)
+                return GeneratedFrame(data, gpu_ms)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
             except (ValueError, TypeError):
@@ -848,9 +857,11 @@ class DiffusersEngine:
                 self._evict_poisoned(manifest.id)
                 raise
             self._evict_except(manifest.id)
-            return await asyncio.to_thread(self._frame, manifest, dict(params), payload)
+            data, gpu_ms = await asyncio.to_thread(
+                self._frame, manifest, dict(params), payload)
+            return GeneratedFrame(data, gpu_ms)
 
-    def _frame(self, manifest: Manifest, params: dict, payload: bytes) -> bytes:
+    def _frame(self, manifest: Manifest, params: dict, payload: bytes) -> tuple[bytes, int]:
         if "realtime" not in manifest.capabilities:
             raise ValueError(f"model {manifest.id} does not support realtime frames")
         if self._pick_rung(manifest) != "full":
@@ -859,6 +870,7 @@ class DiffusersEngine:
         canvas = canvas.resize((REALTIME_SIZE, REALTIME_SIZE))
         strength = min(max(float(params.get("strength", 0.7)), 0.05), 1.0)
         pipeline = self._pipeline(manifest, "i2i")
+        started = time.monotonic()
         image = pipeline(
             prompt=str(params.get("prompt", "")),
             image=canvas,
@@ -868,4 +880,5 @@ class DiffusersEngine:
             strength=strength,
             guidance_scale=0.0,
         ).images[0]
-        return encode_webp(image)
+        gpu_ms = int((time.monotonic() - started) * 1000)
+        return encode_webp(image), gpu_ms


### PR DESCRIPTION
# Description

Implements the two measurement streams specified in [metrics.md](docs/metrics.md): a `usage_events` table the API writes for every completed job and closed realtime session, and an opt-out daily telemetry report from self-hosted installs.

# Functionality

- One `usage_events` row per completed job and per closed realtime session (migration `0007`): user, kind, action, model, category, `gpu_ms`, `duration_ms`, `frames`. Same code in both deployment profiles, stored in the deployment's own PostgreSQL.
- Writes are fire-and-forget on the completion path and swallow their own failures, so a metrics write cannot slow or fail a user's generation, and a database outage degrades to no row rather than an error.
- `TELEMETRY=true` by default: one anonymous daily aggregate keyed to a random install id, with `TELEMETRY=false` to disable. `GET /api/v1/telemetry/preview` returns exactly the payload that would be sent.
- Worker protocol 2 carries `duration_ms`, `category` and static device identity. Static `device` and `memory_mode` live once per worker in a `workers` table (migrations `0008`, `0009`) rather than repeating on every 30-second sample.

# Details

**Privacy.** Deliberately never stored: prompt text, images, IP addresses, user agents. Rows are user-linked because retention and cohort analysis need it, and they are hard deleted with the account through `ON DELETE CASCADE`. The telemetry payload is aggregate-only and cannot be joined back to a person; the day is marked before the network call so a failed send is dropped rather than queued, and the API logs the destination and the off switch at every startup.

**N-1 compatibility.** `MIN_SUPPORTED_VERSION` stays one behind, and an older worker's absent fields fall back rather than breaking the handler: `category` defaults to `other`. `hello` accepts a worker that omits `device` and `memory_mode`.

**Worker identity is bounded.** Telemetry reports only workers whose `last_seen` falls at or after the start of the reported day, so a worker gone for weeks drops out instead of being reported forever, and the table is pruned on the existing maintenance loop. A worker first seen the following day can appear in the previous day's report; that small over-inclusion is documented and avoids a per-day activity log.

**The categorizer is a deliberate stub.** `categorize_output` returns `("other", None)` and ignores its input. A real CLIP zero-shot pass needs a second model download that was not in scope, and a fabricated score would be worse than an honest one. The protocol field, the persistence and the label set are wired, so implementing it is a local change. Consequence to be aware of: `by_category` in the telemetry payload is uniform until it lands.

**`tier` is always null.** `docs/metrics.md` assumes tier routing, which is unshipped. The column exists and is written as null rather than guessed.

**Out of scope:** the admin usage view (#28), the telemetry ingest service and analytics warehouse (private repo, see [repository-boundary.md](docs/repository-boundary.md)), and role-based access to the preview endpoint.

**Docs.** `architecture.md` gains the data-model entries for these tables, and also the `starred_at` and benchmark-session entries that #124 and #107 should have added.

Verified with `make verify`: backend 85 passed, worker 59 passed, frontend lint, svelte-check 0 errors, both builds with the CSP check. All mermaid diagrams validated with mermaid-cli except `connection-handling.md`'s first sequence diagram, which fails identically on `main` and is pre-existing.

Closes #29
