### PR TITLE
Cover the job usage event and document the role requirements

### DIFF
--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -128,15 +128,19 @@ def test_generation_end_to_end():
             async def usage_written() -> bool:
                 assert db.session_factory is not None
                 async with db.session_factory() as session:
+                    # Select the row this case waits for rather than the newest
+                    # for the model: another case writing a later event for the
+                    # same model would otherwise make this flaky.
                     row = (
                         await session.execute(
-                            select(UsageEvent)
-                            .where(UsageEvent.model_id == "sd-test")
-                            .order_by(UsageEvent.created_at.desc())
-                            .limit(1)
+                            select(UsageEvent).where(
+                                UsageEvent.model_id == "sd-test",
+                                UsageEvent.kind == "job",
+                                UsageEvent.action == "generate",
+                            ).order_by(UsageEvent.created_at.desc()).limit(1)
                         )
                     ).scalar_one_or_none()
-                    return row is not None and row.kind == "job" and row.action == "generate"
+                    return row is not None
 
             deadline = time.monotonic() + 3
             while time.monotonic() < deadline and not asyncio.run(usage_written()):

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -8,12 +8,13 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlsplit
 
 import pytest
+from sqlalchemy import select
 from fastapi.testclient import TestClient
 
 from app import db
 from app.main import app
 from app.realtime import PROTOCOL_VERSION
-from app.tables import Asset, Job, Model
+from app.tables import Asset, Job, Model, UsageEvent
 
 MANIFEST = {
     "id": "sd-test",
@@ -123,6 +124,24 @@ def test_generation_end_to_end():
             # The event stream replays the terminal state and ends.
             events = client.get(f"/api/v1/generations/{job_id}/events")
             assert "succeeded" in events.text
+
+            async def usage_written() -> bool:
+                assert db.session_factory is not None
+                async with db.session_factory() as session:
+                    row = (
+                        await session.execute(
+                            select(UsageEvent)
+                            .where(UsageEvent.model_id == "sd-test")
+                            .order_by(UsageEvent.created_at.desc())
+                            .limit(1)
+                        )
+                    ).scalar_one_or_none()
+                    return row is not None and row.kind == "job" and row.action == "generate"
+
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline and not asyncio.run(usage_written()):
+                time.sleep(0.05)
+            assert asyncio.run(usage_written())
 
 
 @pytest.mark.db

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlsplit
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 from fastapi.testclient import TestClient
 
 from app import db
@@ -64,6 +64,22 @@ def test_generation_end_to_end():
 
             models = client.get("/api/v1/models").json()
             assert any(m["id"] == "sd-test" for m in models)
+
+            async def job_events() -> int:
+                assert db.session_factory is not None
+                async with db.session_factory() as session:
+                    return int(await session.scalar(
+                        select(func.count()).select_from(UsageEvent).where(
+                            UsageEvent.model_id == "sd-test",
+                            UsageEvent.kind == "job",
+                            UsageEvent.action == "generate",
+                        )
+                    ) or 0)
+
+            # usage_events carries no job id, and the database is truncated once
+            # per session, so this job's row is identified by the count rising
+            # rather than by any matching row existing.
+            events_before = asyncio.run(job_events())
 
             created = client.post("/api/v1/generations",
                                   json={"model_id": "sd-test",
@@ -125,27 +141,13 @@ def test_generation_end_to_end():
             events = client.get(f"/api/v1/generations/{job_id}/events")
             assert "succeeded" in events.text
 
-            async def usage_written() -> bool:
-                assert db.session_factory is not None
-                async with db.session_factory() as session:
-                    # Select the row this case waits for rather than the newest
-                    # for the model: another case writing a later event for the
-                    # same model would otherwise make this flaky.
-                    row = (
-                        await session.execute(
-                            select(UsageEvent).where(
-                                UsageEvent.model_id == "sd-test",
-                                UsageEvent.kind == "job",
-                                UsageEvent.action == "generate",
-                            ).order_by(UsageEvent.created_at.desc()).limit(1)
-                        )
-                    ).scalar_one_or_none()
-                    return row is not None
+            def usage_written() -> bool:
+                return asyncio.run(job_events()) > events_before
 
             deadline = time.monotonic() + 3
-            while time.monotonic() < deadline and not asyncio.run(usage_written()):
+            while time.monotonic() < deadline and not usage_written():
                 time.sleep(0.05)
-            assert asyncio.run(usage_written())
+            assert usage_written()
 
 
 @pytest.mark.db

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,9 +8,11 @@ Every call a customer's browser makes, from first page load to account deletion.
 
 - Base path `/api/v1`. JSON request and response bodies.
 - Authentication is a session cookie (opaque token, httpOnly), set by the auth endpoints (issue #5). Until those ship, the prototype endpoints are unauthenticated and run as a single implicit local user (`AUTH_MODE=none`).
-- Authorization is the `role` column on the user: `admin` (everything, plus install
-  configuration), `user` (the member tier: create and mutate own work) and `viewer`
-  (read-only). Write endpoints require member or higher and answer 403 for a viewer.
+- Authorization is the `role` column on the user, ranked `viewer` < `user` < `admin`:
+  `admin` covers everything including install configuration, `user` creates and mutates
+  its own work, `viewer` is read-only. Write endpoints require `user` or `admin` and
+  answer 403 for a `viewer`. The code calls the `user` tier "member" in
+  `require_role("member")`; the stored value is `user`.
 - REST errors use FastAPI's shape: `{"detail": "..."}` with a conventional status code.
 - WebSocket errors are control messages `{"type": "error", "code": <int>, "message": "..."}` followed by a close with the same code; the code table is in [connection-handling.md](connection-handling.md).
 - API versioning is the path prefix. The worker protocol versions independently with an N-1 compatibility promise.
@@ -119,7 +121,7 @@ Registered models, each with its JSON-Schema `parameters` and its measured GPU-t
 `POST` queues a job; the job endpoint and the SSE stream report progress; the list endpoint is the history.
 
 ```
-POST /api/v1/generations     member or admin; viewer receives 403
+POST /api/v1/generations     user or admin; viewer receives 403
                              {"model_id": "sdxl-base", "params": {"prompt": "a castle at sunset"}}
                              model_id is REQUIRED. For image_to_image or upscale, also pass
                              "source_asset_id"; upscale requires a source and is mutually
@@ -140,9 +142,9 @@ GET /api/v1/generations      generation history: a list of jobs, each with its n
 
 GET /api/v1/generations/{id}/events   server-sent events: progress ticks until a terminal state
 
-POST /api/v1/generations/{id}/star    member or admin; 204; idempotent, 403 for viewer,
+POST /api/v1/generations/{id}/star    user or admin; 204; idempotent, 403 for viewer,
                                       404 for another user's or missing job
-DELETE /api/v1/generations/{id}/star  member or admin; 204; idempotent, 403 for viewer,
+DELETE /api/v1/generations/{id}/star  user or admin; 204; idempotent, 403 for viewer,
                                       404 for another user's or missing job
 ```
 
@@ -160,7 +162,7 @@ GET /api/v1/metrics/gpu/history        ?from&to&rollup - GPU samples over a rang
                                         (30d retention) for the requested window. See metrics.md.
 GET  /api/v1/benchmark/models          list benchmarkable models (BENCHMARK_API-gated)
 POST /api/v1/benchmark/{load|unload|run}   drive a model for a benchmark run
-POST /api/v1/benchmark/sessions       member or admin; BENCHMARK_API-gated completed
+POST /api/v1/benchmark/sessions       user or admin; BENCHMARK_API-gated completed
                                         scripts/benchmark.py report;
                                         201 {"id": "..."}; 404 when the benchmark API is disabled;
                                         malformed reports return 422
@@ -169,7 +171,7 @@ GET  /api/v1/benchmark/sessions       200 newest-first install-scoped session su
                                         session id as ?cursor to read the next page
 GET  /api/v1/benchmark/sessions/{id}  200 full report in the existing results.json shape;
                                         404 for a missing session
-GET  /api/v1/telemetry/preview        admin only; 403 for viewer or member; 200 exact previous
+GET  /api/v1/telemetry/preview        admin only; 403 for viewer or user; 200 exact previous
                                         UTC day's anonymous aggregate payload;
                                         503 when the database is unavailable
 PUT  /api/v1/files/{key}               local-storage upload target (self-hosted, non-S3); a PUT is

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,9 @@ Every call a customer's browser makes, from first page load to account deletion.
 
 - Base path `/api/v1`. JSON request and response bodies.
 - Authentication is a session cookie (opaque token, httpOnly), set by the auth endpoints (issue #5). Until those ship, the prototype endpoints are unauthenticated and run as a single implicit local user (`AUTH_MODE=none`).
+- Authorization is the `role` column on the user: `admin` (everything, plus install
+  configuration), `user` (the member tier: create and mutate own work) and `viewer`
+  (read-only). Write endpoints require member or higher and answer 403 for a viewer.
 - REST errors use FastAPI's shape: `{"detail": "..."}` with a conventional status code.
 - WebSocket errors are control messages `{"type": "error", "code": <int>, "message": "..."}` followed by a close with the same code; the code table is in [connection-handling.md](connection-handling.md).
 - API versioning is the path prefix. The worker protocol versions independently with an N-1 compatibility promise.
@@ -116,7 +119,8 @@ Registered models, each with its JSON-Schema `parameters` and its measured GPU-t
 `POST` queues a job; the job endpoint and the SSE stream report progress; the list endpoint is the history.
 
 ```
-POST /api/v1/generations     {"model_id": "sdxl-base", "params": {"prompt": "a castle at sunset"}}
+POST /api/v1/generations     member or admin; viewer receives 403
+                             {"model_id": "sdxl-base", "params": {"prompt": "a castle at sunset"}}
                              model_id is REQUIRED. For image_to_image or upscale, also pass
                              "source_asset_id"; upscale requires a source and is mutually
                              exclusive with the diffusion capabilities.
@@ -136,8 +140,10 @@ GET /api/v1/generations      generation history: a list of jobs, each with its n
 
 GET /api/v1/generations/{id}/events   server-sent events: progress ticks until a terminal state
 
-POST /api/v1/generations/{id}/star    204; idempotent, 404 for another user's or missing job
-DELETE /api/v1/generations/{id}/star  204; idempotent, 404 for another user's or missing job
+POST /api/v1/generations/{id}/star    member or admin; 204; idempotent, 403 for viewer,
+                                      404 for another user's or missing job
+DELETE /api/v1/generations/{id}/star  member or admin; 204; idempotent, 403 for viewer,
+                                      404 for another user's or missing job
 ```
 
 Progress also streams as control messages over the realtime WebSocket once issue #19 lands. A failed job (after its single automatic retry) carries the refunded state and the UI shows a retry button.
@@ -154,7 +160,8 @@ GET /api/v1/metrics/gpu/history        ?from&to&rollup - GPU samples over a rang
                                         (30d retention) for the requested window. See metrics.md.
 GET  /api/v1/benchmark/models          list benchmarkable models (BENCHMARK_API-gated)
 POST /api/v1/benchmark/{load|unload|run}   drive a model for a benchmark run
-POST /api/v1/benchmark/sessions       BENCHMARK_API-gated completed scripts/benchmark.py report;
+POST /api/v1/benchmark/sessions       member or admin; BENCHMARK_API-gated completed
+                                        scripts/benchmark.py report;
                                         201 {"id": "..."}; 404 when the benchmark API is disabled;
                                         malformed reports return 422
 GET  /api/v1/benchmark/sessions       200 newest-first install-scoped session summaries;
@@ -162,7 +169,8 @@ GET  /api/v1/benchmark/sessions       200 newest-first install-scoped session su
                                         session id as ?cursor to read the next page
 GET  /api/v1/benchmark/sessions/{id}  200 full report in the existing results.json shape;
                                         404 for a missing session
-GET  /api/v1/telemetry/preview        200 exact previous UTC day's anonymous aggregate payload;
+GET  /api/v1/telemetry/preview        admin only; 403 for viewer or member; 200 exact previous
+                                        UTC day's anonymous aggregate payload;
                                         503 when the database is unavailable
 PUT  /api/v1/files/{key}               local-storage upload target (self-hosted, non-S3); a PUT is
                                         authorized only for a storage key the API minted in-flight


### PR DESCRIPTION
# Description

Two gaps found by auditing the four-way split of the persistence work against the integrated branch it was cut from.

# Functionality

- Restores the assertion that a completed job writes a `usage_events` row. It was removed from #159 because it belonged with usage metrics, and never restored when #161 landed, so the queued-job path was uncovered while the realtime path was tested.
- `docs/api.md` documents the role requirements #164 enforces. The reference still described the write endpoints and the telemetry preview as callable by any account, when they now require member or admin and answer 403 for a viewer.

# Details

- Found by diffing `main` against the pre-split snapshot and looking for lines that existed there but reached no PR. Worth repeating after any future split: a partition can pass every branch's own checks and still drop work, because nothing fails when a test simply is not there.
- No production code changes.
- Verified with `make verify`: backend 90 passed, worker 63 passed, frontend lint, svelte-check 0 errors, both builds with the CSP check.
