### PR TITLE
Fall back to the SPA shell even when the build ships 404.html

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,15 +86,23 @@ async def config() -> dict:
 class SPAStaticFiles(StaticFiles):
     """Serve a built SPA: unknown GET paths fall back to index.html."""
 
+    def _may_fall_back(self, path: str, scope) -> bool:
+        # Unknown API paths must stay 404s; only page routes fall back.
+        return scope["method"] == "GET" and path != "api" and not path.startswith("api/")
+
     async def get_response(self, path: str, scope):
         try:
-            return await super().get_response(path, scope)
+            response = await super().get_response(path, scope)
         except StarletteHTTPException as exc:
-            # Unknown API paths must stay 404s; only page routes fall back.
-            is_api = path == "api" or path.startswith("api/")
-            if exc.status_code == 404 and scope["method"] == "GET" and not is_api:
+            if exc.status_code == 404 and self._may_fall_back(path, scope):
                 return await super().get_response("index.html", scope)
             raise
+        # With html=True, StaticFiles answers a miss with 404.html when the build
+        # ships one instead of raising, which would leave every client-side route
+        # (/app, /benchmark) serving the error page in the self-hosted container.
+        if response.status_code == 404 and self._may_fall_back(path, scope):
+            return await super().get_response("index.html", scope)
+        return response
 
 
 _settings = get_settings()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -25,3 +25,26 @@ def test_spa_static_files_fallback_to_index(tmp_path: Path):
         for path in ("/api", "/api/v1/no-such-endpoint"):
             response = client.get(path)
             assert response.status_code == 404
+
+
+def test_spa_fallback_wins_over_a_shipped_404_document(tmp_path: Path):
+    """A build carrying 404.html must not shadow the client-side routes.
+
+    StaticFiles(html=True) answers a miss with that document and a 404 status
+    rather than raising, so the fallback has to inspect the response too.
+    """
+    dist = tmp_path / "static"
+    dist.mkdir()
+    (dist / "index.html").write_text("<!doctype html><title>potocolom</title>")
+    (dist / "404.html").write_text("<!doctype html><title>not found</title>")
+
+    app = Starlette()
+    app.mount("/", SPAStaticFiles(directory=dist, html=True))
+
+    with TestClient(app) as client:
+        for path in ("/app", "/app/generate", "/benchmark"):
+            response = client.get(path)
+            assert response.status_code == 200
+            assert "potocolom" in response.text
+        for path in ("/api", "/api/v1/no-such-endpoint"):
+            assert client.get(path).status_code == 404


### PR DESCRIPTION
# Description

`GET /app`, `/benchmark`, `/whitepaper` and every other client-side route return 404 from the self-hosted container, serving the error document instead of the SPA shell. A self-hosted install cannot reach the studio on `main` today.

`SPAStaticFiles` falls back to `index.html` only inside an `except StarletteHTTPException` branch. Starlette's `StaticFiles(html=True)` does not raise when the build ships a `404.html`: it serves that document with a 404 status, so the fallback never ran.

# Functionality

- The fallback inspects the response as well as the raised exception, so a 404 answered with a body still yields `index.html` for page routes.
- API paths continue to return 404 rather than the SPA shell.
- A regression test ships `404.html`, which is the state that let the existing fallback test pass while the container was broken.

# Details

- Introduced by `3ea74dc` ("Make the error page mode-aware and give the CDN a 404 document"). Cloudflare Pages, the reason that file exists, is unaffected; only the self-hosted profile regressed.
- Reproduced before the fix with `bash scripts/compose-smoke.sh`: `expected /app to return 200, got 404`. Removing `404.html` from the build returned 200, isolating the cause.
- Verified after: `make verify` green and `scripts/compose-smoke.sh` passes.
- Why it shipped unnoticed: `deploy.yml` is the only check that serves the SPA through the API, and it triggers on `deploy/**` only, so a `frontend/` commit skips it. `make verify` builds the SPA but never serves it. Widening those triggers is noted in #162 as a follow-up rather than done here.

Closes #162
