### PR TITLE
Drive generation updates from the event stream instead of polling

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -152,9 +152,11 @@ The studio opens at most four generation event streams. An `EventSource` error
 before or after the initial event moves that job to the 1.5-second history
 polling fallback; jobs above the stream cap share the same fallback refresh.
 After a streamed terminal event, the studio reads that generation once so its
-final row, timings and assets equal a history poll. Active streams also reconcile
-their single job row every 15 seconds, so a cross-replica event missed during a
-relay interruption cannot leave a spinner running forever.
+final row, timings and assets equal a history poll. A missed cross-replica event
+cannot leave a spinner running forever, by one of two paths: while every working
+job is streamed, each streamed row is reconciled on its own every 15 seconds;
+while any job is on the fallback, the 1.5-second history refresh already covers
+every row, streamed or not.
 
 Progress also streams as control messages over the realtime WebSocket once issue #19 lands. A failed job (after its single automatic retry) carries the refunded state and the UI shows a retry button.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -148,6 +148,14 @@ DELETE /api/v1/generations/{id}/star  user or admin; 204; idempotent, 403 for vi
                                       404 for another user's or missing job
 ```
 
+The studio opens at most four generation event streams. An `EventSource` error
+before or after the initial event moves that job to the 1.5-second history
+polling fallback; jobs above the stream cap share the same fallback refresh.
+After a streamed terminal event, the studio reads that generation once so its
+final row, timings and assets equal a history poll. Active streams also reconcile
+their single job row every 15 seconds, so a cross-replica event missed during a
+relay interruption cannot leave a spinner running forever.
+
 Progress also streams as control messages over the realtime WebSocket once issue #19 lands. A failed job (after its single automatic retry) carries the refunded state and the UI shows a retry button.
 
 <!-- Corrected 2026-07-23: model_id is required (was documented optional with tier routing, which is unshipped); history is GET /api/v1/generations (was mislabeled GET /api/v1/assets); added shipped response fields and the SSE events endpoint. -->

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -135,6 +135,8 @@ const generationStreams = new Map<string, EventSource>();
 const failedGenerationStreams = new Set<string>();
 const pendingTerminalRefreshes = new Set<string>();
 const generationRefreshesInFlight = new Set<string>();
+const terminalRefreshAttempts = new Map<string, number>();
+const MAX_TERMINAL_REFRESH_ATTEMPTS = 3;
 
 // Diffusion models drive the generate form and the sidebar picker; upscalers
 // are reached only through the Upscale action (issue #91). Every model list
@@ -391,24 +393,51 @@ function closeGenerationStream(id: string): void {
 	generationStreams.delete(id);
 }
 
+function abandonTerminalRefresh(id: string): void {
+	// Give up rather than leave the entry pending: the loop keeps running while
+	// anything is pending, so a refresh that can never succeed would poll forever.
+	closeGenerationStream(id);
+	pendingTerminalRefreshes.delete(id);
+	terminalRefreshAttempts.delete(id);
+}
+
 async function refreshGeneration(id: string): Promise<void> {
 	if (generationRefreshesInFlight.has(id)) return;
 	generationRefreshesInFlight.add(id);
 	try {
 		const response = await fetch(`/api/v1/generations/${id}`);
-		if (!response.ok) return;
+		if (response.status === 404) {
+			// The generation is gone; retrying cannot change that.
+			abandonTerminalRefresh(id);
+			return;
+		}
+		if (!response.ok) {
+			countTerminalRefreshFailure(id);
+			return;
+		}
 		const generation = (await response.json()) as Generation;
 		replaceGeneration(generation);
 		if (generation.state === 'succeeded' || generation.state === 'failed') {
 			closeGenerationStream(id);
 			pendingTerminalRefreshes.delete(id);
+			terminalRefreshAttempts.delete(id);
 		}
 	} catch {
-		// The update loop retries terminal refreshes. A running stream gets
-		// another low-rate reconciliation without affecting its live events.
+		countTerminalRefreshFailure(id);
 	} finally {
 		generationRefreshesInFlight.delete(id);
 	}
+}
+
+function countTerminalRefreshFailure(id: string): void {
+	if (!pendingTerminalRefreshes.has(id)) return;
+	const attempts = (terminalRefreshAttempts.get(id) ?? 0) + 1;
+	if (attempts >= MAX_TERMINAL_REFRESH_ATTEMPTS) {
+		// The next full history refresh reconciles this row.
+		abandonTerminalRefresh(id);
+		return;
+	}
+	terminalRefreshAttempts.set(id, attempts);
 }
 
 function subscribeToGeneration(id: string): void {
@@ -476,6 +505,7 @@ export function stopGenerationUpdates(): void {
 	for (const id of generationStreams.keys()) closeGenerationStream(id);
 	failedGenerationStreams.clear();
 	pendingTerminalRefreshes.clear();
+	terminalRefreshAttempts.clear();
 }
 
 export async function pollWhileWorking(): Promise<void> {

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -46,6 +46,8 @@ export type Generation = {
 };
 
 const HISTORY_LIMIT = 50;
+const MAX_GENERATION_STREAMS = 4;
+const STREAM_RECONCILE_MS = 15_000;
 const STARRED_STORAGE_KEY = 'potocolom-starred';
 
 function loadStarredIds(): string[] {
@@ -120,6 +122,19 @@ let polling = false;
 // Without this, `if (polling) return` drops the request in the race between the
 // last idle check and `polling = false`, and the UI stops refreshing until reload.
 let pollRequested = false;
+let updatesEnabled = true;
+
+type GenerationEvent = {
+	job_id: string;
+	state: string;
+	progress?: number | null;
+	reason?: string;
+};
+
+const generationStreams = new Map<string, EventSource>();
+const failedGenerationStreams = new Set<string>();
+const pendingTerminalRefreshes = new Set<string>();
+const generationRefreshesInFlight = new Set<string>();
 
 // Diffusion models drive the generate form and the sidebar picker; upscalers
 // are reached only through the Upscale action (issue #91). Every model list
@@ -256,6 +271,33 @@ export function generationById(id: string): Generation | undefined {
 	);
 }
 
+function replaceGeneration(incoming: Generation): void {
+	const replace = (generations: Generation[]) =>
+		generations.map((generation) =>
+			generation.id === incoming.id ? preserveAssetUrls([incoming], [generation])[0] : generation
+		);
+	studio.history = replace(studio.history);
+	studio.historyRecent = replace(studio.historyRecent);
+	studio.starredExtras = replace(studio.starredExtras);
+}
+
+function applyGenerationEvent(event: GenerationEvent): void {
+	const apply = (generations: Generation[]) =>
+		generations.map((generation) => {
+			if (generation.id !== event.job_id) return generation;
+			return {
+				...generation,
+				state: event.state,
+				progress: event.state === 'running' ? (event.progress ?? generation.progress) : null,
+				failure_reason:
+					event.state === 'failed' ? (event.reason ?? generation.failure_reason) : null
+			};
+		});
+	studio.history = apply(studio.history);
+	studio.historyRecent = apply(studio.historyRecent);
+	studio.starredExtras = apply(studio.starredExtras);
+}
+
 export function starredGenerations(): Generation[] {
 	return studio.starredIds.flatMap((id) => {
 		const generation = generationById(id);
@@ -264,8 +306,8 @@ export function starredGenerations(): Generation[] {
 }
 
 // History refreshes cannot change which generations are starred, only whether a
-// favorite is already on the page. Reconciling locally keeps the 1.5s polling
-// loop from re-paginating the whole favorites list on every tick.
+// favorite is already on the page. Reconciling locally keeps fallback history
+// refreshes from re-paginating the whole favorites list.
 export function reconcileStarredExtras(): void {
 	const historyIds = new Set(studio.history.map((generation) => generation.id));
 	studio.starredExtras = studio.starredExtras.filter(
@@ -344,29 +386,138 @@ export function toggleStarred(id: string): void {
 		});
 }
 
+function closeGenerationStream(id: string): void {
+	generationStreams.get(id)?.close();
+	generationStreams.delete(id);
+}
+
+async function refreshGeneration(id: string): Promise<void> {
+	if (generationRefreshesInFlight.has(id)) return;
+	generationRefreshesInFlight.add(id);
+	try {
+		const response = await fetch(`/api/v1/generations/${id}`);
+		if (!response.ok) return;
+		const generation = (await response.json()) as Generation;
+		replaceGeneration(generation);
+		if (generation.state === 'succeeded' || generation.state === 'failed') {
+			closeGenerationStream(id);
+			pendingTerminalRefreshes.delete(id);
+		}
+	} catch {
+		// The update loop retries terminal refreshes. A running stream gets
+		// another low-rate reconciliation without affecting its live events.
+	} finally {
+		generationRefreshesInFlight.delete(id);
+	}
+}
+
+function subscribeToGeneration(id: string): void {
+	if (typeof EventSource === 'undefined') {
+		failedGenerationStreams.add(id);
+		return;
+	}
+	let source: EventSource;
+	try {
+		source = new EventSource(`/api/v1/generations/${id}/events`);
+	} catch {
+		failedGenerationStreams.add(id);
+		return;
+	}
+	generationStreams.set(id, source);
+	source.onmessage = (message) => {
+		let event: GenerationEvent;
+		try {
+			event = JSON.parse(message.data) as GenerationEvent;
+		} catch {
+			return;
+		}
+		if (event.job_id !== id) return;
+		applyGenerationEvent(event);
+		if (event.state === 'succeeded' || event.state === 'failed') {
+			closeGenerationStream(id);
+			pendingTerminalRefreshes.add(id);
+			void refreshGeneration(id);
+		}
+	};
+	source.onerror = () => {
+		if (generationStreams.get(id) !== source) return;
+		// This covers an error before the initial snapshot as well as a broken
+		// established stream. Polling is safer than relying on a reconnect that
+		// may have missed the terminal event.
+		closeGenerationStream(id);
+		failedGenerationStreams.add(id);
+		pollRequested = true;
+	};
+}
+
+function syncGenerationStreams(): boolean {
+	const working = studio.history.filter(
+		(generation) => generation.state === 'queued' || generation.state === 'running'
+	);
+	const workingIds = new Set(working.map((generation) => generation.id));
+	for (const id of generationStreams.keys()) {
+		if (!workingIds.has(id)) closeGenerationStream(id);
+	}
+	for (const id of failedGenerationStreams) {
+		if (!workingIds.has(id)) failedGenerationStreams.delete(id);
+	}
+	for (const generation of working) {
+		if (generationStreams.size >= MAX_GENERATION_STREAMS) break;
+		if (!generationStreams.has(generation.id) && !failedGenerationStreams.has(generation.id)) {
+			subscribeToGeneration(generation.id);
+		}
+	}
+	return working.some((generation) => !generationStreams.has(generation.id));
+}
+
+export function stopGenerationUpdates(): void {
+	updatesEnabled = false;
+	pollRequested = false;
+	for (const id of generationStreams.keys()) closeGenerationStream(id);
+	failedGenerationStreams.clear();
+	pendingTerminalRefreshes.clear();
+}
+
 export async function pollWhileWorking(): Promise<void> {
 	pollRequested = true;
+	updatesEnabled = true;
 	if (polling) return;
 	polling = true;
+	let nextStreamReconcile = Date.now() + STREAM_RECONCILE_MS;
 	try {
 		do {
 			pollRequested = false;
-			while (studio.history.some((g) => g.state === 'queued' || g.state === 'running')) {
+			while (
+				updatesEnabled &&
+				(studio.history.some((g) => g.state === 'queued' || g.state === 'running') ||
+					pendingTerminalRefreshes.size > 0)
+			) {
+				syncGenerationStreams();
 				await new Promise((resolve) => setTimeout(resolve, 1500));
-				try {
-					await loadHistory();
-				} catch {
-					continue;
+				if (!updatesEnabled) break;
+				if (syncGenerationStreams()) {
+					try {
+						await loadHistory();
+						nextStreamReconcile = Date.now() + STREAM_RECONCILE_MS;
+					} catch {
+						// Keep the fallback active until history answers again.
+					}
+				} else if (Date.now() >= nextStreamReconcile) {
+					await Promise.all([...generationStreams.keys()].map((id) => refreshGeneration(id)));
+					nextStreamReconcile = Date.now() + STREAM_RECONCILE_MS;
 				}
+				await Promise.all([...pendingTerminalRefreshes].map((id) => refreshGeneration(id)));
 			}
 			// Re-check: a generate() during the idle gap sets pollRequested and may
 			// have already refreshed history with new queued/running jobs.
 		} while (
-			pollRequested ||
-			studio.history.some((g) => g.state === 'queued' || g.state === 'running')
+			updatesEnabled &&
+			(pollRequested || studio.history.some((g) => g.state === 'queued' || g.state === 'running'))
 		);
 	} finally {
+		for (const id of generationStreams.keys()) closeGenerationStream(id);
+		failedGenerationStreams.clear();
 		polling = false;
-		if (pollRequested) void pollWhileWorking();
+		if (updatesEnabled && pollRequested) void pollWhileWorking();
 	}
 }

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -416,6 +416,8 @@ async function refreshGeneration(id: string): Promise<void> {
 			return;
 		}
 		const generation = (await response.json()) as Generation;
+		// The page may have unmounted while this was in flight.
+		if (!updatesEnabled) return;
 		replaceGeneration(generation);
 		if (generation.state === 'succeeded' || generation.state === 'failed') {
 			closeGenerationStream(id);

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -510,9 +510,17 @@ export function stopGenerationUpdates(): void {
 	terminalRefreshAttempts.clear();
 }
 
-export async function pollWhileWorking(): Promise<void> {
-	pollRequested = true;
+/** Enable updates for a mounted view. Only the route that mounts should call this. */
+export async function startGenerationUpdates(): Promise<void> {
 	updatesEnabled = true;
+	await pollWhileWorking();
+}
+
+export async function pollWhileWorking(): Promise<void> {
+	// Requesting a tick must not re-enable a stopped view: callers reach here from
+	// async work that can resolve after teardown.
+	if (!updatesEnabled) return;
+	pollRequested = true;
 	if (polling) return;
 	polling = true;
 	let nextStreamReconcile = Date.now() + STREAM_RECONCILE_MS;

--- a/frontend/src/routes/app/+page.svelte
+++ b/frontend/src/routes/app/+page.svelte
@@ -12,7 +12,7 @@
 		loadModels,
 		loadStarredGenerations,
 		migrateStoredFavorites,
-		pollWhileWorking,
+		startGenerationUpdates,
 		stopGenerationUpdates,
 		studio
 	} from '$lib/studio.svelte';
@@ -39,7 +39,7 @@
 			.then(loadStarredGenerations)
 			.then(() => {
 				if (cancelled) return;
-				return pollWhileWorking();
+				return startGenerationUpdates();
 			})
 			.catch(() => {
 				// Best-effort preload: the panel shows its empty states and the

--- a/frontend/src/routes/app/+page.svelte
+++ b/frontend/src/routes/app/+page.svelte
@@ -24,6 +24,10 @@
 	// of the studio. Product builds leave the variable empty.
 	const landing = PUBLIC_SITE_MODE === 'landing';
 
+	// Set on teardown: the preload chain can resolve after unmount, and starting
+	// the update loop then would run streams with no UI mounted.
+	let cancelled = false;
+
 	onMount(() => {
 		if (landing) return;
 		void loadModels();
@@ -33,14 +37,20 @@
 		void loadHistory()
 			.then(migrateStoredFavorites)
 			.then(loadStarredGenerations)
-			.then(pollWhileWorking)
+			.then(() => {
+				if (cancelled) return;
+				return pollWhileWorking();
+			})
 			.catch(() => {
 				// Best-effort preload: the panel shows its empty states and the
 				// poll loop recovers once the API answers.
 			});
 	});
 
-	onDestroy(stopGenerationUpdates);
+	onDestroy(() => {
+		cancelled = true;
+		stopGenerationUpdates();
+	});
 </script>
 
 <Seo

--- a/frontend/src/routes/app/+page.svelte
+++ b/frontend/src/routes/app/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { PUBLIC_SITE_MODE } from '$env/static/public';
 	import AppSidebar from '$lib/components/app-sidebar.svelte';
 	import GeneratePanel from '$lib/components/generate-panel.svelte';
@@ -13,6 +13,7 @@
 		loadStarredGenerations,
 		migrateStoredFavorites,
 		pollWhileWorking,
+		stopGenerationUpdates,
 		studio
 	} from '$lib/studio.svelte';
 	import { t } from '$lib/i18n.svelte';
@@ -38,6 +39,8 @@
 				// poll loop recovers once the API answers.
 			});
 	});
+
+	onDestroy(stopGenerationUpdates);
 </script>
 
 <Seo


### PR DESCRIPTION
# Description

The studio refreshed generation history by polling: `pollWhileWorking` called `loadHistory()` every 1500 ms for as long as any job was queued or running, and every response regenerated a storage URL for each asset, which is a presign per asset per poll once `STORAGE_BACKEND=s3`. The API already streamed exactly the state changes needed over `GET /api/v1/generations/{id}/events`, with `: keepalive` comments for long model loads and a terminal end, and nothing in the studio consumed it.

# Functionality

- Waiting generations subscribe to the per-job event stream and update from it, instead of the timer re-fetching the whole page.
- The terminal transition triggers one fetch of that generation, so final timings and assets match what a poll produced.
- Streams close when a job leaves the working set and when the studio unmounts.
- Concurrency is capped at four streams. Jobs above the cap, clients without `EventSource`, and streams that error before their first message fall back to the existing poll, so behaviour degrades rather than breaks.
- Rows whose state has not changed reuse their existing asset URLs through the existing `preserveAssetUrls` helper.

# Details

**Measured** over a 5.2 second generation with one unchanged succeeded row:

| Metric | Before | After |
|---|---:|---:|
| `/api/v1/generations*` requests | 6 | 4 |
| GET only | 5 | 3 |
| Asset URL generations | 13 | 5 |

The saving grows with generation length, because the old loop polled once per 1.5 seconds regardless of duration. A 5 second generation is close to the worst case for showing the improvement; a minute-long one previously cost about 40 polls.

**Both deployment profiles use one contract.** Self-hosted receives events in the process holding both sockets; the cloud profile relays between API replicas over Redis pub/sub (`docs/architecture.md`). Because the generation subscriber is process-local today, a single-job reconciliation every 15 seconds covers a missed cross-replica event, so a stream cannot leave a spinner forever. No sticky sessions and no per-profile branching in the frontend.

**The `pollRequested` race guard is preserved.** It exists because `if (polling) return` otherwise drops a request in the race between the last idle check and `polling = false`, which would stop the UI refreshing until reload.

**No new test framework.** `verify-frontend` is lint, `svelte-check` and build, with no frontend test runner in the repo, so adding one for this was out of scope. The logic is covered by type checking, both builds, and the measurement above, which executed the real state module through Vite's loader.

Verified with `make verify` (backend 90 passed, worker 63 passed, frontend lint, svelte-check 0 errors) and `PUBLIC_SITE_MODE=landing npm run build`, since the studio ships in the marketing bundle too.

Closes #165
