### PR TITLE
Add role tiers, take GPU sampling off the event loop, rotate container logs

### DIFF
--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -2,6 +2,9 @@
 the single local user. The local and oauth providers land with the accounts
 milestone behind the same dependency (docs/blueprint.md, the mode seam)."""
 
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
 from fastapi import Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,3 +19,19 @@ async def current_user(session: AsyncSession = Depends(db.get_session)) -> User:
     if user is None:
         raise HTTPException(status_code=503, detail="local user missing")
     return user
+
+
+RoleTier = Literal["viewer", "member", "admin"]
+_ROLE_RANK = {"viewer": 0, "user": 1, "admin": 2}
+
+
+def require_role(minimum: RoleTier) -> Callable[..., Awaitable[User]]:
+    """Require a role tier while preserving "user" as the stored member value."""
+    required = "user" if minimum == "member" else minimum
+
+    async def role_user(user: User = Depends(current_user)) -> User:
+        if _ROLE_RANK.get(user.role, -1) < _ROLE_RANK[required]:
+            raise HTTPException(status_code=403, detail="insufficient role")
+        return user
+
+    return role_user

--- a/backend/app/benchmark.py
+++ b/backend/app/benchmark.py
@@ -5,10 +5,12 @@ with warm-cache state from earlier jobs. Commands are forwarded to a connected
 worker over the fleet socket (docs/connection-handling.md).
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
+from app.auth import current_user, require_role
 from app.realtime import gpu_command, pick_any_worker, pick_worker_for_model
+from app.tables import User
 
 router = APIRouter()
 
@@ -17,7 +19,7 @@ GPU_TIMEOUT = 120.0
 
 
 @router.get("/api/v1/benchmark/models")
-async def benchmark_models() -> list[dict]:
+async def benchmark_models(_user: User = Depends(current_user)) -> list[dict]:
     """All worker manifests, including benchmark_only (hidden from the studio UI)."""
     from app import registry
 
@@ -25,7 +27,7 @@ async def benchmark_models() -> list[dict]:
 
 
 @router.get("/api/v1/benchmark/gpu")
-async def gpu_status() -> dict:
+async def gpu_status(_user: User = Depends(current_user)) -> dict:
     worker = pick_any_worker()
     if worker is None:
         raise HTTPException(status_code=503, detail="no worker connected")
@@ -37,7 +39,10 @@ class LoadRequest(BaseModel):
 
 
 @router.post("/api/v1/benchmark/gpu/load")
-async def gpu_load(request: LoadRequest) -> dict:
+async def gpu_load(
+    request: LoadRequest,
+    _user: User = Depends(require_role("member")),
+) -> dict:
     worker = pick_worker_for_model(request.model_id)
     if worker is None:
         raise HTTPException(status_code=503,
@@ -55,7 +60,10 @@ class UnloadRequest(BaseModel):
 
 
 @router.post("/api/v1/benchmark/gpu/unload")
-async def gpu_unload(request: UnloadRequest = UnloadRequest()) -> dict:
+async def gpu_unload(
+    request: UnloadRequest = UnloadRequest(),
+    _user: User = Depends(require_role("member")),
+) -> dict:
     worker = pick_any_worker()
     if worker is None:
         raise HTTPException(status_code=503, detail="no worker connected")

--- a/backend/app/benchmark_sessions.py
+++ b/backend/app/benchmark_sessions.py
@@ -13,7 +13,7 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db
-from app.auth import current_user
+from app.auth import current_user, require_role
 from app.settings import get_settings
 from app.tables import BenchmarkMeasurement, BenchmarkSession, User
 
@@ -140,7 +140,7 @@ def require_benchmark_api() -> None:
 async def create_benchmark_session(
     report: BenchmarkInput,
     _: None = Depends(require_benchmark_api),
-    user: User = Depends(current_user),
+    user: User = Depends(require_role("member")),
     session: AsyncSession = Depends(db.get_session),
 ) -> dict:
     row = BenchmarkSession(

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -32,6 +32,7 @@ from app.tables import User
 logger = logging.getLogger("potocolom.db")
 
 LOCAL_USER_EMAIL = "local@localhost"
+MIN_POSTGRES_VERSION = (13, 0)
 
 engine: AsyncEngine | None = None
 session_factory: async_sessionmaker[AsyncSession] | None = None
@@ -51,10 +52,33 @@ def _migrate(database_url: str) -> None:
     command.upgrade(config, "head")
 
 
+def _postgres_version_supported(version: tuple[int, ...]) -> bool:
+    return version >= MIN_POSTGRES_VERSION
+
+
+async def _postgres_version(database_url: str) -> tuple[int, ...]:
+    check_engine = create_async_engine(async_url(database_url), poolclass=NullPool)
+    try:
+        async with check_engine.connect() as connection:
+            version = connection.dialect.server_version_info
+            if version is None:
+                raise RuntimeError("could not determine PostgreSQL server version")
+            return version
+    finally:
+        await check_engine.dispose()
+
+
 async def connect() -> bool:
     global engine, session_factory, local_user_id
     settings = get_settings()
     try:
+        postgres_version = await _postgres_version(settings.database_url)
+        if not _postgres_version_supported(postgres_version):
+            minimum = ".".join(str(part) for part in MIN_POSTGRES_VERSION)
+            found = ".".join(str(part) for part in postgres_version)
+            raise RuntimeError(
+                f"PostgreSQL {minimum} or newer is required; found PostgreSQL {found}"
+            )
         # Alembic's env.py runs its own event loop, so migrate off this one.
         await asyncio.to_thread(_migrate, settings.database_url)
     except Exception as error:
@@ -86,8 +110,11 @@ async def _ensure_local_user(factory: async_sessionmaker[AsyncSession]) -> uuid.
             await session.execute(select(User).where(User.email == LOCAL_USER_EMAIL))
         ).scalar_one_or_none()
         if user is None:
-            user = User(email=LOCAL_USER_EMAIL)
+            user = User(email=LOCAL_USER_EMAIL, role="admin")
             session.add(user)
+            await session.commit()
+        elif user.role != "admin":
+            user.role = "admin"
             await session.commit()
         return user.id
 

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -27,7 +27,7 @@ from sqlalchemy import and_, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db, realtime, registry
-from app.auth import current_user
+from app.auth import current_user, require_role
 from app.manifests import validate_params
 from app.settings import get_settings
 from app.storage import get_storage
@@ -114,7 +114,7 @@ class GenerationRequest(BaseModel):
 @router.post("/api/v1/generations", status_code=202)
 async def create_generation(
     request: GenerationRequest,
-    user: User = Depends(current_user),
+    user: User = Depends(require_role("member")),
     session: AsyncSession = Depends(db.get_session),
 ) -> dict:
     manifest = registry.for_jobs().get(request.model_id)
@@ -286,7 +286,7 @@ async def _set_star(
 @router.post("/api/v1/generations/{job_id}/star", status_code=204)
 async def star_generation(
     job_id: uuid.UUID,
-    user: User = Depends(current_user),
+    user: User = Depends(require_role("member")),
     session: AsyncSession = Depends(db.get_session),
 ) -> Response:
     await _set_star(session, job_id, user, func.coalesce(Job.starred_at, func.now()))
@@ -296,7 +296,7 @@ async def star_generation(
 @router.delete("/api/v1/generations/{job_id}/star", status_code=204)
 async def unstar_generation(
     job_id: uuid.UUID,
-    user: User = Depends(current_user),
+    user: User = Depends(require_role("member")),
     session: AsyncSession = Depends(db.get_session),
 ) -> Response:
     await _set_star(session, job_id, user, None)

--- a/backend/app/telemetry.py
+++ b/backend/app/telemetry.py
@@ -14,7 +14,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db
-from app.auth import current_user
+from app.auth import require_role
 from app.settings import get_settings
 from app.tables import TelemetryState, UsageEvent, User, WorkerIdentity
 
@@ -94,7 +94,7 @@ async def payload_for_day(session: AsyncSession, day: date) -> dict:
 
 @router.get("/api/v1/telemetry/preview")
 async def telemetry_preview(
-    _user: User = Depends(current_user),
+    _user: User = Depends(require_role("admin")),
     session: AsyncSession = Depends(db.get_session),
 ) -> dict:
     return await payload_for_day(session, datetime.now(timezone.utc).date() - timedelta(days=1))

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,85 @@
+import asyncio
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app import db
+from app.auth import require_role
+from app.main import app
+from app.tables import User
+
+
+async def _set_local_role(role: str) -> None:
+    assert db.session_factory is not None
+    assert db.local_user_id is not None
+    async with db.session_factory() as session:
+        user = await session.get(User, db.local_user_id)
+        assert user is not None
+        user.role = role
+        await session.commit()
+
+
+def test_role_tiers_preserve_user_as_member_value():
+    viewer = User(email="viewer@example.test", role="viewer")
+    member = User(email="member@example.test", role="user")
+    admin = User(email="admin@example.test", role="admin")
+    member_dependency = require_role("member")
+    admin_dependency = require_role("admin")
+
+    with pytest.raises(HTTPException) as denied:
+        asyncio.run(member_dependency(viewer))
+    assert denied.value.status_code == 403
+    assert asyncio.run(member_dependency(member)) is member
+    assert asyncio.run(member_dependency(admin)) is admin
+    with pytest.raises(HTTPException) as denied:
+        asyncio.run(admin_dependency(member))
+    assert denied.value.status_code == 403
+
+
+@pytest.mark.db
+def test_viewer_reads_but_cannot_mutate_and_preview_is_admin_only():
+    missing_job = uuid.UUID("00000000-0000-0000-0000-000000000000")
+    with TestClient(app) as client:
+        try:
+            asyncio.run(_set_local_role("viewer"))
+            assert client.get("/api/v1/generations").status_code == 200
+            assert client.get("/api/v1/benchmark/sessions").status_code == 200
+            assert client.post(
+                f"/api/v1/generations/{missing_job}/star"
+            ).status_code == 403
+            assert client.get("/api/v1/telemetry/preview").status_code == 403
+
+            asyncio.run(_set_local_role("user"))
+            assert client.post(
+                f"/api/v1/generations/{missing_job}/star"
+            ).status_code == 404
+            assert client.get("/api/v1/telemetry/preview").status_code == 403
+
+            asyncio.run(_set_local_role("admin"))
+            assert client.post(
+                f"/api/v1/generations/{missing_job}/star"
+            ).status_code == 404
+            assert client.get("/api/v1/telemetry/preview").status_code == 200
+        finally:
+            asyncio.run(_set_local_role("admin"))
+
+
+@pytest.mark.db
+def test_existing_implicit_local_user_is_promoted_to_admin():
+    with TestClient(app):
+        assert db.session_factory is not None
+        assert db.local_user_id is not None
+        asyncio.run(_set_local_role("user"))
+        user_id = asyncio.run(db._ensure_local_user(db.session_factory))
+        assert user_id == db.local_user_id
+
+        async def read_role() -> str:
+            assert db.session_factory is not None
+            async with db.session_factory() as session:
+                user = await session.get(User, user_id)
+                assert user is not None
+                return user.role
+
+        assert asyncio.run(read_role()) == "admin"

--- a/backend/tests/test_db.py
+++ b/backend/tests/test_db.py
@@ -1,0 +1,7 @@
+from app.db import _postgres_version_supported
+
+
+def test_postgres_version_comparison():
+    assert not _postgres_version_supported((12, 99))
+    assert _postgres_version_supported((13, 0))
+    assert _postgres_version_supported((16, 3))

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -1,7 +1,14 @@
 # Self-hosted stack: one API (SPA + backend), PostgreSQL and one GPU worker.
 # Shape matches docs/blueprint.md; no Redis, billing or safety services.
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   api:
+    logging: *default-logging
     build:
       context: ../..
       dockerfile: deploy/docker/Dockerfile.api
@@ -21,6 +28,7 @@ services:
         condition: service_healthy
 
   postgres:
+    logging: *default-logging
     image: postgres:16
     environment:
       POSTGRES_USER: potocolom
@@ -35,6 +43,7 @@ services:
       retries: 5
 
   worker:
+    logging: *default-logging
     profiles: ["gpu"]
     build:
       context: ../..
@@ -60,6 +69,7 @@ services:
   # AMD worker (docker compose --profile rocm). Same volumes as the NVIDIA
   # worker: run one profile or the other, not both.
   worker-rocm:
+    logging: *default-logging
     profiles: ["rocm"]
     build:
       context: ../..
@@ -81,6 +91,7 @@ services:
 
   # Simulated worker for smoke tests (docker compose --profile smoke).
   worker-sim:
+    logging: *default-logging
     profiles: ["smoke"]
     build:
       context: ../..

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -449,7 +449,7 @@ erDiagram
     users {
         uuid id PK
         text email
-        text role "user or admin"
+        text role "viewer, user (member), or admin"
         timestamptz deleted_at "starts 30 day purge"
         timestamptz created_at
     }

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -544,6 +544,12 @@ Supersedes issue #107's static-JSON-only position. Each completed suite run is o
 
 Rejected alternatives: keeping session history solely as committed static JSON, where each run overwrites the previous report, publishing runtime data requires a source-control operation, and the session picker can never show more than one run; scoping sessions to the account that ran them, which would hide an install's own hardware history from everyone but whoever happened to trigger the benchmark.
 
+## Roles: three tiers on the user row
+
+Access is a single `role` column on `users` with three values, checked by a dependency beside `current_user` rather than inside each endpoint: `admin` (everything, including install configuration), `user` (the member tier: generate, star, upload, manage their own work) and `viewer` (read-only, including the metrics section and benchmark history). The `AUTH_MODE=none` local user is an admin, and an existing local user is promoted on startup, so a single-user self-hosted install behaves exactly as before. This covers the requirement that a friend on someone's install may look without spending their GPU, and the cloud requirement that install-wide reads are not open to every customer.
+
+Rejected alternatives: a per-resource permission table, and admin-assignable per-tab grants, both of which add a matrix nobody has asked for and can be layered on these tiers later if a real need appears; no roles at all, which cannot express read-only access and leaves install-wide endpoints open to any authenticated account once the cloud has more than one.
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:

--- a/docs/deployment-profiles.md
+++ b/docs/deployment-profiles.md
@@ -87,6 +87,19 @@ flowchart TB
 
 The corresponding editable diagram is the Profile comparison page in [diagrams/](diagrams/).
 
+## Cloud-readiness ledger
+
+This table records local choices whose deferred consequences have a concrete
+scaling trigger. It is a status ledger, not a roadmap or a new decision record.
+
+| Local choice | Why it is safe today | Trigger that forces the change |
+|---|---|---|
+| **Database connection pooling.** `backend/app/db.py` uses `NullPool`, so each request and fire-and-forget write opens a connection. Tests currently drive requests and WebSockets on separate event loops, and asyncpg connections are loop-bound. | A single self-hosted API process has modest connection concurrency. | More than one API replica, or use of managed PostgreSQL with a connection ceiling. Move the tests to one event loop, then tune the pool per profile. |
+| **In-process queue and relay.** With `REDIS_URL` empty, dispatch uses an in-process heap and frame relay uses an in-process call. | One API process owns all workers and browser connections. | More than one API replica. Configure the Redis queue and frame bus described in [04 - Architecture seams](internals/04-architecture-seams.md). |
+| **Container log rotation.** Compose uses Docker's bounded `json-file` driver. | The self-hosted stack runs as Docker containers on one host. | The cloud deployment. ECS must use `awslogs`; the compose logging block does not apply there. |
+| **Shipped model timings.** `backend/app/estimates.py` reads committed `model_timings.json` measurements from one machine. | Estimates are advisory rather than billing or scheduling inputs in the current profile. | Any deployment on different hardware, including every packaged install. Measure and select timings for that hardware. |
+| **Worker and usage event retention.** Worker identities are pruned after 30 days; `usage_events` has no retention window. | Worker identity growth is bounded, and one self-hosted install produces a modest event volume. | `usage_events` reaching a size where the admin usage view or daily telemetry aggregation slows down. Add retention or partitioning based on measured query behavior. |
+
 ## Migration paths
 
 Every path below is possible because the schema, storage keys and API are identical everywhere. Paths that need a small tool name the issue that ships it; nothing here requires code the architecture does not already plan.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -120,7 +120,9 @@ The cardinality rule that keeps CloudWatch cheap: aggregates become metrics, det
 
 ## GPU fleet metrics
 
-The worker samples its card once per heartbeat - GPU utilization, VRAM used and total, temperature, power - via NVML on CUDA and amd-smi on ROCm, behind the same device layer as inference. The API fans each heartbeat out three ways: the `worker:{id}` Redis hash (the admin fleet view and the autoscaler read this), fleet-level CloudWatch aggregates (workers connected, slots in use and free, average and max GPU utilization, minimum VRAM free), and one JSON log line for history.
+The worker samples its card once per heartbeat - GPU utilization, VRAM used and total, temperature, power - with one `nvidia-smi` subprocess on CUDA or one combined `rocm-smi --json` subprocess on ROCm. The blocking hardware query runs through `asyncio.to_thread`, off the async event loop that relays realtime frames and dispatches jobs. The ROCm parser prefers structured output and retains the human-readable regex parsers as defensive fallbacks. The API fans each heartbeat out three ways: the `worker:{id}` Redis hash (the admin fleet view and the autoscaler read this), fleet-level CloudWatch aggregates (workers connected, slots in use and free, average and max GPU utilization, minimum VRAM free), and one JSON log line for history.
+
+In-process NVML and amd-smi bindings remain a possible future optimization with no licensing obstacle. They are not adopted here because each GPU family would add a new vendor dependency, while the single subprocess per heartbeat captures most of the benefit.
 
 A multi-GPU machine runs one worker process per GPU, pinned by device index, so every GPU is one connection, one heartbeat stream and one set of slots - the fleet view lists them all individually with no special casing. The admin area is the live many-GPU console; CloudWatch is for trends and alarms; Logs Insights is for the post-mortem on one specific worker.
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -64,6 +64,11 @@ docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
   rebuild the image) and restart the worker; see
   [third-party-models.md](third-party-models.md) for licensing notes.
 
+The bundled profile runs PostgreSQL 16. PostgreSQL 13 or newer is required if
+you point `DATABASE_URL` at an existing server. The API checks the server version
+before running migrations and starts in degraded mode with a clear warning when
+the server is too old.
+
 ## TLS and HSTS
 
 The API emits `Strict-Transport-Security: max-age=31536000` on every HTTP
@@ -99,6 +104,29 @@ upgrade an initial plain-HTTP connection.
 Back up `pgdata` and `assets` together: jobs and asset rows reference files
 by storage key, so restoring one without the other leaves dangling
 references. `hf-cache` and `models` are reproducible.
+
+## Logs
+
+Every service in `deploy/compose/compose.yml` uses Docker's `json-file`
+logging driver with five 10 MB files per container. The files live in Docker's
+data directory on the host, survive container restarts, and are removed when
+the container is removed. Read them with:
+
+```bash
+docker compose -f deploy/compose/compose.yml logs
+docker compose -f deploy/compose/compose.yml logs -f api worker
+```
+
+To change the approximately 50 MB per-container limit, edit `max-size` or
+`max-file` in the `x-logging` block and recreate the services. Job state,
+`jobs.failure_reason`, phase timings, GPU sample history, and usage events are
+operational records in PostgreSQL; container logs retain the remaining process
+detail such as startup, protocol, driver, and traceback messages.
+
+The API sends the anonymous daily aggregate documented in
+[metrics.md](metrics.md) by default. Set `TELEMETRY=false` in
+`deploy/compose/.env` and recreate the API service to disable it. The exact
+next payload is available from `GET /api/v1/telemetry/preview`.
 
 ## Updating
 

--- a/worker/tests/test_gpu_metrics.py
+++ b/worker/tests/test_gpu_metrics.py
@@ -1,4 +1,4 @@
-from worker.gpu_metrics import sample_gpu
+from worker.gpu_metrics import _parse_rocm_metrics, sample_gpu
 
 
 def test_sample_gpu_cpu_is_unavailable(monkeypatch):
@@ -20,31 +20,83 @@ def test_sample_gpu_merges_torch_vram(monkeypatch):
     assert snapshot["available"] is True
 
 
-def test_rocm_metrics_parses_smi_output(monkeypatch):
-    def fake_run(command):
-        joined = " ".join(command)
-        if "--showuse" in joined:
-            return "GPU[0] : GPU use (%): 73"
-        if "--showtemp" in joined:
-            return "Temperature (Sensor edge) (C): 61.0"
-        if "--showpower" in joined:
-            return "Average Graphics Package Power (W): 88.0"
-        if "--showmeminfo" in joined:
-            return "VRAM Total Memory (B): 17163091968\nVRAM Total Used Memory (B): 8589934592"
-        return ""
-
-    monkeypatch.setattr("worker.gpu_metrics._run_smi", fake_run)
+def test_sample_gpu_never_raises_when_collectors_fail(monkeypatch):
     monkeypatch.setattr("worker.gpu_metrics.shutil.which", lambda name: "/usr/bin/rocm-smi")
-    monkeypatch.setattr("worker.gpu_metrics._torch_vram_bytes", lambda: None)
-    from worker.gpu_metrics import _rocm_metrics
+    monkeypatch.setattr(
+        "worker.gpu_metrics._rocm_metrics",
+        lambda: (_ for _ in ()).throw(RuntimeError("collector failed")),
+    )
+    monkeypatch.setattr(
+        "worker.gpu_metrics._torch_vram_bytes",
+        lambda: (_ for _ in ()).throw(RuntimeError("torch failed")),
+    )
+    assert sample_gpu("rocm") == {
+        "device": "rocm",
+        "available": False,
+    }
 
-    metrics = _rocm_metrics()
+
+def test_rocm_metrics_parses_combined_json():
+    captured = """{
+  "card0": {
+    "GPU use (%)": "73",
+    "Temperature (Sensor edge) (C)": "61.0",
+    "Average Graphics Package Power (W)": "88.0",
+    "VRAM Total Memory (B)": "17163091968",
+    "VRAM Total Used Memory (B)": "8589934592"
+  }
+}"""
+    metrics = _parse_rocm_metrics(captured)
     assert metrics["util_pct"] == 73
     assert metrics["temperature_c"] == 61.0
     assert metrics["power_w"] == 88.0
-    metrics = _rocm_metrics()
     assert metrics["vram_used_bytes"] == 8589934592
     assert metrics["vram_total_bytes"] == 17163091968
+
+
+def test_rocm_metrics_regex_fallback_parses_combined_text():
+    captured = """GPU[0] : GPU use (%): 73
+GPU[0] : Temperature (Sensor edge) (C): 61.0
+GPU[0] : Average Graphics Package Power (W): 88.0
+GPU[0] : VRAM Total Memory (B): 17163091968
+GPU[0] : VRAM Total Used Memory (B): 8589934592"""
+    metrics = _parse_rocm_metrics(captured)
+    assert metrics == {
+        "util_pct": 73,
+        "temperature_c": 61.0,
+        "power_w": 88.0,
+        "vram_used_bytes": 8589934592,
+        "vram_total_bytes": 17163091968,
+    }
+
+
+def test_rocm_metrics_regex_fallback_parses_existing_per_flag_text():
+    captured = """GPU[0] : GPU use (%): 73
+Temperature (Sensor edge) (C): 61.0
+Average Graphics Package Power (W): 88.0
+VRAM Total Memory (B): 17163091968
+VRAM Total Used Memory (B): 8589934592"""
+    metrics = _parse_rocm_metrics(captured)
+    assert metrics["util_pct"] == 73
+    assert metrics["temperature_c"] == 61.0
+    assert metrics["power_w"] == 88.0
+    assert metrics["vram_used_bytes"] == 8589934592
+    assert metrics["vram_total_bytes"] == 17163091968
+
+
+def test_rocm_metrics_uses_one_combined_call(monkeypatch):
+    calls = []
+
+    def fake_run(command):
+        calls.append(command)
+        return ""
+
+    monkeypatch.setattr("worker.gpu_metrics._run_smi", fake_run)
+    from worker.gpu_metrics import _rocm_metrics
+
+    assert _rocm_metrics() == {}
+    assert len(calls) == 1
+    assert calls[0][-1] == "--json"
 
 
 def test_rocm_gpu0_vram_parses_discrete_gpu():

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -334,11 +334,12 @@ async def serve_connection(ws, settings: Settings, manifests: list[Manifest],
     async def heartbeats() -> None:
         while True:
             await asyncio.sleep(settings.heartbeat_seconds)
+            gpu = await asyncio.to_thread(sample_gpu, settings.device)
             await ws.send(json.dumps({
                 "type": "heartbeat",
                 "slots_in_use": len(runners),
                 "loaded_models": engine.loaded_models(),
-                "gpu": sample_gpu(settings.device),
+                "gpu": gpu,
             }))
 
     heartbeat_task = asyncio.create_task(heartbeats())
@@ -384,11 +385,12 @@ async def serve_connection(ws, settings: Settings, manifests: list[Manifest],
                         jobs.add(task)
                         task.add_done_callback(jobs.discard)
                     elif control["type"] == "gpu_status":
+                        gpu = await asyncio.to_thread(sample_gpu, settings.device)
                         await ws.send(json.dumps({
                             "type": "gpu_status",
                             "request_id": control["request_id"],
                             "loaded_models": engine.loaded_models(),
-                            "gpu": sample_gpu(settings.device),
+                            "gpu": gpu,
                         }))
                     elif control["type"] == "load_model":
                         await _gpu_load(ws, engine, by_id, control)

--- a/worker/worker/gpu_metrics.py
+++ b/worker/worker/gpu_metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import subprocess
@@ -66,9 +67,12 @@ def _torch_vram_bytes() -> tuple[int, int] | None:
         import torch
     except ImportError:
         return None
-    if not torch.cuda.is_available():
+    try:
+        if not torch.cuda.is_available():
+            return None
+        free, total = torch.cuda.mem_get_info()
+    except Exception:
         return None
-    free, total = torch.cuda.mem_get_info()
     used = int(total) - int(free)
     return used, int(total)
 
@@ -122,31 +126,66 @@ def _rocm_gpu0_vram_bytes(mem_text: str) -> tuple[int, int] | None:
     return None
 
 
-def _rocm_metrics() -> dict[str, Any]:
+def _json_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        match = re.search(r"-?\d+(?:\.\d+)?", value.replace(",", ""))
+        if match:
+            return float(match.group(0))
+    return None
+
+
+def _parse_rocm_json(text: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    card = next((value for value in payload.values() if isinstance(value, dict)), payload)
     metrics: dict[str, Any] = {}
-    use_text = _run_smi(["rocm-smi", "--showuse"])
-    util = _parse_util(use_text)
+    for key, value in card.items():
+        name = str(key).lower()
+        number = _json_number(value)
+        if number is None:
+            continue
+        if "gpu use" in name and "(%)" in name:
+            metrics["util_pct"] = int(number)
+        elif "temperature" in name and "(c)" in name:
+            metrics["temperature_c"] = number
+        elif "power" in name and "(w)" in name:
+            metrics["power_w"] = number
+        elif "vram total used memory" in name and "(b)" in name:
+            metrics["vram_used_bytes"] = int(number)
+        elif "vram total memory" in name and "(b)" in name:
+            metrics["vram_total_bytes"] = int(number)
+    return metrics
+
+
+def _parse_rocm_text(text: str) -> dict[str, Any]:
+    metrics: dict[str, Any] = {}
+    util = _parse_util(text)
     if util is not None:
         metrics["util_pct"] = util
 
-    temp_text = _run_smi(["rocm-smi", "--showtemp"])
-    temp = _parse_temperature(temp_text)
+    temp = _parse_temperature(text)
     if temp is not None:
         metrics["temperature_c"] = temp
 
-    power_text = _run_smi(["rocm-smi", "--showpower"])
-    power = _parse_power(power_text)
+    power = _parse_power(text)
     if power is not None:
         metrics["power_w"] = power
 
-    mem_text = _run_smi(["rocm-smi", "--showmeminfo", "vram"])
-    gpu0_vram = _rocm_gpu0_vram_bytes(mem_text)
+    gpu0_vram = _rocm_gpu0_vram_bytes(text)
     if gpu0_vram is not None:
         used, total = gpu0_vram
         metrics["vram_used_bytes"] = used
         metrics["vram_total_bytes"] = total
     else:
-        pair = _VRAM_PAIR_RE.search(mem_text.replace(",", " "))
+        pair = _VRAM_PAIR_RE.search(text.replace(",", " "))
         if pair:
             used = int(pair.group(1))
             total = int(pair.group(2))
@@ -154,8 +193,8 @@ def _rocm_metrics() -> dict[str, Any]:
                 metrics["vram_used_bytes"] = used
                 metrics["vram_total_bytes"] = total
         else:
-            used_match = _VRAM_USED_B_RE.search(mem_text)
-            total_match = _VRAM_TOTAL_B_RE.search(mem_text)
+            used_match = _VRAM_USED_B_RE.search(text)
+            total_match = _VRAM_TOTAL_B_RE.search(text)
             if used_match and total_match:
                 used = int(used_match.group(1))
                 total = int(total_match.group(1))
@@ -163,6 +202,26 @@ def _rocm_metrics() -> dict[str, Any]:
                     metrics["vram_used_bytes"] = used
                     metrics["vram_total_bytes"] = total
     return metrics
+
+
+def _parse_rocm_metrics(text: str) -> dict[str, Any]:
+    metrics = _parse_rocm_json(text)
+    for key, value in _parse_rocm_text(text).items():
+        metrics.setdefault(key, value)
+    return metrics
+
+
+def _rocm_metrics() -> dict[str, Any]:
+    text = _run_smi([
+        "rocm-smi",
+        "--showuse",
+        "--showtemp",
+        "--showpower",
+        "--showmeminfo",
+        "vram",
+        "--json",
+    ])
+    return _parse_rocm_metrics(text)
 
 
 def _attach_vram_pct(metrics: dict[str, Any]) -> None:
@@ -180,12 +239,18 @@ def sample_gpu(device: str) -> dict[str, Any]:
         metrics["available"] = False
         return metrics
 
-    if device == "rocm" and shutil.which("rocm-smi"):
-        metrics.update(_rocm_metrics())
-    elif device == "cuda" and shutil.which("nvidia-smi"):
-        metrics.update(_nvidia_metrics())
+    try:
+        if device == "rocm" and shutil.which("rocm-smi"):
+            metrics.update(_rocm_metrics())
+        elif device == "cuda" and shutil.which("nvidia-smi"):
+            metrics.update(_nvidia_metrics())
+    except Exception:
+        pass
 
-    vram = _torch_vram_bytes()
+    try:
+        vram = _torch_vram_bytes()
+    except Exception:
+        vram = None
     if vram is not None:
         used, total = vram
         metrics.setdefault("vram_used_bytes", used)


### PR DESCRIPTION
# Description

The cross-cutting hardening left over from the persistence work: role tiers, GPU sampling that cannot stall the realtime relay, container log rotation for self-hosted installs, a PostgreSQL version guard, and a ledger of what must change before the cloud profile.

No migration: the `role` column already existed on `users` and was unused.

# Functionality

**Roles.** One `role` column, three tiers, checked by a dependency beside `current_user` rather than inside each endpoint:

- `admin`: everything, including install configuration and the telemetry preview.
- `user` (the member tier): generate, star, upload, manage their own work.
- `viewer`: read-only, and still sees history, the metrics section and benchmark history.

Writes require member or higher. `GET /api/v1/telemetry/preview` is admin-only, because it aggregates every account on the install and would be cross-tenant in the cloud. The `AUTH_MODE=none` local user is created as an admin, and an existing one is promoted at startup, so a single-user self-hosted install behaves exactly as before.

**GPU sampling off the event loop.** `sample_gpu` ran synchronously on the loop that also relays realtime canvas frames and dispatches jobs, and on ROCm it spawned four `rocm-smi` subprocesses per heartbeat with a three second timeout each, so a wedged tool could stall frame delivery for twelve seconds. Sampling now runs through `asyncio.to_thread`, and ROCm uses one combined `rocm-smi --json` call.

**Container log rotation.** One shared `json-file` anchor at 10 MB by 5 files per service, so history survives a restart and cannot fill the volume.

**PostgreSQL 13 guard.** `gen_random_uuid()` entered core in 13. A self-hoster pointing `DATABASE_URL` at an older server previously failed part way through migrating with an opaque error; it now degrades with an actionable message naming the required and detected versions.

**Cloud-readiness ledger** in `docs/deployment-profiles.md`: each local-only choice, why it is safe today, and the concrete trigger that forces the change. Seeded with the `NullPool` connection strategy, the in-process queue and relay, Docker-only log rotation, shipped model timings, and usage event retention.

# Details

- The ROCm structured-output path could not be exercised: the GPU was running a benchmark for most of this work, and a bare parser test is worth more than a tool invocation anyway. Every human-readable regex parser is retained as a fallback, sampling never raises, and the parsers are covered with captured text. The real-hardware path is unexercised and that is stated rather than implied.
- In-process NVML and amd-smi bindings remain a future option with no licensing obstacle, deliberately not adopted because each GPU family would add a vendor dependency while one subprocess per heartbeat captures most of the benefit.
- `role="member"` is accepted at the dependency layer but stored as `"user"`, keeping the existing column value. An unknown role fails closed.
- Log rotation is Docker-specific and does not apply to ECS, which uses `awslogs`. Recorded in the ledger.
- Removing a container still discards its logs; `docker compose down && up` during an upgrade loses history. Documented rather than worked around.
- Not included: per-user or per-tab permission grants, and WebSocket authentication. `/api/v1/realtime` still derives identity from the implicit local user, and that seam is marked in `realtime.py` for the accounts milestone.

Verified with `make verify` (backend 90 passed, worker 63 passed, frontend lint, svelte-check 0 errors, both builds with the CSP check) and `scripts/compose-smoke.sh`.
