### PR TITLE
Bound the dependency ranges to the series that are tested

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,22 +8,22 @@ version = "0.0.1"
 description = "potocolom API server"
 requires-python = ">=3.11"
 dependencies = [
-    "fastapi>=0.115",
-    "uvicorn[standard]>=0.30",
-    "pydantic-settings>=2.4",
-    "sqlalchemy[asyncio]>=2.0",
-    "asyncpg>=0.29",
-    "alembic>=1.13",
-    "boto3>=1.34",
-    "jsonschema>=4.21",
+    "fastapi>=0.115,<1",
+    "uvicorn[standard]>=0.30,<1",
+    "pydantic-settings>=2.4,<3",
+    "sqlalchemy[asyncio]>=2.0,<3",
+    "asyncpg>=0.29,<1",
+    "alembic>=1.13,<2",
+    "boto3>=1.34,<2",
+    "jsonschema>=4.21,<5",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8",
-    "httpx>=0.27",
+    "pytest>=9,<10",
+    "httpx>=0.27,<1",
     "ruff>=0.6,<0.16",
-    "mypy>=1.11",
+    "mypy>=2,<3",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -667,6 +667,12 @@ The text encoder window a prompt is measured against comes from the manifest fie
 
 Rejected alternatives: hardcoding 77 in the studio, which is correct only for the models shipped today and silently wrong for the first model with a larger encoder; defaulting the field to 77 so existing manifests need no edit, which turns a forgotten declaration into a confident false warning rather than silence; asking the worker for an exact count per keystroke, which spends a round trip on a hint; and bundling a real tokenizer, which costs more transfer than the feature is worth.
 
+## Python dependencies: bounded ranges without a lockfile
+
+Direct Python dependencies use bounded ranges from the supported floor to the next major version. This keeps contributor installs within tested release series while preserving the worker's device-specific installation path: CUDA wheels come from PyPI, while ROCm and CPU torch wheels come from the matching `download.pytorch.org` index.
+
+Rejected alternatives: a lockfile, `uv` or `pip-tools`. A single resolved dependency tree cannot express the worker's different torch indexes by device, so these options would fight the documented install path.
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -8,29 +8,29 @@ version = "0.0.1"
 description = "potocolom inference worker"
 requires-python = ">=3.11"
 dependencies = [
-    "pydantic-settings>=2.4",
-    "websockets>=12",
-    "httpx>=0.27",
-    "pillow>=10",
+    "pydantic-settings>=2.4,<3",
+    "websockets>=16,<17",
+    "httpx>=0.27,<1",
+    "pillow>=12,<13",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8",
+    "pytest>=9,<10",
     "ruff>=0.6,<0.16",
-    "mypy>=1.11",
+    "mypy>=2,<3",
 ]
 # Install torch for your device first (CUDA wheels from PyPI; ROCm and CPU
 # wheels from the matching https://download.pytorch.org/whl/ index), then
 # install this extra. See docs/local-development.md for the ROCm notes.
 inference = [
-    "torch>=2.5",
-    "diffusers>=0.39",
-    "transformers>=4.44",
-    "accelerate>=0.33",
-    "torchao>=0.17",
-    "peft>=0.13",
-    "spandrel>=0.4",
+    "torch>=2.5,<3",
+    "diffusers>=0.39,<1",
+    "transformers>=5,<6",
+    "accelerate>=1,<2",
+    "torchao>=0.17,<1",
+    "peft>=0.13,<1",
+    "spandrel>=0.4,<1",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
# Description

Closes #182.

Every direct Python dependency now spans its tested floor to the next major version, in both `backend/pyproject.toml` and `worker/pyproject.toml`.

# Motivation

Floors with no ceiling and no lockfile mean two contributors installing weeks apart get different trees. Six dependencies had drifted so far that their floor sat below a major they had since crossed, so a fresh `make setup` could legitimately resolve a series nobody tests:

| dependency | declared | installed |
| --- | --- | --- |
| pytest | `>=8` | 9.1.1 |
| mypy | `>=1.11` | 2.1.0 |
| websockets | `>=12` | 16.0 |
| pillow | `>=10` | 12.2.0 |
| transformers | `>=4.44` | 5.13.1 |
| accelerate | `>=0.33` | 1.14.0 |

The transformers row is not hypothetical. transformers 5 removed `build_inputs_with_special_tokens`, and worker code would have crashed on one side of that boundary or the other depending on where an install landed. That was found by running against real weights, not by the test suite, because a fake stood in for the tokenizer.

# Functionality

The rule, applied uniformly: an upper bound at the next major, `<1` for a `0.x` dependency, and where the installed version sat a whole major above the declared floor, the floor moves up to the tested major.

This extends a shape the repository already used for `ruff>=0.6,<0.16` rather than introducing a mechanism. `ruff` itself is unchanged. `torchao`, added by #158, gains `>=0.17,<1` under the same rule.

# Details

**Not a lockfile, and the decision entry records why.** The worker installs torch per device from different indexes: CUDA wheels from PyPI, ROCm and CPU wheels from `download.pytorch.org`, which is documented in `worker/pyproject.toml` itself. A single resolved tree cannot express that, so `uv` or `pip-tools` would fight the documented install path. Bounded ranges get most of the benefit with none of that conflict.

**The floating container tags are deliberately untouched.** `postgres:16` and `redis:7` do move within their major, so they are a real reproducibility gap, but pinning them trades a self-hoster's automatic security patches for reproducibility. That is a separate decision and not mine to take here. Flagged rather than changed.

`hatchling` in `[build-system]` is also left alone: it is a build requirement rather than a project dependency.

# Verification

`make verify-backend` 100 passed, `make verify-worker` 79 passed 4 skipped, `make verify-mermaid` 35 diagrams, all with ruff and mypy.

Because bounds that exclude the installed version would break setup rather than fail a test, I checked the ranges two ways beyond the suites: programmatically, that all 19 installed versions fall inside their new range, and by resolving a clean install from an empty venv. `pip install --dry-run -e backend[dev]` and `-e worker[dev]` both resolve. The `worker[inference]` extra pulls torch and its resolve was interrupted by a network error partway; the extra is device-specific by design, so a plain PyPI resolve of it is not the path most users take anyway.