### PR TITLE
Store generation masters as PNG

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,7 +66,7 @@ grouped (M2-M8) view of what is open.
   gated to full residency.
 - Survival on one card: OOM during a load or run evicts other resident models and
   retries once, so model switching works on 16 GB.
-- Outputs are lossy WebP quality 80 (PNG masters are planned, #125).
+- Generation masters are lossless PNG; realtime frames and thumbnails are WebP.
 - Models shipped: SDXL Base (default, 1024, DPM++ 2M Karras), SDXL Fast
   (Lightning 8-step), SSD-1B and SSD-1B-Lightning (fast batch tier), DreamShaper-LCM
   (smallest at ~6 GB), and VegaRT (Apache-2.0, the studio-shippable realtime model,

--- a/backend/app/files.py
+++ b/backend/app/files.py
@@ -17,7 +17,12 @@ from app.storage import LocalStorage, get_storage
 
 router = APIRouter()
 
-MAX_UPLOAD_BYTES = 20 * 1024 * 1024
+# Lossless masters are far larger than the WebP this route used to carry, and
+# the biggest one the fleet can produce is a 4x upscale of a 1024 px image. A
+# real 1024 px generation re-encoded to PNG at 4096 px measures about 19 MB,
+# and 4096 px of incompressible detail is 50 MB, so the old 20 MB ceiling
+# would have started refusing upscale uploads with a 413 (issue #125).
+MAX_UPLOAD_BYTES = 64 * 1024 * 1024
 
 
 def local_storage() -> LocalStorage:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -451,7 +451,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
         worker = pick_job_worker(job.model_id)
         if worker is None:
             return False
-        storage_key = f"{job.user_id}/{job.id}.webp"
+        storage_key = f"{job.user_id}/{job.id}.png"
         thumb_storage_key = f"{job.user_id}/{job.id}-thumb.webp"
         target = await get_storage().upload_target(storage_key)
         thumb_target = await get_storage().upload_target(thumb_storage_key)
@@ -540,7 +540,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
                 job_id=job_id,
                 parent_asset_id=job.source_asset_id,
                 storage_key=entry.storage_key,
-                mime="image/webp",
+                mime="image/png",
                 width=width,
                 height=height,
             )

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -14,6 +14,7 @@ from typing import Protocol
 from app.settings import Settings, get_settings
 
 SIGNED_URL_TTL = 3600
+PNG_CONTENT_TYPE = "image/png"
 WEBP_CONTENT_TYPE = "image/webp"
 
 
@@ -48,7 +49,11 @@ class LocalStorage:
         return path
 
     async def upload_target(self, key: str) -> UploadTarget:
-        return UploadTarget(url=f"{self.worker_url}/api/v1/files/{key}")
+        content_type = PNG_CONTENT_TYPE if key.endswith(".png") else WEBP_CONTENT_TYPE
+        return UploadTarget(
+            url=f"{self.worker_url}/api/v1/files/{key}",
+            headers={"Content-Type": content_type},
+        )
 
     async def url(self, key: str) -> str:
         return f"{self.public_url}/api/v1/files/{key}"
@@ -79,16 +84,17 @@ class S3Storage:
 
     async def upload_target(self, key: str) -> UploadTarget:
         # Presigning is local computation, no network round trip.
+        content_type = PNG_CONTENT_TYPE if key.endswith(".png") else WEBP_CONTENT_TYPE
         url = self.client.generate_presigned_url(
             "put_object",
             Params={
                 "Bucket": self.bucket,
                 "Key": key,
-                "ContentType": WEBP_CONTENT_TYPE,
+                "ContentType": content_type,
             },
             ExpiresIn=SIGNED_URL_TTL,
         )
-        return UploadTarget(url=url, headers={"Content-Type": WEBP_CONTENT_TYPE})
+        return UploadTarget(url=url, headers={"Content-Type": content_type})
 
     async def url(self, key: str) -> str:
         return self.client.generate_presigned_url(

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -96,9 +96,13 @@ def test_generation_end_to_end():
             assert dispatch["type"] == "dispatch_job"
             assert dispatch["job_id"] == job_id
             assert dispatch["params"] == {"prompt": "a lighthouse"}
+            assert dispatch["upload"]["url"].endswith(f"/{job_id}.png")
+            assert dispatch["upload"]["headers"] == {"Content-Type": "image/png"}
+            assert dispatch["thumb_upload"]["url"].endswith(f"/{job_id}-thumb.webp")
+            assert dispatch["thumb_upload"]["headers"] == {"Content-Type": "image/webp"}
 
             upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+            assert client.put(upload_path, content=b"png-bytes").status_code == 200
             thumb_path = urlsplit(dispatch["thumb_upload"]["url"]).path
             assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
 
@@ -111,8 +115,10 @@ def test_generation_end_to_end():
             assert job["gpu_ms"] == 1234
             asset = job["assets"][0]
             assert asset["width"] == 512
+            assert asset["mime"] == "image/png"
+            assert asset["url"].endswith(f"/{job_id}.png")
             assert asset["thumbnail_url"] is not None
-            assert client.get(urlsplit(asset["url"]).path).content == b"webp-bytes"
+            assert client.get(urlsplit(asset["url"]).path).content == b"png-bytes"
             assert client.get(urlsplit(asset["thumbnail_url"]).path).content == b"thumb-bytes"
 
             history = client.get("/api/v1/generations").json()
@@ -309,7 +315,7 @@ def test_recover_requeues_running_and_dispatches_queued():
             first_id = first["job_id"]
 
             upload_path = urlsplit(first["upload"]["url"]).path
-            assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+            assert client.put(upload_path, content=b"png-bytes").status_code == 200
             thumb_path = urlsplit(first["thumb_upload"]["url"]).path
             assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
             worker.send_json({"type": "job_done", "job_id": first_id,
@@ -337,7 +343,7 @@ def test_img2img_dispatch_includes_input_url():
 
             dispatch = worker.receive_json()
             upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=b"source-webp").status_code == 200
+            assert client.put(upload_path, content=b"source-png").status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
                               "gpu_ms": 100, "width": 512, "height": 512})
             source_job = poll_until(client, source_job_id, "succeeded")
@@ -355,14 +361,14 @@ def test_img2img_dispatch_includes_input_url():
             assert i2i_dispatch["job_id"] == edit_job_id
             assert "input" in i2i_dispatch
             input_path = urlsplit(i2i_dispatch["input"]["url"]).path
-            assert client.get(input_path).content == b"source-webp"
+            assert client.get(input_path).content == b"source-png"
 
             assert client.put(urlsplit(i2i_dispatch["upload"]["url"]).path,
-                              content=b"edited-webp").status_code == 200
+                              content=b"edited-png").status_code == 200
             worker.send_json({"type": "job_done", "job_id": edit_job_id,
                               "gpu_ms": 200, "width": 512, "height": 512})
             edit_job = poll_until(client, edit_job_id, "succeeded")
-            assert edit_job["assets"][0]["url"].endswith(".webp")
+            assert edit_job["assets"][0]["url"].endswith(".png")
 
 
 @pytest.mark.db
@@ -414,7 +420,7 @@ def test_upscale_dispatch_includes_input_url():
             source_job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
             assert client.put(urlsplit(dispatch["upload"]["url"]).path,
-                              content=b"source-webp").status_code == 200
+                              content=b"source-png").status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
                               "gpu_ms": 50, "width": 512, "height": 512})
             source_asset_id = poll_until(client, source_job_id, "succeeded")["assets"][0]["id"]
@@ -441,10 +447,10 @@ def test_upscale_dispatch_includes_input_url():
             assert up_dispatch["job_id"] == upscale_job_id
             assert up_dispatch["params"] == {"factor": 2}
             assert "input" in up_dispatch
-            assert client.get(urlsplit(up_dispatch["input"]["url"]).path).content == b"source-webp"
+            assert client.get(urlsplit(up_dispatch["input"]["url"]).path).content == b"source-png"
 
             assert client.put(urlsplit(up_dispatch["upload"]["url"]).path,
-                              content=b"upscaled-webp").status_code == 200
+                              content=b"upscaled-png").status_code == 200
             worker.send_json({"type": "job_done", "job_id": upscale_job_id,
                               "gpu_ms": 400, "width": 1024, "height": 1024})
             done = poll_until(client, upscale_job_id, "succeeded")
@@ -544,7 +550,7 @@ def test_job_phase_timings_persisted():
             job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
             upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+            assert client.put(upload_path, content=b"png-bytes").status_code == 200
 
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 900, "input_fetch_ms": 50,
@@ -614,7 +620,7 @@ def _wait_for_dispatch(worker, expected: set[str], timeout=5.0) -> dict:
 
 def _finish_job(client, worker, dispatch: dict) -> None:
     upload_path = urlsplit(dispatch["upload"]["url"]).path
-    assert client.put(upload_path, content=b"webp-bytes").status_code == 200
+    assert client.put(upload_path, content=b"png-bytes").status_code == 200
     worker.send_json({"type": "job_done", "job_id": dispatch["job_id"],
                       "gpu_ms": 1, "width": 512, "height": 512})
     poll_until(client, dispatch["job_id"], "succeeded")

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -3,6 +3,7 @@ import asyncio
 import pytest
 from fastapi.testclient import TestClient
 
+from app.files import MAX_UPLOAD_BYTES
 from app.main import app
 from app.settings import Settings
 from app.storage import LocalStorage, S3Storage, get_storage
@@ -18,8 +19,11 @@ def test_local_storage_rejects_escaping_keys(tmp_path):
 
 def test_local_storage_urls(tmp_path):
     storage = LocalStorage(str(tmp_path), "http://browser/", "http://worker/")
-    target = asyncio.run(storage.upload_target("u/j.webp"))
-    assert target.url == "http://worker/api/v1/files/u/j.webp"
+    target = asyncio.run(storage.upload_target("u/j.png"))
+    assert target.url == "http://worker/api/v1/files/u/j.png"
+    assert target.headers == {"Content-Type": "image/png"}
+    thumb_target = asyncio.run(storage.upload_target("u/j-thumb.webp"))
+    assert thumb_target.headers == {"Content-Type": "image/webp"}
     assert asyncio.run(storage.url("u/j.webp")) == "http://browser/api/v1/files/u/j.webp"
 
 
@@ -28,15 +32,17 @@ def test_s3_storage_presigns_offline():
                                  storage_s3_endpoint="http://localhost:9100",
                                  storage_s3_access_key="key",
                                  storage_s3_secret_key="secret"))
-    target = asyncio.run(storage.upload_target("u/j.webp"))
+    target = asyncio.run(storage.upload_target("u/j.png"))
     assert target.url.startswith("http://localhost:9100/")
-    assert "u/j.webp" in target.url
+    assert "u/j.png" in target.url
     assert "X-Amz-Signature" in target.url
-    assert target.headers == {"Content-Type": "image/webp"}
+    assert target.headers == {"Content-Type": "image/png"}
+    thumb_target = asyncio.run(storage.upload_target("u/j-thumb.webp"))
+    assert thumb_target.headers == {"Content-Type": "image/webp"}
     # Browser-facing image URL (SPA <img src>), not the worker upload target.
-    view = asyncio.run(storage.url("u/j.webp"))
+    view = asyncio.run(storage.url("u/j.png"))
     assert view.startswith("http://localhost:9100/")
-    assert "u/j.webp" in view
+    assert "u/j.png" in view
     assert "X-Amz-Signature" in view
 
 
@@ -50,8 +56,27 @@ def test_files_get_after_direct_write():
     response = client.get("/api/v1/files/u1/j1.webp")
     assert response.status_code == 200
     assert response.content == b"image-bytes"
+    assert response.headers["content-type"] == "image/webp"
+    png_path = storage.path("u1/j2.png")
+    png_path.write_bytes(b"png-bytes")
+    png_response = client.get("/api/v1/files/u1/j2.png")
+    assert png_response.status_code == 200
+    assert png_response.content == b"png-bytes"
+    assert png_response.headers["content-type"] == "image/png"
     assert client.get("/api/v1/files/u1/missing.webp").status_code == 404
 
 
 def test_upload_requires_inflight_job():
     assert client.put("/api/v1/files/u1/j1.webp", content=b"image-bytes").status_code == 403
+
+
+def test_upload_ceiling_admits_a_lossless_upscale_master():
+    """The largest master the fleet can produce is a 4x upscale of a 1024 px
+    image, and PNG is lossless, so the ceiling has to clear that size even when
+    the detail does not compress. Measured: a real 1024 px generation reaches
+    about 19 MB re-encoded at 4096 px, and incompressible content there is
+    50 MB. The 20 MB ceiling this route shipped with would have started
+    refusing upscale uploads once masters stopped being WebP (issue #125).
+    """
+    pixels = (1024 * 4) ** 2
+    assert MAX_UPLOAD_BYTES >= pixels * 3  # raw RGB, which PNG does not exceed in practice

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -496,11 +496,11 @@ Generated images land in object storage through the storage adapter (local files
 | `users/{user_id}/` | Paying subscribers | Indefinite retention |
 | `trial/{user_id}/` | Trial accounts | `expires_at` on the asset row plus an S3 lifecycle rule expiring the prefix after 30 days |
 
-Object keys are `{prefix}{asset_id}.webp` with a sibling `{asset_id}-thumb.webp` thumbnail. History is the `assets` table, never a bucket listing.
+Object keys are `{prefix}{asset_id}.png` for PNG masters with a sibling `{asset_id}-thumb.webp` WebP thumbnail. History is the `assets` table, never a bucket listing.
 
 **Access:** objects are private by default. The API mints short-lived CloudFront signed GET URLs after session or API-key auth, only for rows the principal owns. Share links expose one asset under an unguessable token on a `/shared/*` behavior with a short TTL. Payment flips quota in the billing service; it never creates AWS IAM principals, buckets or access points for users.
 
-**Self-hosted:** keys are `{user_id}/{job_id}.webp` under `STORAGE_LOCAL_PATH`, served through the API's file route. There is no tier prefix because installs are single-tenant.
+**Self-hosted:** master keys are `{user_id}/{job_id}.png` with `{user_id}/{job_id}-thumb.webp` thumbnails under `STORAGE_LOCAL_PATH`, served through the API's file route. There is no tier prefix because installs are single-tenant.
 
 How the pieces reference each other - bytes live once in object storage, every relationship (thumbnail, lineage, favorite per issue #124, category per issue #95) is a column or foreign key on the PostgreSQL rows, and the browser only ever reaches bytes through URLs the API minted from those rows:
 
@@ -529,7 +529,7 @@ flowchart LR
     CLEAN -.-> STORE
 ```
 
-**Today versus target:** the S3 backend currently uses the same `{user_id}/{job_id}.webp` key shape and returns presigned S3 GET URLs (backend/app/storage.py); the tier prefixes, `{asset_id}` keys and CloudFront signed URLs above are the cloud-profile target and land with billing tiers and the CDN.
+**Today versus target:** the S3 backend currently uses the same `{user_id}/{job_id}.png` master key shape and returns presigned S3 GET URLs (backend/app/storage.py); the tier prefixes, `{asset_id}` keys and CloudFront signed URLs above are the cloud-profile target and land with billing tiers and the CDN.
 
 **Account purge and export:** deletion removes the user's database rows and deletes their prefix in storage. GDPR export streams the same prefix as a zip alongside account JSON.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -308,15 +308,20 @@ Models registered by workers persist in PostgreSQL, and `GET /api/v1/models` ret
 
 Rejected alternatives: listing only live models (simpler response, but a worker restart makes models vanish from the UI and orphans old history); returning the stored registry with no signal (the user discovers unavailability by a failed generation).
 
-## Stored outputs: WebP today, PNG masters planned
+## Stored outputs: PNG masters, WebP thumbnails and frames
 
-<!-- corrected 2026-07-23: header was "Stored outputs: PNG" but the code ships WebP -->
+<!-- corrected 2026-07-23: header was "Stored outputs: PNG" but the code shipped WebP -->
+<!-- corrected 2026-07-29: issue #125 shipped, so the code matches the original decision again -->
 
-Shipped reality: generated images and their thumbnails are written as **lossy WebP quality 80** by the worker (a single code path, small files, no extra dependency). The realtime wire is WebP too.
+The stored master is **lossless PNG**, written by Pillow with no extra dependency: universal, no quality knobs, and the archival copy of the user's work. Cloud storage cost is bounded by the retention decision rather than by the format.
 
-The original decision (kept for the record) was to store PNG masters: lossless, universal, no quality knobs, written by Pillow with no extra dependency, with cloud storage cost bounded by the retention decision rather than the format. That PNG-master intent is now tracked as open issue **#125** ("Store generation masters as PNG per the stored-outputs decision"); until it lands, masters are the same lossy WebP as everything else, so this entry and the code disagree by design-not-yet-shipped.
+Everything that exists to be looked at rather than kept is **WebP**: the derived thumbnails the gallery displays, and the realtime frame stream, where bytes on the wire decide the frame rate.
 
-Rejected alternatives: format as a request parameter (two code paths and a decision pushed onto every caller, for flexibility nobody asked for).
+Masters written before this shipped are still WebP and stay that way. There is no backfill: history and share links serve whatever `mime` and `storage_key` the asset row records, so a mixed bucket is normal and nothing reading an asset may assume the extension.
+
+One consequence worth recording: the largest master the fleet can produce is a 4x upscale of a 1024 px image, which measures about 19 MB losslessly and reaches 50 MB on incompressible detail. The local upload route's ceiling exists to bound abuse and has to stay clear of that, so it moved from 20 MB to 64 MB with this change.
+
+Rejected alternatives: format as a request parameter (two code paths and a decision pushed onto every caller, for flexibility nobody asked for); JPEG for the master (lossy, and no alpha); keeping WebP for the master too, which is what shipped between 2026-07-23 and this change, and which left the archival copy quietly lossy.
 
 ## Model manifests: JSON
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,7 +97,7 @@ upgrade an initial plain-HTTP connection.
 | Volume | Contents | Losing it means |
 |---|---|---|
 | `pgdata` | users, jobs (prompts, params, seeds), asset records | history and gallery are gone |
-| `assets` | generated images and thumbnails (WebP) | images are gone; rows point at nothing |
+| `assets` | generated PNG masters and WebP thumbnails | images are gone; rows point at nothing |
 | `models` | model manifests (JSON) | re-seeded from the image on next boot |
 | `hf-cache` | downloaded model weights | re-downloaded on next use (2-7 GB per model) |
 

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -119,7 +119,7 @@ def test_rejected_registration_raises_cleanly():
 class FakeUpload:
     """Stands in for httpx.AsyncClient; records the PUT it receives."""
 
-    puts: list[tuple[str, bytes]] = []
+    puts: list[tuple[str, bytes, dict[str, str] | None]] = []
     gets: list[str] = []
     get_body = b"input-webp"
     fail = False
@@ -148,7 +148,7 @@ class FakeUpload:
         return Response()
 
     async def put(self, url, content=b"", headers=None):
-        FakeUpload.puts.append((url, content))
+        FakeUpload.puts.append((url, content, headers))
 
         class Response:
             @staticmethod
@@ -167,8 +167,14 @@ def dispatch_control():
         "job_id": "j-1",
         "model_id": "sd-sim",
         "params": {"prompt": "a test"},
-        "upload": {"url": "http://api/api/v1/files/u/j-1.webp", "headers": {}},
-        "thumb_upload": {"url": "http://api/api/v1/files/u/j-1-thumb.webp", "headers": {}},
+        "upload": {
+            "url": "http://api/api/v1/files/u/j-1.png",
+            "headers": {"Content-Type": "image/png"},
+        },
+        "thumb_upload": {
+            "url": "http://api/api/v1/files/u/j-1-thumb.webp",
+            "headers": {"Content-Type": "image/webp"},
+        },
     }
 
 
@@ -181,11 +187,13 @@ def test_run_job_generates_uploads_and_reports(monkeypatch):
     asyncio.run(run_job(socket, SimulatedEngine(0.01), SIMULATED_MANIFEST, dispatch_control()))
 
     assert len(FakeUpload.puts) == 2
-    url, content = FakeUpload.puts[0]
-    assert url.endswith("j-1.webp")
-    assert content[:4] == b"RIFF"  # WebP container
-    thumb_url, thumb_content = FakeUpload.puts[1]
+    url, content, headers = FakeUpload.puts[0]
+    assert url.endswith("j-1.png")
+    assert headers == {"Content-Type": "image/png"}
+    assert content[:8] == b"\x89PNG\r\n\x1a\n"
+    thumb_url, thumb_content, thumb_headers = FakeUpload.puts[1]
     assert thumb_url.endswith("j-1-thumb.webp")
+    assert thumb_headers == {"Content-Type": "image/webp"}
     assert thumb_content[:4] == b"RIFF"
     reports = [json.loads(m) for m in socket.sent]
     types = [r["type"] for r in reports]

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -42,7 +42,7 @@ def test_simulated_generate_with_input_image():
     assert result.height == 128
     assert result.load_ms >= 0
     assert engine.loaded_models() == ["sd-sim"]
-    assert result.data[:4] == b"RIFF"
+    assert result.data[:8] == b"\x89PNG\r\n\x1a\n"
 
 
 def test_simulated_upscale_resizes_by_factor():
@@ -71,7 +71,7 @@ def test_simulated_upscale_resizes_by_factor():
     assert result.width == 256
     assert result.height == 192
     assert progress_values[-1] == 1.0
-    assert result.data[:4] == b"RIFF"
+    assert result.data[:8] == b"\x89PNG\r\n\x1a\n"
 
 
 def test_simulated_upscale_requires_input():

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -49,7 +49,7 @@ CALIBRATION_SAMPLES = 20
 
 @dataclass
 class GeneratedImage:
-    data: bytes  # always WebP; storage keys and asset rows assume it
+    data: bytes  # PNG generation master
     width: int
     height: int
     gpu_ms: int
@@ -97,6 +97,12 @@ def decode_input_image(data: bytes) -> Image.Image:
 def encode_webp(image: Image.Image) -> bytes:
     buffer = io.BytesIO()
     image.save(buffer, "WEBP", quality=80)
+    return buffer.getvalue()
+
+
+def encode_png(image: Image.Image) -> bytes:
+    buffer = io.BytesIO()
+    image.save(buffer, "PNG")
     return buffer.getvalue()
 
 
@@ -175,7 +181,7 @@ class SimulatedEngine:
             image = source.resize((width, height), Image.Resampling.LANCZOS)
             progress(1.0)
             gpu_ms = int((time.monotonic() - start) * 1000)
-            return GeneratedImage(encode_webp(image), width, height, gpu_ms, load_ms)
+            return GeneratedImage(encode_png(image), width, height, gpu_ms, load_ms)
         if input_image is not None and "image_to_image" not in manifest.capabilities:
             raise ValueError(f"model {manifest.id} does not support image_to_image jobs")
         load_ms = 0
@@ -207,7 +213,7 @@ class SimulatedEngine:
             rgb = (color[0], color[1], color[2])
             image = Image.new("RGB", (width, height), rgb)
         gpu_ms = int((time.monotonic() - start) * 1000)
-        return GeneratedImage(encode_webp(image), width, height, gpu_ms, load_ms)
+        return GeneratedImage(encode_png(image), width, height, gpu_ms, load_ms)
 
     async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame:
         started = time.monotonic()
@@ -767,7 +773,7 @@ class DiffusersEngine:
             callback_on_step_end=on_step,
         ).images[0]
         gpu_ms = int((time.monotonic() - start) * 1000)
-        return GeneratedImage(encode_webp(image), image.width, image.height, gpu_ms, load_ms)
+        return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 
     def _generate_i2i(self, manifest: Manifest, params: dict, progress: ProgressFn,
                       loop: asyncio.AbstractEventLoop,
@@ -808,7 +814,7 @@ class DiffusersEngine:
         ).images[0]
         gpu_ms = int((time.monotonic() - start) * 1000)
         loop.call_soon_threadsafe(progress, 1.0)
-        return GeneratedImage(encode_webp(image), image.width, image.height, gpu_ms, load_ms)
+        return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 
     def _generate_upscale(self, manifest: Manifest, params: dict, progress: ProgressFn,
                           loop: asyncio.AbstractEventLoop,
@@ -841,7 +847,7 @@ class DiffusersEngine:
         )
         gpu_ms = int((time.monotonic() - start) * 1000)
         loop.call_soon_threadsafe(progress, 1.0)
-        return GeneratedImage(encode_webp(image), image.width, image.height, gpu_ms, load_ms)
+        return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 
     async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame:
         async with self._gpu:


### PR DESCRIPTION
# Description

Closes #125.

The worker encodes a finished job's master as lossless PNG, the key ends `.png`, and the asset row records `image/png`. Thumbnails keep `-thumb.webp` and WebP encoding. The realtime frame stream is untouched.

# Motivation

`docs/decisions.md` has said masters are PNG since before the code shipped WebP for everything, and that entry has carried a correction note about the disagreement since 23 July. This closes the drift from the code side, which is the direction the decision always pointed.

PNG is the archival copy of the user's work: lossless, universal, no quality knobs. WebP stays where bytes on the wire decide the experience, which is the realtime stream and the thumbnails the gallery displays.

# Functionality

| Artifact | Key | Content type | Encoding |
| --- | --- | --- | --- |
| Master | `{user_id}/{job_id}.png` | `image/png` | PNG, lossless |
| Thumbnail | `{user_id}/{job_id}-thumb.webp` | `image/webp` | WebP, unchanged |
| Realtime frame | not stored | n/a | WebP, untouched |

No migration and no backfill. Masters written before this stay WebP and keep working: `FileResponse` already infers the type from the file, and the S3 upload target now derives its content type from the key, so a mixed bucket serves correctly. Nothing reading an asset assumes its extension.

# Details

**The upload ceiling had to move, and that is part of this fix rather than a separate concern.** Lossless masters are far larger than the WebP this route used to carry. The largest master the fleet can produce is a 4x upscale of a 1024 px image; I measured a real 1024 px generation at about **19 MB** re-encoded at 4096 px, against the route's **20 MB** ceiling, with incompressible detail at that size reaching 50 MB. As WebP the same image was 0.3 MB, so the ceiling was never close to being reached before. Left alone, upscale uploads would have begun failing with a 413 on every self-hosted install, and only there, since presigned S3 PUTs have no such limit. The ceiling is now 64 MB and a test pins it against that size so it cannot quietly shrink back.

This did not show up in the delegated implementation's own testing because the simulated engine emits flat-colour images that compress to almost nothing at any resolution.

**The decision entry did need editing, contrary to the issue.** The issue said it needed no change, but it described PNG masters as planned and #125 as open, which shipping this makes false. It now records the master/thumbnail split, the absence of a backfill, and the ceiling that follows from lossless masters, keeping the existing correction trail.

**Docs corrected alongside:** `ROADMAP.md` said "Outputs are lossy WebP quality 80 (PNG masters are planned, #125)", and `docs/architecture.md` and `docs/self-hosting.md` described the stored key shapes. All three would have been wrong on merge.

# Verification

- `make verify-backend`: ruff, mypy and **100 passed**.
- `make verify-worker`: ruff, mypy and **64 passed, 3 skipped**.
- `scripts/compose-smoke.sh`: passed, a real job through the container stack.
- Tests assert real bytes, not just names: PNG magic on the master and its upload, `RIFF` on the thumbnail, and a legacy `.webp` master still serving as `image/webp`.

Implementation delegated; the sandbox it ran in blocked the database, the full worker suite and the Docker socket, so all three verifications above are mine.