### PR TITLE
Start the verify jobs when the Makefile changes

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,12 +7,14 @@ on:
     paths:
       - "backend/**"
       - "scripts/**"
+      - "Makefile"
       - ".github/workflows/backend.yml"
   push:
     branches: [main]
     paths:
       - "backend/**"
       - "scripts/**"
+      - "Makefile"
       - ".github/workflows/backend.yml"
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
       - "frontend/**"
       - "deploy/**"
       - "scripts/compose-smoke.sh"
+      - "Makefile"
       - ".github/workflows/deploy.yml"
   push:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - "frontend/**"
       - "deploy/**"
       - "scripts/compose-smoke.sh"
+      - "Makefile"
       - ".github/workflows/deploy.yml"
 
 permissions:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -5,11 +5,13 @@ on:
   pull_request:
     paths:
       - "frontend/**"
+      - "Makefile"
       - ".github/workflows/frontend.yml"
   push:
     branches: [main]
     paths:
       - "frontend/**"
+      - "Makefile"
       - ".github/workflows/frontend.yml"
 
 permissions:

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -5,11 +5,13 @@ on:
   pull_request:
     paths:
       - "worker/**"
+      - "Makefile"
       - ".github/workflows/worker.yml"
   push:
     branches: [main]
     paths:
       - "worker/**"
+      - "Makefile"
       - ".github/workflows/worker.yml"
 
 permissions:


### PR DESCRIPTION
# Description

Closes #177.

Adds `Makefile` to the `pull_request` and `push` path filters of the four workflows whose only substantive step is a make target.

# Motivation

Each of these workflows carries a comment saying the Makefile target is the single definition of what the job checks, and none of them watched the file holding that definition. A commit editing only the Makefile could weaken all four jobs and start none of them, which is the shape of the gap that let #162 reach main.

# Functionality

| Workflow | Filter before | Now |
| --- | --- | --- |
| backend | `backend/**`, `scripts/**` | plus `Makefile` |
| worker | `worker/**` | plus `Makefile` |
| frontend | `frontend/**` | plus `Makefile` |
| deploy | `backend/**`, `frontend/**`, `deploy/**`, `scripts/compose-smoke.sh` | plus `Makefile` |

# Details

Narrower than the issue first claimed, and I have corrected the issue: `toolchain.yml` already triggers on `Makefile`, so `make verify-guards` and `make setup` did run on a Makefile-only commit. The four verify jobs did not, which is what this fixes.

`simulation.yml` is deliberately left out. It runs `scripts/simulate.py` through a venv it builds itself and invokes no make target, so the Makefile does not decide its work. It already watches `scripts/**`.

I did not add `scripts/**` to the worker or frontend filters, which the issue floated. `verify-worker` only lints and tests `worker/`, and `verify-frontend` only runs npm inside `frontend/`, so neither reads `scripts/`. `backend.yml` already has it because `verify-backend` lints `../scripts`.

# Verification

All four files parse and carry `Makefile` in both filters. This PR edits the workflows themselves, so every affected job runs here by its self-reference; proving the new trigger takes a later Makefile-only commit, which the next one to touch it will demonstrate.

Separate finding while checking this, filed rather than folded in: `verify-mermaid` runs in no workflow at all, so every diagram under docs/ is validated only by local convention.