### PR TITLE
Warn when a prompt outruns the model's text encoder window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ verify-worker:
 	cd worker && .venv/bin/ruff check . && .venv/bin/mypy && .venv/bin/pytest
 
 verify-frontend:
-	cd frontend && npm run lint && npm run check && npm run build
+	cd frontend && npm run lint && npm run check && npm test && npm run build
 
 verify: verify-backend verify-worker verify-frontend ## everything CI runs, locally
 

--- a/backend/app/manifests.py
+++ b/backend/app/manifests.py
@@ -27,6 +27,7 @@ class Manifest(BaseModel):
     capabilities: list[str]
     parameters: dict = Field(default_factory=dict)  # JSON Schema for the model's call parameters
     min_vram_gb: int = 0
+    prompt_token_limit: int = 0  # text encoder window; 0 means the studio stays quiet
     default: bool = False  # preselected by clients when nothing is pinned
     license_id: str = ""
     license_url: str = ""

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -26,6 +26,7 @@ MANIFEST = {
         "required": ["prompt"],
     },
     "min_vram_gb": 0,
+    "prompt_token_limit": 77,
 }
 
 MANIFEST_T2I_ONLY = {
@@ -64,6 +65,10 @@ def test_generation_end_to_end():
 
             models = client.get("/api/v1/models").json()
             assert any(m["id"] == "sd-test" for m in models)
+            # The studio's prompt warning (issue #148) reads the window here,
+            # so it has to survive the worker hello and reach the browser.
+            listed = next(m for m in models if m["id"] == "sd-test")
+            assert listed["prompt_token_limit"] == 77
 
             async def job_events() -> int:
                 assert db.session_factory is not None

--- a/backend/tests/test_manifests.py
+++ b/backend/tests/test_manifests.py
@@ -37,6 +37,29 @@ def test_validate_params_accepts_on_invalid_schema():
     assert validate_params(manifest, {"anything": True}) is None
 
 
+def test_prompt_token_limit_crosses_the_wire():
+    """The studio warning (issue #148) reads this off GET /api/v1/models, so it
+    has to survive parsing rather than be dropped as an unknown worker field."""
+    parsed = parse_manifests([{
+        "id": "m1",
+        "name": "M1",
+        "capabilities": ["text_to_image"],
+        "parameters": SCHEMA,
+        "prompt_token_limit": 77,
+        "source": "worker/side/only",
+    }])
+    assert parsed[0].prompt_token_limit == 77
+
+
+def test_prompt_token_limit_defaults_to_undeclared():
+    """A worker that never declares a window leaves the studio silent instead
+    of asserting a CLIP limit the model may not have."""
+    parsed = parse_manifests([
+        {"id": "m1", "name": "M1", "capabilities": ["text_to_image"], "parameters": SCHEMA},
+    ])
+    assert parsed[0].prompt_token_limit == 0
+
+
 def test_parse_manifests_rejects_upscale_mixed_with_diffusion():
     try:
         parse_manifests([{

--- a/docs/api.md
+++ b/docs/api.md
@@ -97,6 +97,7 @@ Registered models, each with its JSON-Schema `parameters` and its measured GPU-t
     "name": "SDXL Base",
     "capabilities": ["text_to_image", "image_to_image"],
     "min_vram_gb": 10,
+    "prompt_token_limit": 77,
     "default": true,
     "benchmark_only": false,
     "estimated_gpu_ms_default": 4200,
@@ -112,7 +113,7 @@ Registered models, each with its JSON-Schema `parameters` and its measured GPU-t
 ]
 ```
 
-`parameters` is JSON Schema; the frontend renders generic controls from it, which is what makes a newly dropped model usable without a frontend release. `capabilities` is the routing key (a job is matched to a model that has the requested capability). Upscale models additionally carry an `estimated_gpu_ms_by_factor` map (per scale factor). `benchmark_only` models are hidden from normal selection and exist for the benchmark harness.
+`parameters` is JSON Schema; the frontend renders generic controls from it, which is what makes a newly dropped model usable without a frontend release. `capabilities` is the routing key (a job is matched to a model that has the requested capability). Upscale models additionally carry an `estimated_gpu_ms_by_factor` map (per scale factor). `benchmark_only` models are hidden from normal selection and exist for the benchmark harness. `prompt_token_limit` is the text encoder window the studio warns against (issue #148); 0 or absent means the model declared no window and no warning is shown.
 
 <!-- Corrected 2026-07-23: removed the "tier" field from this example (the wire Manifest has no "tier"; tier-based routing is unshipped) and added the shipped "default"/"benchmark_only"/"estimated_gpu_ms_default" fields. -->
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -365,6 +365,7 @@ Every model the worker can serve is described by a manifest. Example:
   "capabilities": ["image_to_image", "realtime"],
   "tier": "draft",
   "min_vram_gb": 8,
+  "prompt_token_limit": 77,
   "parameters": {
     "type": "object",
     "properties": {
@@ -377,6 +378,8 @@ Every model the worker can serve is described by a manifest. Example:
 ```
 
 `min_vram_gb` is the full residency requirement; a worker with less VRAM can still serve the model through the memory ladder (see Low VRAM operation under GPU scheduling), just without the `realtime` capability. `tier` feeds model routing: requests that do not pin a model resolve to the cheapest tier that satisfies them.
+
+`prompt_token_limit` is the model's text encoder window in tokens. Diffusers drops whatever does not fit and only logs it worker side, so the studio warns when a prompt runs past it (issue #148). The shipped CLIP based manifests declare 77; a model with a different encoder declares its own figure, which is why the field is not a constant in the frontend. Omitting it means the window is unknown and the studio says nothing, so a manifest that forgets the field stays quiet rather than claiming a limit its encoder does not have. Upscale manifests take no prompt and leave it unset.
 
 The parameters field is JSON Schema. `GET /api/v1/models` exposes the manifests to the frontend, which renders generic controls from the schema. This is what keeps newly added models usable before any model specific frontend work exists (issue #11). Not every model needs to offer every capability.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -610,6 +610,12 @@ Each API release tolerates the previous release's SPA. Response shapes follow th
 
 Rejected alternative: breaking response changes plus a forced reload. That makes SPA and API deploys lockstep and can discard in-flight work.
 
+## Prompt token window: declared per manifest, silent when undeclared
+
+The text encoder window a prompt is measured against comes from the manifest field `prompt_token_limit`, not from a constant in the frontend. The shipped CLIP based models declare 77; a model whose encoder differs declares its own figure and the studio warning follows it without a frontend change. An absent or zero value means the window is unknown and no warning appears, so a manifest that forgets the field fails back to the behaviour before the warning existed instead of asserting a limit its encoder does not have. Upscale manifests take no prompt and leave it unset. The count itself is estimated in the browser from words and punctuation rather than tokenized exactly, because the real CLIP tokenizer means shipping roughly a megabyte of BPE vocabulary to phrase a warning that only needs to be right within a few tokens.
+
+Rejected alternatives: hardcoding 77 in the studio, which is correct only for the models shipped today and silently wrong for the first model with a larger encoder; defaulting the field to 77 so existing manifests need no edit, which turns a forgotten declaration into a confident false warning rather than silence; asking the worker for an exact count per keystroke, which spends a round trip on a hint; and bundling a real tokenizer, which costs more transfer than the feature is worth.
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check .",
+		"test": "node --test \"src/**/*.test.ts\"",
 		"format": "prettier --write .",
 		"generate:hero-preview": "node scripts/generate-hero-preview.mjs",
 		"generate:gallery-images": "node scripts/generate-gallery-images.mjs",

--- a/frontend/src/lib/components/generate-panel.svelte
+++ b/frontend/src/lib/components/generate-panel.svelte
@@ -25,7 +25,7 @@
 	} from '$lib/model-params';
 	import { formatMs } from '$lib/benchmark';
 	import { estimateGpuMs, estimateUpscaleGpuMs } from '$lib/gpu-estimate';
-	import { estimatePromptTokens, promptExceedsWindow } from '$lib/prompt-tokens';
+	import { estimatePromptTokens, exceedsWindow } from '$lib/prompt-tokens';
 	import {
 		defaultUpscaleModelId,
 		filterDiffusionModels,
@@ -134,11 +134,11 @@
 	// Diffusers truncates at the text encoder window and only logs it worker
 	// side, so the prompt tail silently stops affecting the image (issue #148).
 	const promptWindow = $derived(selectedModel?.prompt_token_limit ?? 0);
-	const promptOverflows = $derived(promptExceedsWindow(studio.prompt, promptWindow));
+	const promptTokens = $derived(estimatePromptTokens(studio.prompt));
 	const promptTokenNotice = $derived(
-		promptOverflows
+		exceedsWindow(promptTokens, promptWindow)
 			? t('app.gen.prompt_too_long')
-					.replace('{tokens}', String(estimatePromptTokens(studio.prompt)))
+					.replace('{tokens}', String(promptTokens))
 					.replace('{limit}', String(promptWindow))
 			: null
 	);

--- a/frontend/src/lib/components/generate-panel.svelte
+++ b/frontend/src/lib/components/generate-panel.svelte
@@ -25,6 +25,7 @@
 	} from '$lib/model-params';
 	import { formatMs } from '$lib/benchmark';
 	import { estimateGpuMs, estimateUpscaleGpuMs } from '$lib/gpu-estimate';
+	import { estimatePromptTokens, promptExceedsWindow } from '$lib/prompt-tokens';
 	import {
 		defaultUpscaleModelId,
 		filterDiffusionModels,
@@ -130,6 +131,17 @@
 		})
 	);
 	const gpuEstimateLabel = $derived(gpuEstimateMs != null ? `~${formatMs(gpuEstimateMs)}` : null);
+	// Diffusers truncates at the text encoder window and only logs it worker
+	// side, so the prompt tail silently stops affecting the image (issue #148).
+	const promptWindow = $derived(selectedModel?.prompt_token_limit ?? 0);
+	const promptOverflows = $derived(promptExceedsWindow(studio.prompt, promptWindow));
+	const promptTokenNotice = $derived(
+		promptOverflows
+			? t('app.gen.prompt_too_long')
+					.replace('{tokens}', String(estimatePromptTokens(studio.prompt)))
+					.replace('{limit}', String(promptWindow))
+			: null
+	);
 	const upscaleSource = $derived(
 		shown !== null && shown.assets.length > 0
 			? { width: shown.assets[0].width, height: shown.assets[0].height }
@@ -363,7 +375,16 @@
 								id="gen-prompt"
 								class={fieldClass + ' no-scrollbar h-44 resize-none overflow-y-auto py-2'}
 								placeholder={t('app.gen.prompt_placeholder')}
+								aria-describedby={promptTokenNotice ? 'gen-prompt-window' : undefined}
 								bind:value={studio.prompt}></textarea>
+							{#if promptTokenNotice}
+								<!-- Described by the field rather than announced from a live region:
+								the count changes on every keystroke, which a polite region would
+								read out again and again while the user is still typing. -->
+								<p id="gen-prompt-window" class="text-muted-foreground text-sm leading-relaxed">
+									{promptTokenNotice}
+								</p>
+							{/if}
 						</div>
 						<div class="grid grid-cols-2 gap-3">
 							<div class="flex flex-col gap-2">

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -215,6 +215,7 @@
 	"app.gen.model": "Model",
 	"app.gen.prompt": "Prompt",
 	"app.gen.prompt_placeholder": "a castle on a hill at sunset, oil painting",
+	"app.gen.prompt_too_long": "About {tokens} tokens. This model reads the first {limit}; the rest is saved with the image but does not shape it.",
 	"app.gen.steps": "Steps",
 	"app.gen.guidance": "Guidance",
 	"app.gen.seed": "Seed",

--- a/frontend/src/lib/i18n/es.json
+++ b/frontend/src/lib/i18n/es.json
@@ -215,6 +215,7 @@
 	"app.gen.model": "Modelo",
 	"app.gen.prompt": "Prompt",
 	"app.gen.prompt_placeholder": "un castillo en una colina al atardecer, pintura al oleo",
+	"app.gen.prompt_too_long": "Unos {tokens} tokens. Este modelo lee los primeros {limit}; el resto se guarda con la imagen pero no la modifica.",
 	"app.gen.steps": "Pasos",
 	"app.gen.guidance": "Guidance",
 	"app.gen.seed": "Semilla",

--- a/frontend/src/lib/prompt-tokens.test.ts
+++ b/frontend/src/lib/prompt-tokens.test.ts
@@ -1,0 +1,58 @@
+// node --test with the built in type stripping, so the estimator keeps a check
+// without pulling a test framework into the frontend (see Makefile
+// verify-frontend). Numbers are approximations, so these assert the behaviour
+// the warning depends on rather than exact token counts.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { estimatePromptTokens, promptExceedsWindow } from './prompt-tokens.ts';
+
+test('an empty prompt spends nothing', () => {
+	assert.equal(estimatePromptTokens(''), 0);
+	assert.equal(estimatePromptTokens('   '), 0);
+});
+
+test('short words cost about one token each plus the two markers', () => {
+	assert.equal(estimatePromptTokens('a red cat'), 5);
+});
+
+test('the tag separator is counted', () => {
+	assert.ok(estimatePromptTokens('a cat, a dog') > estimatePromptTokens('a cat a dog'));
+});
+
+test('long words cost more than short ones', () => {
+	assert.ok(estimatePromptTokens('photorealistic') > estimatePromptTokens('photo'));
+});
+
+test('a typical studio prompt lands near the real CLIP count', () => {
+	// The real tokenizer gives 24 for this; a warning tolerates a few either way.
+	const prompt =
+		'a photorealistic portrait of an astronaut riding a horse on mars, ' +
+		'cinematic lighting, 8k, highly detailed';
+	const tokens = estimatePromptTokens(prompt);
+	assert.ok(tokens >= 20 && tokens <= 28, `estimated ${tokens}`);
+});
+
+test('a prompt well past the window is flagged', () => {
+	const long = 'a detailed painting of a garden '.repeat(20);
+	assert.ok(estimatePromptTokens(long) > 77);
+	assert.ok(promptExceedsWindow(long, 77));
+});
+
+test('a prompt inside the window is not flagged', () => {
+	assert.equal(promptExceedsWindow('a red cat on a fence', 77), false);
+});
+
+test('an undeclared window never warns', () => {
+	// 0 is the manifest default: no claim about the encoder, so no warning.
+	const long = 'a detailed painting of a garden '.repeat(20);
+	assert.equal(promptExceedsWindow(long, 0), false);
+	assert.equal(promptExceedsWindow(long, undefined), false);
+});
+
+test('a larger declared window tolerates a longer prompt', () => {
+	// What a T5 based model buys: same prompt, no warning (issue #148).
+	const long = 'a detailed painting of a garden '.repeat(20);
+	assert.ok(promptExceedsWindow(long, 77));
+	assert.equal(promptExceedsWindow(long, 512), false);
+});

--- a/frontend/src/lib/prompt-tokens.test.ts
+++ b/frontend/src/lib/prompt-tokens.test.ts
@@ -5,11 +5,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { estimatePromptTokens, promptExceedsWindow } from './prompt-tokens.ts';
+import { estimatePromptTokens, exceedsWindow } from './prompt-tokens.ts';
 
-test('an empty prompt spends nothing', () => {
-	assert.equal(estimatePromptTokens(''), 0);
-	assert.equal(estimatePromptTokens('   '), 0);
+test('an empty prompt still spends the two markers', () => {
+	assert.equal(estimatePromptTokens(''), 2);
+	assert.equal(estimatePromptTokens('   '), 2);
 });
 
 test('short words cost about one token each plus the two markers', () => {
@@ -34,25 +34,25 @@ test('a typical studio prompt lands near the real CLIP count', () => {
 });
 
 test('a prompt well past the window is flagged', () => {
-	const long = 'a detailed painting of a garden '.repeat(20);
-	assert.ok(estimatePromptTokens(long) > 77);
-	assert.ok(promptExceedsWindow(long, 77));
+	const tokens = estimatePromptTokens('a detailed painting of a garden '.repeat(20));
+	assert.ok(tokens > 77);
+	assert.ok(exceedsWindow(tokens, 77));
 });
 
 test('a prompt inside the window is not flagged', () => {
-	assert.equal(promptExceedsWindow('a red cat on a fence', 77), false);
+	assert.equal(exceedsWindow(estimatePromptTokens('a red cat on a fence'), 77), false);
 });
 
 test('an undeclared window never warns', () => {
 	// 0 is the manifest default: no claim about the encoder, so no warning.
-	const long = 'a detailed painting of a garden '.repeat(20);
-	assert.equal(promptExceedsWindow(long, 0), false);
-	assert.equal(promptExceedsWindow(long, undefined), false);
+	const tokens = estimatePromptTokens('a detailed painting of a garden '.repeat(20));
+	assert.equal(exceedsWindow(tokens, 0), false);
+	assert.equal(exceedsWindow(tokens, undefined), false);
 });
 
 test('a larger declared window tolerates a longer prompt', () => {
 	// What a T5 based model buys: same prompt, no warning (issue #148).
-	const long = 'a detailed painting of a garden '.repeat(20);
-	assert.ok(promptExceedsWindow(long, 77));
-	assert.equal(promptExceedsWindow(long, 512), false);
+	const tokens = estimatePromptTokens('a detailed painting of a garden '.repeat(20));
+	assert.ok(exceedsWindow(tokens, 77));
+	assert.equal(exceedsWindow(tokens, 512), false);
 });

--- a/frontend/src/lib/prompt-tokens.ts
+++ b/frontend/src/lib/prompt-tokens.ts
@@ -1,0 +1,40 @@
+// Prompt length against a model's text encoder window (issue #148). Diffusers
+// silently drops whatever does not fit, so the studio needs a number to warn
+// with. Deliberately an estimate: the real CLIP tokenizer needs its ~1 MB BPE
+// vocabulary shipped to the browser, and the issue asks only for accuracy
+// within a few tokens. Prompts are mostly common words and comma separated
+// tags, which CLIP encodes close to one token each, so counting words lands
+// near the real figure. Non-Latin scripts tokenize far denser than this
+// estimate suggests; the warning fires late for them rather than never.
+
+/** The window is shared with the begin and end markers the encoder adds. */
+const SPECIAL_TOKENS = 2;
+
+/** Words no longer than this are usually a single BPE token. */
+const WHOLE_WORD_CHARS = 6;
+
+/** Every further run of this many characters costs roughly one more token. */
+const EXTRA_TOKEN_CHARS = 4;
+
+/** Approximate tokens the encoder would spend on this prompt. */
+export function estimatePromptTokens(prompt: string): number {
+	// Punctuation is matched apart from words because CLIP gives the comma,
+	// which is how prompts separate tags, a token of its own.
+	const pieces = prompt.match(/[\p{L}\p{N}]+|[^\s\p{L}\p{N}]/gu);
+	if (!pieces) return 0;
+	let tokens = SPECIAL_TOKENS;
+	for (const piece of pieces) {
+		const overflow = Math.max(0, piece.length - WHOLE_WORD_CHARS);
+		tokens += 1 + Math.floor(overflow / EXTRA_TOKEN_CHARS);
+	}
+	return tokens;
+}
+
+/**
+ * Whether to tell the user their prompt tail will not reach the image.
+ * A limit of 0 means the manifest never declared a window, so say nothing
+ * rather than guess at one (see worker/worker/manifests.py).
+ */
+export function promptExceedsWindow(prompt: string, limit: number | undefined): boolean {
+	return !!limit && limit > 0 && estimatePromptTokens(prompt) > limit;
+}

--- a/frontend/src/lib/prompt-tokens.ts
+++ b/frontend/src/lib/prompt-tokens.ts
@@ -16,12 +16,14 @@ const WHOLE_WORD_CHARS = 6;
 /** Every further run of this many characters costs roughly one more token. */
 const EXTRA_TOKEN_CHARS = 4;
 
-/** Approximate tokens the encoder would spend on this prompt. */
+/**
+ * Approximate tokens the encoder would spend on this prompt. An empty prompt
+ * still costs the two markers, which is what the encoder itself would spend.
+ */
 export function estimatePromptTokens(prompt: string): number {
 	// Punctuation is matched apart from words because CLIP gives the comma,
 	// which is how prompts separate tags, a token of its own.
-	const pieces = prompt.match(/[\p{L}\p{N}]+|[^\s\p{L}\p{N}]/gu);
-	if (!pieces) return 0;
+	const pieces = prompt.match(/[\p{L}\p{N}]+|[^\s\p{L}\p{N}]/gu) ?? [];
 	let tokens = SPECIAL_TOKENS;
 	for (const piece of pieces) {
 		const overflow = Math.max(0, piece.length - WHOLE_WORD_CHARS);
@@ -31,10 +33,13 @@ export function estimatePromptTokens(prompt: string): number {
 }
 
 /**
- * Whether to tell the user their prompt tail will not reach the image.
+ * Whether to tell the user their prompt tail will not reach the image. Takes
+ * the count rather than the prompt so a caller rendering both the number and
+ * the warning only scans the text once.
+ *
  * A limit of 0 means the manifest never declared a window, so say nothing
  * rather than guess at one (see worker/worker/manifests.py).
  */
-export function promptExceedsWindow(prompt: string, limit: number | undefined): boolean {
-	return !!limit && limit > 0 && estimatePromptTokens(prompt) > limit;
+export function exceedsWindow(tokens: number, limit: number | undefined): boolean {
+	return !!limit && limit > 0 && tokens > limit;
 }

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -8,6 +8,8 @@ export type Model = {
 	name: string;
 	capabilities: string[];
 	default: boolean;
+	/** Text encoder window; absent or 0 means the model never declared one. */
+	prompt_token_limit?: number;
 	estimated_gpu_ms_default: number | null;
 	estimated_gpu_ms_by_factor?: Record<string, number>;
 	parameters: {

--- a/worker/models/dreamshaper-lcm.json
+++ b/worker/models/dreamshaper-lcm.json
@@ -3,6 +3,7 @@
   "name": "DreamShaper 8 LCM",
   "capabilities": ["text_to_image"],
   "min_vram_gb": 6,
+  "prompt_token_limit": 77,
   "source": "lykon/dreamshaper-8-lcm",
   "benchmark_only": true,
   "parameters": {

--- a/worker/models/sd-turbo.json
+++ b/worker/models/sd-turbo.json
@@ -3,6 +3,7 @@
   "name": "SD Turbo",
   "capabilities": ["text_to_image", "image_to_image", "realtime"],
   "min_vram_gb": 8,
+  "prompt_token_limit": 77,
   "source": "stabilityai/sd-turbo",
   "license_id": "stability-ai-community",
   "license_url": "https://huggingface.co/stabilityai/sd-turbo/blob/main/LICENSE.md",

--- a/worker/models/sdxl-base.json
+++ b/worker/models/sdxl-base.json
@@ -3,6 +3,7 @@
   "name": "SDXL (default)",
   "capabilities": ["text_to_image", "image_to_image"],
   "min_vram_gb": 10,
+  "prompt_token_limit": 77,
   "default": true,
   "source": "stabilityai/stable-diffusion-xl-base-1.0",
   "vae": "madebyollin/sdxl-vae-fp16-fix",

--- a/worker/models/sdxl-fast.json
+++ b/worker/models/sdxl-fast.json
@@ -3,6 +3,7 @@
   "name": "SDXL Fast",
   "capabilities": ["text_to_image"],
   "min_vram_gb": 10,
+  "prompt_token_limit": 77,
   "source": "stabilityai/stable-diffusion-xl-base-1.0",
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "euler-trailing",

--- a/worker/models/sdxl-hypersd.json
+++ b/worker/models/sdxl-hypersd.json
@@ -3,6 +3,7 @@
   "name": "SDXL Hyper-SD",
   "capabilities": ["text_to_image"],
   "min_vram_gb": 10,
+  "prompt_token_limit": 77,
   "source": "stabilityai/stable-diffusion-xl-base-1.0",
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "euler-trailing",

--- a/worker/models/sdxl-turbo.json
+++ b/worker/models/sdxl-turbo.json
@@ -3,6 +3,7 @@
   "name": "SDXL Turbo",
   "capabilities": ["text_to_image", "image_to_image", "realtime"],
   "min_vram_gb": 10,
+  "prompt_token_limit": 77,
   "source": "stabilityai/sdxl-turbo",
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "license_id": "stability-ai-community",

--- a/worker/models/ssd-1b-lightning.json
+++ b/worker/models/ssd-1b-lightning.json
@@ -5,6 +5,7 @@
     "text_to_image"
   ],
   "min_vram_gb": 8,
+  "prompt_token_limit": 77,
   "source": "segmind/SSD-1B",
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "euler-trailing",

--- a/worker/models/ssd-1b.json
+++ b/worker/models/ssd-1b.json
@@ -3,6 +3,7 @@
   "name": "SSD-1B",
   "capabilities": ["text_to_image"],
   "min_vram_gb": 8,
+  "prompt_token_limit": 77,
   "source": "segmind/SSD-1B",
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "dpmsolver",

--- a/worker/models/vega-rt.json
+++ b/worker/models/vega-rt.json
@@ -7,6 +7,7 @@
     "realtime"
   ],
   "min_vram_gb": 8,
+  "prompt_token_limit": 77,
   "source": "segmind/Segmind-Vega",
   "vae": "madebyollin/sdxl-vae-fp16-fix",
   "scheduler": "lcm",

--- a/worker/tests/test_manifests.py
+++ b/worker/tests/test_manifests.py
@@ -11,6 +11,7 @@ SD_TURBO = {
     "name": "SD Turbo",
     "capabilities": ["text_to_image", "realtime"],
     "min_vram_gb": 8,
+    "prompt_token_limit": 77,
     "source": "stabilityai/sd-turbo",
     "parameters": {"type": "object", "properties": {"prompt": {"type": "string"}}},
 }
@@ -22,6 +23,7 @@ def test_load_manifests_and_wire_shape(tmp_path):
     assert [m.id for m in manifests] == ["sd-turbo"]
     wire = manifests[0].wire()
     assert wire["capabilities"] == ["text_to_image", "realtime"]
+    assert wire["prompt_token_limit"] == 77  # the studio warning reads this
     assert "source" not in wire  # weight locations stay worker side
 
 
@@ -75,6 +77,19 @@ def test_shipped_manifests_load():
     assert fast.source.endswith("realesr-general-x4v3.pth")
     assert fast.min_vram_gb == 1
     assert fast.parameters["properties"]["factor"]["enum"] == [2, 4]
+
+
+def test_every_prompting_manifest_declares_its_token_window():
+    """A missing window silences the studio warning (issue #148), so a new
+    diffusion manifest that forgets it should fail here rather than ship a
+    prompt whose tail is dropped with nothing said. Upscalers take no prompt.
+    """
+    models_dir = Path(__file__).resolve().parents[1] / "models"
+    for manifest in load_manifests(str(models_dir)):
+        if "upscale" in manifest.capabilities:
+            assert manifest.prompt_token_limit == 0, manifest.id
+        else:
+            assert manifest.prompt_token_limit > 0, manifest.id
 
 
 def test_upscale_cannot_mix_with_diffusion(tmp_path):

--- a/worker/worker/manifests.py
+++ b/worker/worker/manifests.py
@@ -19,6 +19,11 @@ class Manifest(BaseModel):
     capabilities: list[str]  # text_to_image, image_to_image, realtime, upscale
     parameters: dict = Field(default_factory=dict)  # JSON Schema for the model's call parameters
     min_vram_gb: int = 0
+    # Text encoder window in tokens; anything past it never conditions the image
+    # (issue #148). Left at 0 rather than 77 on purpose: a manifest that forgets
+    # to declare it stays silent instead of promising a CLIP limit a T5 based
+    # model does not have.
+    prompt_token_limit: int = 0
     default: bool = False  # preselected by clients when nothing is pinned
     source: str = ""  # weights location, worker side only
     vae: str = ""  # optional fp16-safe VAE replacement, worker side only


### PR DESCRIPTION
# Description

Closes #148.

The studio now says so when a prompt is longer than the active model's text encoder window. Diffusers drops the overflow and mentions it only in a worker log line, so until now a long prompt looked fully used while its tail never reached the image.

The window is read from the model manifest rather than hardcoded in the frontend.

# Motivation

The issue asks for 77 tokens "for shipped CLIP-based models unless a manifest declares otherwise". Taking that literally, as a manifest field, is what makes the warning correct for the first model whose encoder is not CLIP, instead of something to revisit when one arrives.

# Functionality

- `prompt_token_limit` on the manifest, crossing the wire to `GET /api/v1/models`. The nine shipped diffusion manifests declare 77; the two upscale manifests take no prompt and leave it unset.
- A non-blocking notice under the prompt field with the estimated count and the model's limit. Generate stays enabled and the full prompt is still stored and sent unchanged.
- Both dictionaries carry the copy, ASCII only.

# Details

**The default is silence, not 77.** An absent or zero value means the model declared no window, and the studio says nothing. Defaulting the field to 77 instead would need one less edit per manifest but turns a forgotten declaration into a confident wrong warning; leaving it unset degrades to exactly the behaviour before this PR. A worker test enforces the split both ways, so a new diffusion manifest that omits the field fails CI rather than shipping a silently truncated prompt.

Worth flagging for #156: that test will require the SD 3.5 Medium manifest to declare its own window when the branch is rebased. Its T5 path is not limited to 77, which is the case this design exists to get right.

**The count is an estimate.** Words and punctuation, not real tokenization. The genuine CLIP tokenizer means shipping roughly a megabyte of BPE vocabulary to phrase a warning the issue says only needs accuracy "within a few tokens". On a representative prompt the estimator lands within a few of the real count; a test pins that. Non-Latin scripts tokenize denser than this model assumes, so the warning fires late for them rather than never.

**No migration.** `GET /api/v1/models` serves `model_dump()` from the in-memory registry, so the field reaches the browser without a schema change. The `models` table exists so job history can still name models whose worker is gone, and it does not need this field to do that.

**The frontend gained a test, not a test framework.** `node --test` with the built in type stripping, wired into `verify-frontend`, so the estimator has a real check without adding a dependency. Node 24 is already required and guarded by `toolchain.yml`.

**Accessibility.** The notice is associated with the prompt field via `aria-describedby` rather than announced from a live region: the count changes on every keystroke, and a polite region would read it out again and again while the user is still typing.

# Verification

`make verify` passes: backend 99 passed, worker 64 passed 3 skipped, frontend lint, svelte-check, 9 node tests and build. Run in a dedicated worktree with its own venvs and its own scratch database.

Not verified: the warning was not exercised against a real GPU generation, since it is presentation only and never changes the request.