### PR TITLE
Stop the recovery test depending on what ran before it

### DIFF
--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlsplit
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from fastapi.testclient import TestClient
 
 from app import db
@@ -214,6 +214,11 @@ async def _seed_recover_jobs() -> tuple[uuid.UUID, uuid.UUID]:
     queued_id = uuid.uuid4()
     running_id = uuid.uuid4()
     async with db.session_factory() as session:
+        # recover() dispatches everything queued or running, so a leftover job
+        # from an earlier case in this session would arrive at the worker here
+        # and break the assertion about which two were dispatched. The database
+        # is truncated once per session, not per test.
+        await session.execute(delete(Job).where(Job.state.in_(("queued", "running"))))
         if await session.get(Model, "sd-test") is None:
             session.add(Model(
                 id="sd-test",


### PR DESCRIPTION
# Description

`test_recover_requeues_running_and_dispatches_queued` asserts that exactly the two jobs it seeds are the two dispatched. But `recover()` dispatches everything queued or running, and `backend/tests/conftest.py` truncates the database once per pytest session rather than per test. Any earlier case that leaves a dispatchable job behind makes this one receive it, and the set comparison fails.

# Motivation

It has failed this way three times in CI today, on pull requests that had nothing to do with job dispatch (#161, #170, #173), while passing locally and in isolation every time. A test that randomly blocks unrelated work costs more than the coverage it provides, and re-running CI to get past it teaches the wrong habit.

The failures are consistent with the diagnosis: each showed one of the two expected ids present and the other replaced, which is what a third dispatched job looks like.

# Functionality

Seeding clears queued and running jobs before inserting its own, so the case controls what is dispatchable regardless of what ran before it.

# Details

**On verification, plainly:** I could not reproduce the flake locally. A job planted before the session starts is removed by the same truncation, so the leftover has to be created during the session by an earlier test, and locally the file passes with and without this change. This removes the dependency that explains the observed failures rather than demonstrating the failure first and then fixing it. I would rather say that than imply a proof I do not have.

**Why not fix the truncation instead:** making `_prepare_database` truncate per test would slow every database test in the suite to solve one case's problem. The narrower fix belongs in the case that has the requirement.

**Related, not addressed here:** the same session-scoped truncation means any test asserting exact database state depends on ordering. Two were already hardened this way today, in #167 and #174. A broader sweep for that pattern would be its own piece of work.

Verified with `make verify`: backend 96 passed, worker 63 passed, frontend lint, svelte-check 0 errors, both builds.
