### PR TITLE
Download a generation with a name that says what it is

### DIFF
--- a/backend/app/files.py
+++ b/backend/app/files.py
@@ -13,7 +13,7 @@ import asyncio
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 
-from app.storage import LocalStorage, get_storage
+from app.storage import LocalStorage, get_storage, validate_download_name
 
 router = APIRouter()
 
@@ -65,12 +65,18 @@ async def upload(key: str, request: Request) -> dict:
 
 
 @router.get("/api/v1/files/{key:path}")
-async def serve(key: str) -> FileResponse:
+async def serve(key: str, download: str | None = None) -> FileResponse:
     storage = local_storage()
+    try:
+        download_name = validate_download_name(download) if download is not None else None
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
     try:
         path = storage.path(key)
     except ValueError as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
     if not path.is_file():
         raise HTTPException(status_code=404, detail="no such file")
+    if download_name is not None:
+        return FileResponse(path, filename=download_name)
     return FileResponse(path)

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -12,7 +12,9 @@ import asyncio
 import heapq
 import json
 import logging
+import re
 import time
+import unicodedata
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
@@ -44,6 +46,8 @@ JOB_DISPATCH_DEPTH = 2  # queued jobs per worker; overlap encode/upload with den
 
 TERMINAL_STATES = ("succeeded", "failed")
 THUMBNAIL_MAX_EDGE = 384  # thumbnail rendition size (issue #56)
+DOWNLOAD_SLUG_MAX_LENGTH = 48
+DOWNLOAD_SLUG_MAX_WORDS = 6
 
 
 class Queues(Protocol):
@@ -111,6 +115,31 @@ class GenerationRequest(BaseModel):
     source_asset_id: uuid.UUID | None = None
 
 
+def generation_download_name(
+    job: Job,
+    asset: Asset,
+    position: int | None = None,
+) -> str:
+    prompt = job.params.get("prompt")
+    source = prompt if isinstance(prompt, str) and prompt.strip() else job.model_id
+    ascii_source = (
+        unicodedata.normalize("NFKD", source).encode("ascii", "ignore").decode("ascii").lower()
+    )
+    words = re.findall(r"[a-z0-9]+", ascii_source)[:DOWNLOAD_SLUG_MAX_WORDS]
+    slug = "-".join(words)[:DOWNLOAD_SLUG_MAX_LENGTH].strip("-")
+    if not slug:
+        slug = "generation"
+    timestamp = job.created_at.strftime("%Y%m%d-%H%M%S")
+    filename = asset.storage_key.rsplit("/", 1)[-1]
+    _, separator, extension = filename.rpartition(".")
+    if not separator or not extension:
+        extension = asset.mime.rpartition("/")[2]
+        if re.fullmatch(r"[a-z0-9]+", extension) is None:
+            extension = "bin"
+    position_suffix = f"-{position}" if position is not None else ""
+    return f"potocolom-{timestamp}-{slug}{position_suffix}.{extension}"
+
+
 @router.post("/api/v1/generations", status_code=202)
 async def create_generation(
     request: GenerationRequest,
@@ -158,6 +187,14 @@ async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
                 thumbs_by_parent[asset.parent_asset_id] = asset
     storage = get_storage()
     now = datetime.now(timezone.utc)
+    masters = {
+        job.id: [
+            asset
+            for asset in assets.get(job.id, [])
+            if not asset.storage_key.endswith("-thumb.webp")
+        ]
+        for job in jobs
+    }
     return [
         {
             "id": str(job.id),
@@ -179,26 +216,29 @@ async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
                 {
                     "id": str(asset.id),
                     "url": await storage.url(asset.storage_key),
+                    "download_url": await storage.url(
+                        asset.storage_key,
+                        download_name=generation_download_name(
+                            job,
+                            asset,
+                            position if len(masters[job.id]) > 1 else None,
+                        ),
+                    ),
                     "thumbnail_url": await storage.url(thumb.storage_key)
                     if (thumb := thumbs_by_parent.get(asset.id)) is not None else None,
                     "mime": asset.mime,
                     "width": asset.width,
                     "height": asset.height,
                 }
-                for asset in assets.get(job.id, [])
-                if not asset.storage_key.endswith("-thumb.webp")
-                and (asset.expires_at is None or asset.expires_at > now)
+                for position, asset in enumerate(masters[job.id], start=1)
+                if asset.expires_at is None or asset.expires_at > now
             ],
             "expired_favorite": bool(
                 job.starred_at
-                and any(
-                    not asset.storage_key.endswith("-thumb.webp")
-                    for asset in assets.get(job.id, [])
-                )
+                and masters[job.id]
                 and not any(
-                    not asset.storage_key.endswith("-thumb.webp")
-                    and (asset.expires_at is None or asset.expires_at > now)
-                    for asset in assets.get(job.id, [])
+                    asset.expires_at is None or asset.expires_at > now
+                    for asset in masters[job.id]
                 )
             ),
         }

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -134,8 +134,9 @@ def generation_download_name(
     _, separator, extension = filename.rpartition(".")
     if not separator or not extension:
         extension = asset.mime.rpartition("/")[2]
-        if re.fullmatch(r"[a-z0-9]+", extension) is None:
+        if re.fullmatch(r"[a-z0-9]+", extension.lower()) is None:
             extension = "bin"
+    extension = extension.lower()
     position_suffix = f"-{position}" if position is not None else ""
     return f"potocolom-{timestamp}-{slug}{position_suffix}.{extension}"
 
@@ -187,11 +188,21 @@ async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
                 thumbs_by_parent[asset.parent_asset_id] = asset
     storage = get_storage()
     now = datetime.now(timezone.utc)
-    masters = {
+    # Keep expired masters for expired_favorite, but number only the assets the
+    # client can see.
+    all_masters = {
         job.id: [
             asset
             for asset in assets.get(job.id, [])
             if not asset.storage_key.endswith("-thumb.webp")
+        ]
+        for job in jobs
+    }
+    visible_masters = {
+        job.id: [
+            asset
+            for asset in all_masters[job.id]
+            if asset.expires_at is None or asset.expires_at > now
         ]
         for job in jobs
     }
@@ -221,7 +232,7 @@ async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
                         download_name=generation_download_name(
                             job,
                             asset,
-                            position if len(masters[job.id]) > 1 else None,
+                            position if len(visible_masters[job.id]) > 1 else None,
                         ),
                     ),
                     "thumbnail_url": await storage.url(thumb.storage_key)
@@ -230,15 +241,14 @@ async def serialize_jobs(session: AsyncSession, jobs: list[Job]) -> list[dict]:
                     "width": asset.width,
                     "height": asset.height,
                 }
-                for position, asset in enumerate(masters[job.id], start=1)
-                if asset.expires_at is None or asset.expires_at > now
+                for position, asset in enumerate(visible_masters[job.id], start=1)
             ],
             "expired_favorite": bool(
                 job.starred_at
-                and masters[job.id]
+                and all_masters[job.id]
                 and not any(
                     asset.expires_at is None or asset.expires_at > now
-                    for asset in masters[job.id]
+                    for asset in all_masters[job.id]
                 )
             ),
         }

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -6,16 +6,32 @@ URL in the cloud, an internal API route (app/files.py) when local.
 """
 
 import asyncio
+import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 from typing import Protocol
+from urllib.parse import urlencode
 
 from app.settings import Settings, get_settings
 
 SIGNED_URL_TTL = 3600
 PNG_CONTENT_TYPE = "image/png"
 WEBP_CONTENT_TYPE = "image/webp"
+DOWNLOAD_NAME_MAX_LENGTH = 96
+DOWNLOAD_NAME_PATTERN = re.compile(
+    r"[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+",
+)
+
+
+def validate_download_name(name: str) -> str:
+    if len(name) > DOWNLOAD_NAME_MAX_LENGTH or DOWNLOAD_NAME_PATTERN.fullmatch(name) is None:
+        raise ValueError("unsafe download filename")
+    return name
+
+
+def download_content_disposition(name: str) -> str:
+    return f'attachment; filename="{validate_download_name(name)}"'
 
 
 @dataclass
@@ -27,7 +43,7 @@ class UploadTarget:
 class Storage(Protocol):
     async def upload_target(self, key: str) -> UploadTarget: ...
 
-    async def url(self, key: str) -> str: ...
+    async def url(self, key: str, download_name: str | None = None) -> str: ...
 
     async def worker_fetch_url(self, key: str) -> str: ...
 
@@ -55,8 +71,11 @@ class LocalStorage:
             headers={"Content-Type": content_type},
         )
 
-    async def url(self, key: str) -> str:
-        return f"{self.public_url}/api/v1/files/{key}"
+    async def url(self, key: str, download_name: str | None = None) -> str:
+        url = f"{self.public_url}/api/v1/files/{key}"
+        if download_name is None:
+            return url
+        return f"{url}?{urlencode({'download': validate_download_name(download_name)})}"
 
     async def worker_fetch_url(self, key: str) -> str:
         return f"{self.worker_url}/api/v1/files/{key}"
@@ -96,10 +115,13 @@ class S3Storage:
         )
         return UploadTarget(url=url, headers={"Content-Type": content_type})
 
-    async def url(self, key: str) -> str:
+    async def url(self, key: str, download_name: str | None = None) -> str:
+        params = {"Bucket": self.bucket, "Key": key}
+        if download_name is not None:
+            params["ResponseContentDisposition"] = download_content_disposition(download_name)
         return self.client.generate_presigned_url(
             "get_object",
-            Params={"Bucket": self.bucket, "Key": key},
+            Params=params,
             ExpiresIn=SIGNED_URL_TTL,
         )
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -78,6 +78,30 @@ def test_generation_download_name_uses_mime_for_extensionless_key():
     )
 
 
+@pytest.mark.parametrize(
+    ("storage_key", "mime", "expected_extension"),
+    [
+        ("user/generation.PNG", "image/png", "png"),
+        ("user/generation", "image/WEBP", "webp"),
+    ],
+)
+def test_generation_download_name_normalizes_extension(
+    storage_key,
+    mime,
+    expected_extension,
+):
+    job = Job(
+        model_id="sd-test",
+        params={"prompt": "A lighthouse"},
+        created_at=datetime(2026, 7, 29, 14, 25, 30, tzinfo=timezone.utc),
+    )
+    asset = Asset(storage_key=storage_key, mime=mime)
+
+    assert generation_download_name(job, asset) == (
+        f"potocolom-20260729-142530-a-lighthouse.{expected_extension}"
+    )
+
+
 def test_generation_download_name_includes_batch_position():
     job = Job(
         model_id="sd-test",
@@ -107,7 +131,7 @@ def poll_until(client, job_id, state, timeout=5.0):
 
 
 @pytest.mark.db
-def test_generation_download_names_match_master_extensions_and_positions():
+def test_generation_download_names_count_only_visible_masters():
     created_at = datetime(2026, 7, 29, 14, 25, 30, tzinfo=timezone.utc)
 
     async def seed_generation() -> uuid.UUID:
@@ -163,6 +187,50 @@ def test_generation_download_names_match_master_extensions_and_positions():
             ))
             await session.commit()
 
+    async def seed_generation_with_expired_first() -> uuid.UUID:
+        assert db.local_user_id is not None
+        assert db.session_factory is not None
+        job_id = uuid.uuid4()
+        async with db.session_factory() as session:
+            if await session.get(Model, "sd-test") is None:
+                session.add(Model(
+                    id="sd-test",
+                    name="SD Test",
+                    capabilities=["text_to_image"],
+                    parameters_schema=MANIFEST["parameters"],
+                    min_vram_gb=0,
+                ))
+            await session.flush()
+            session.add(Job(
+                id=job_id,
+                user_id=db.local_user_id,
+                model_id="sd-test",
+                params={"prompt": "A lighthouse"},
+                state="succeeded",
+                created_at=created_at,
+            ))
+            await session.flush()
+            session.add(Asset(
+                user_id=db.local_user_id,
+                job_id=job_id,
+                storage_key=f"{db.local_user_id}/{job_id}-expired.png",
+                mime="image/png",
+                width=512,
+                height=512,
+                expires_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            ))
+            await session.flush()
+            session.add(Asset(
+                user_id=db.local_user_id,
+                job_id=job_id,
+                storage_key=f"{db.local_user_id}/{job_id}-survivor.webp",
+                mime="image/webp",
+                width=512,
+                height=512,
+            ))
+            await session.commit()
+        return job_id
+
     base_name = "potocolom-20260729-142530-a-lighthouse"
     with TestClient(app) as client:
         job_id = asyncio.run(seed_generation())
@@ -179,6 +247,15 @@ def test_generation_download_names_match_master_extensions_and_positions():
             assert parse_qs(urlsplit(asset["download_url"]).query) == {
                 "download": [f"{base_name}-{position}.{extension}"],
             }
+
+        expired_first_job_id = asyncio.run(seed_generation_with_expired_first())
+        surviving_assets = client.get(
+            f"/api/v1/generations/{expired_first_job_id}"
+        ).json()["assets"]
+        assert len(surviving_assets) == 1
+        assert parse_qs(urlsplit(surviving_assets[0]["download_url"]).query) == {
+            "download": [f"{base_name}.webp"],
+        }
 
 
 @pytest.mark.db

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -5,13 +5,14 @@ import asyncio
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
-from urllib.parse import urlsplit
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from sqlalchemy import delete, func, select
 from fastapi.testclient import TestClient
 
 from app import db
+from app.jobs import generation_download_name
 from app.main import app
 from app.realtime import PROTOCOL_VERSION
 from app.tables import Asset, Job, Model, UsageEvent
@@ -40,6 +41,54 @@ MANIFEST_WITH_RT = {
     "capabilities": ["text_to_image", "image_to_image", "realtime"],
 }
 
+HOSTILE_PROMPT = 'A "lighthouse"\n; ../../ caf\u00e9'
+
+
+def test_generation_download_name_falls_back_to_model():
+    job = Job(
+        model_id="sd-test",
+        params={"prompt": " \n "},
+        created_at=datetime(2026, 7, 29, 14, 25, 30, tzinfo=timezone.utc),
+    )
+    asset = Asset(storage_key="user/generation.png", mime="image/png")
+    assert generation_download_name(job, asset) == "potocolom-20260729-142530-sd-test.png"
+
+
+def test_generation_download_name_uses_webp_master_extension():
+    job = Job(
+        model_id="sd-test",
+        params={"prompt": "A lighthouse"},
+        created_at=datetime(2026, 7, 29, 14, 25, 30, tzinfo=timezone.utc),
+    )
+    asset = Asset(storage_key="user/generation.webp", mime="image/webp")
+    assert generation_download_name(job, asset) == (
+        "potocolom-20260729-142530-a-lighthouse.webp"
+    )
+
+
+def test_generation_download_name_uses_mime_for_extensionless_key():
+    job = Job(
+        model_id="sd-test",
+        params={"prompt": "A lighthouse"},
+        created_at=datetime(2026, 7, 29, 14, 25, 30, tzinfo=timezone.utc),
+    )
+    asset = Asset(storage_key="user/generation", mime="image/webp")
+    assert generation_download_name(job, asset) == (
+        "potocolom-20260729-142530-a-lighthouse.webp"
+    )
+
+
+def test_generation_download_name_includes_batch_position():
+    job = Job(
+        model_id="sd-test",
+        params={"prompt": "A lighthouse"},
+        created_at=datetime(2026, 7, 29, 14, 25, 30, tzinfo=timezone.utc),
+    )
+    asset = Asset(storage_key="user/generation.webp", mime="image/webp")
+    assert generation_download_name(job, asset, position=2) == (
+        "potocolom-20260729-142530-a-lighthouse-2.webp"
+    )
+
 
 def fleet_hello(ws, worker_id, manifest=MANIFEST):
     ws.send_json({"type": "hello", "protocol_version": PROTOCOL_VERSION,
@@ -55,6 +104,76 @@ def poll_until(client, job_id, state, timeout=5.0):
             return job
         time.sleep(0.05)
     raise AssertionError(f"job {job_id} never reached {state}")
+
+
+@pytest.mark.db
+def test_generation_download_names_match_master_extensions_and_positions():
+    created_at = datetime(2026, 7, 29, 14, 25, 30, tzinfo=timezone.utc)
+
+    async def seed_generation() -> uuid.UUID:
+        assert db.local_user_id is not None
+        assert db.session_factory is not None
+        job_id = uuid.uuid4()
+        async with db.session_factory() as session:
+            if await session.get(Model, "sd-test") is None:
+                session.add(Model(
+                    id="sd-test",
+                    name="SD Test",
+                    capabilities=["text_to_image"],
+                    parameters_schema=MANIFEST["parameters"],
+                    min_vram_gb=0,
+                ))
+            session.add(Job(
+                id=job_id,
+                user_id=db.local_user_id,
+                model_id="sd-test",
+                params={"prompt": "A lighthouse"},
+                state="succeeded",
+                created_at=created_at,
+            ))
+            # Flush the job first because jobs and assets have circular foreign keys.
+            await session.flush()
+            session.add(Asset(
+                user_id=db.local_user_id,
+                job_id=job_id,
+                storage_key=f"{db.local_user_id}/{job_id}.webp",
+                mime="image/webp",
+                width=512,
+                height=512,
+            ))
+            await session.commit()
+        return job_id
+
+    async def add_second_asset(job_id: uuid.UUID) -> None:
+        assert db.local_user_id is not None
+        assert db.session_factory is not None
+        async with db.session_factory() as session:
+            session.add(Asset(
+                user_id=db.local_user_id,
+                job_id=job_id,
+                storage_key=f"{db.local_user_id}/{job_id}-second.png",
+                mime="image/png",
+                width=512,
+                height=512,
+            ))
+            await session.commit()
+
+    base_name = "potocolom-20260729-142530-a-lighthouse"
+    with TestClient(app) as client:
+        job_id = asyncio.run(seed_generation())
+        single_asset = client.get(f"/api/v1/generations/{job_id}").json()["assets"][0]
+        assert parse_qs(urlsplit(single_asset["download_url"]).query) == {
+            "download": [f"{base_name}.webp"],
+        }
+
+        asyncio.run(add_second_asset(job_id))
+        batch_assets = client.get(f"/api/v1/generations/{job_id}").json()["assets"]
+        assert len(batch_assets) == 2
+        for position, asset in enumerate(batch_assets, start=1):
+            extension = asset["url"].rsplit(".", 1)[-1]
+            assert parse_qs(urlsplit(asset["download_url"]).query) == {
+                "download": [f"{base_name}-{position}.{extension}"],
+            }
 
 
 @pytest.mark.db
@@ -88,14 +207,14 @@ def test_generation_end_to_end():
 
             created = client.post("/api/v1/generations",
                                   json={"model_id": "sd-test",
-                                        "params": {"prompt": "a lighthouse"}})
+                                        "params": {"prompt": HOSTILE_PROMPT}})
             assert created.status_code == 202
             job_id = created.json()["job_id"]
 
             dispatch = worker.receive_json()
             assert dispatch["type"] == "dispatch_job"
             assert dispatch["job_id"] == job_id
-            assert dispatch["params"] == {"prompt": "a lighthouse"}
+            assert dispatch["params"] == {"prompt": HOSTILE_PROMPT}
             assert dispatch["upload"]["url"].endswith(f"/{job_id}.png")
             assert dispatch["upload"]["headers"] == {"Content-Type": "image/png"}
             assert dispatch["thumb_upload"]["url"].endswith(f"/{job_id}-thumb.webp")
@@ -117,6 +236,15 @@ def test_generation_end_to_end():
             assert asset["width"] == 512
             assert asset["mime"] == "image/png"
             assert asset["url"].endswith(f"/{job_id}.png")
+            created_stamp = datetime.fromisoformat(job["created_at"]).strftime("%Y%m%d-%H%M%S")
+            expected_name = f"potocolom-{created_stamp}-a-lighthouse-cafe.png"
+            download_url = urlsplit(asset["download_url"])
+            assert parse_qs(download_url.query) == {"download": [expected_name]}
+            download_response = client.get(f"{download_url.path}?{download_url.query}")
+            assert download_response.content == b"png-bytes"
+            assert download_response.headers["content-disposition"] == (
+                f'attachment; filename="{expected_name}"'
+            )
             assert asset["thumbnail_url"] is not None
             assert client.get(urlsplit(asset["url"]).path).content == b"png-bytes"
             assert client.get(urlsplit(asset["thumbnail_url"]).path).content == b"thumb-bytes"

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -123,6 +123,12 @@ def test_generation_download_names_match_master_extensions_and_positions():
                     parameters_schema=MANIFEST["parameters"],
                     min_vram_gb=0,
                 ))
+            # The models table is deliberately not truncated, so an existing row
+            # can hide this model-to-job ordering requirement. Flush the model
+            # before the job on a pristine database, then flush the job before its
+            # asset because jobs.source_asset_id and assets.job_id form a cycle
+            # that SQLAlchemy cannot order.
+            await session.flush()
             session.add(Job(
                 id=job_id,
                 user_id=db.local_user_id,
@@ -131,7 +137,6 @@ def test_generation_download_names_match_master_extensions_and_positions():
                 state="succeeded",
                 created_at=created_at,
             ))
-            # Flush the job first because jobs and assets have circular foreign keys.
             await session.flush()
             session.add(Asset(
                 user_id=db.local_user_id,
@@ -366,6 +371,8 @@ async def _seed_recover_jobs() -> tuple[uuid.UUID, uuid.UUID]:
                 parameters_schema=MANIFEST["parameters"],
                 min_vram_gb=0,
             ))
+        # Keep the model-to-job foreign key order explicit on a pristine database.
+        await session.flush()
         session.add(Job(
             id=queued_id,
             user_id=db.local_user_id,

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,4 +1,5 @@
 import asyncio
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 from fastapi.testclient import TestClient
@@ -25,6 +26,12 @@ def test_local_storage_urls(tmp_path):
     thumb_target = asyncio.run(storage.upload_target("u/j-thumb.webp"))
     assert thumb_target.headers == {"Content-Type": "image/webp"}
     assert asyncio.run(storage.url("u/j.webp")) == "http://browser/api/v1/files/u/j.webp"
+    download_url = asyncio.run(
+        storage.url("u/j.png", download_name="potocolom-20260729-142530-castle.png")
+    )
+    assert parse_qs(urlsplit(download_url).query) == {
+        "download": ["potocolom-20260729-142530-castle.png"],
+    }
 
 
 def test_s3_storage_presigns_offline():
@@ -44,6 +51,18 @@ def test_s3_storage_presigns_offline():
     assert view.startswith("http://localhost:9100/")
     assert "u/j.png" in view
     assert "X-Amz-Signature" in view
+    download = asyncio.run(
+        storage.url("u/j.png", download_name="potocolom-20260729-142530-castle.png")
+    )
+    assert parse_qs(urlsplit(download).query)["response-content-disposition"] == [
+        'attachment; filename="potocolom-20260729-142530-castle.png"',
+    ]
+
+
+def test_storage_rejects_unsafe_download_name(tmp_path):
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    with pytest.raises(ValueError, match="unsafe download filename"):
+        asyncio.run(storage.url("u/j.png", download_name='safe.png"\r\nX-Evil: injected'))
 
 
 def test_files_get_after_direct_write():
@@ -57,6 +76,12 @@ def test_files_get_after_direct_write():
     assert response.status_code == 200
     assert response.content == b"image-bytes"
     assert response.headers["content-type"] == "image/webp"
+    assert "content-disposition" not in response.headers
+    unsafe_response = client.get(
+        "/api/v1/files/u1/j1.webp",
+        params={"download": 'safe.webp"\r\nX-Evil: injected'},
+    )
+    assert unsafe_response.status_code == 400
     png_path = storage.path("u1/j2.png")
     png_path.write_bytes(b"png-bytes")
     png_response = client.get("/api/v1/files/u1/j2.png")

--- a/frontend/src/lib/components/generate-panel.svelte
+++ b/frontend/src/lib/components/generate-panel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import ClipboardPasteIcon from '@lucide/svelte/icons/clipboard-paste';
+	import DownloadIcon from '@lucide/svelte/icons/download';
 	import PencilIcon from '@lucide/svelte/icons/pencil';
 	import ScanLineIcon from '@lucide/svelte/icons/scan-line';
 	import StarIcon from '@lucide/svelte/icons/star';
@@ -623,19 +624,30 @@
 		<Card.Root class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
 			<Card.Content class="flex min-h-0 flex-1 flex-col gap-2 p-4">
 				{#if shown !== null}
-					<a
-						href={shown.assets[0].url}
-						target="_blank"
-						rel="noopener"
-						class="block min-h-0 flex-1"
-						title={t('app.gen.open_full')}
-					>
-						<img
-							src={shown.assets[0].url}
-							alt={shown.params.prompt ?? t('app.gen.result')}
-							class="h-full w-full rounded-lg object-contain"
-						/>
-					</a>
+					<div class="relative min-h-0 flex-1">
+						<a
+							href={shown.assets[0].url}
+							target="_blank"
+							rel="noopener"
+							class="block h-full"
+							title={t('app.gen.open_full')}
+						>
+							<img
+								src={shown.assets[0].url}
+								alt={shown.params.prompt ?? t('app.gen.result')}
+								class="h-full w-full rounded-lg object-contain"
+							/>
+						</a>
+						<Button
+							href={shown.assets[0].download_url}
+							variant="secondary"
+							size="sm"
+							class="absolute top-2 right-2"
+						>
+							<DownloadIcon />
+							{t('app.gen.download')}
+						</Button>
+					</div>
 					<p class="text-muted-foreground min-w-0 truncate text-center text-xs">
 						{#if shown.params.prompt}
 							{shown.params.prompt}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -229,6 +229,7 @@
 	"app.gen.result": "Generated image",
 	"app.gen.result_hint": "Your image appears here",
 	"app.gen.open_full": "Open full size",
+	"app.gen.download": "Download",
 	"app.gen.badge_failed": "failed",
 	"app.gen.badge_working": "working",
 	"app.gen.load_older": "Older",

--- a/frontend/src/lib/i18n/es.json
+++ b/frontend/src/lib/i18n/es.json
@@ -229,6 +229,7 @@
 	"app.gen.result": "Imagen generada",
 	"app.gen.result_hint": "Tu imagen aparece aqui",
 	"app.gen.open_full": "Abrir a tamano completo",
+	"app.gen.download": "Descargar",
 	"app.gen.badge_failed": "fallida",
 	"app.gen.badge_working": "en curso",
 	"app.gen.load_older": "Anteriores",

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -29,7 +29,13 @@ export type Model = {
 	} & Record<string, unknown>;
 };
 
-export type Asset = { id: string; url: string; width: number; height: number };
+export type Asset = {
+	id: string;
+	url: string;
+	download_url: string;
+	width: number;
+	height: number;
+};
 
 export type Generation = {
 	id: string;


### PR DESCRIPTION
# Description

Closes #188.

A download control on the result view. The saved file keeps the stored master's bytes unchanged and gets a name built from the generation's own data: `potocolom-20260729-142530-a-castle-on-a-hill.png`.

# Motivation

There was no download feature at all. The result view linked the asset with `<a target="_blank">`, so saving meant opening a tab and using Save As, which named the file after the storage key, a bare job UUID. The filename is most of the value here: a folder of UUIDs cannot be searched.

# Functionality

- Download control on the displayed image, with copy in both dictionaries.
- Filename is `potocolom-{timestamp}-{slug}.{ext}`, the slug from the prompt, falling back to the model id, and `generation` if neither yields anything usable.
- Bytes are the stored master. No re-encoding, no format conversion, no format selector.

# Details

**The obvious approach would have worked here and failed silently in the cloud.** The HTML `download` attribute sets the saved name, but browsers ignore it cross-origin. Self-hosted installs serve from `/api/v1/files/...` on the API's own origin, so it would have worked locally; the cloud mints presigned S3 URLs on another host, where it is dropped, and `S3Storage.url` passed only `Bucket` and `Key`. So this goes through the storage seam instead: an optional download name, honoured by `FileResponse(filename=...)` locally and `ResponseContentDisposition` on S3, requested only when a download is wanted so ordinary display still serves inline.

**The prompt reaches a response header, so it is a trust boundary.** The slug is built from lowercase ASCII words only, capped at six words and 48 characters, with separators collapsed and no edge hyphens. Independently of that, the storage layer validates the finished name against a strict pattern and raises rather than emitting a header, and the local route answers 400 for a tampered `download` parameter, since that one is client-visible. A test drives a prompt containing quotes, a newline, a semicolon, a traversal attempt and non-ASCII.

**The extension comes from the asset, not from an assumption.** The first implementation hardcoded `.png`. Issue #125 shipped PNG masters with no backfill, and `docs/decisions.md` records that nothing reading an asset may assume its extension: every older image is still WebP, and all **4361** asset rows in the development database are. Naming those `.png` would have described bytes that are not in the file. The extension now comes from the asset's key, falling back to its MIME subtype for a key without one.

A generation can hold eight images, and each shares one job, so a batch numbers its images and a single image is left unnumbered rather than growing a pointless `-1`.

**One test could not pass as first written**, and the reason is worth recording: `jobs.source_asset_id` references `assets` while `assets.job_id` references `jobs`, so the two tables have a circular foreign key and SQLAlchemy cannot order them inside one flush. Seeding a job and its asset in a single flush inserted the asset first and violated the constraint. The test now flushes the job before adding the asset, with a comment naming the cycle.

# Verification

`make verify-backend` **106 passed**, `make verify-frontend` including its 9 node tests and build, both with ruff, mypy and svelte-check.

Beyond the suites I checked the naming directly against real shapes: a `.webp` key yields a `.webp` name, a `.png` key a `.png` name, an extensionless key falls back to the MIME subtype, a batch member gains its position, and an empty prompt yields the model id.

Implementation delegated; its sandbox could not reach PostgreSQL, so the suites and the checks above are mine. That is how the hardcoded extension and the circular-foreign-key failure were caught.