### PR TITLE
Hold the GPU lock only for work that needs the GPU

### DIFF
--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -6,7 +6,12 @@ from unittest.mock import MagicMock, patch
 
 from PIL import Image
 
-from worker.engine import CALIBRATION_SAMPLES, DiffusersEngine, SimulatedEngine
+from worker.engine import (
+    CALIBRATION_SAMPLES,
+    DiffusersEngine,
+    SimulatedEngine,
+    encode_webp,
+)
 from worker.manifests import Manifest, SIMULATED_MANIFEST
 
 
@@ -569,6 +574,127 @@ def test_group_offload_uses_disk_only_for_unquantized_models(tmp_path):
     )
 
 
+def test_frame_keeps_pillow_work_outside_gpu_lock():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    torch_stub = SimpleNamespace(
+        OutOfMemoryError=type("OutOfMemoryError", (Exception,), {}),
+    )
+    engine.torch = torch_stub
+    engine._gpu = asyncio.Lock()
+    engine._pick_rung = MagicMock(return_value="full")
+    engine._evict_except = MagicMock()
+    engine._evict_poisoned = MagicMock()
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+    )
+    rendered = Image.new("RGB", (32, 32), (12, 34, 56))
+    expected = encode_webp(rendered)
+    events: list[tuple[str, bool]] = []
+
+    def run_pipeline(**kwargs):
+        events.append(("diffusion", engine._gpu.locked()))
+        assert kwargs["image"].size == (512, 512)
+        return SimpleNamespace(images=[rendered])
+
+    pipeline = MagicMock(side_effect=run_pipeline)
+
+    def load_pipeline(*_args):
+        events.append(("pipeline", engine._gpu.locked()))
+        return pipeline
+
+    def prompt_kwargs(*_args):
+        events.append(("prompt", engine._gpu.locked()))
+        return {"prompt": "frame"}
+
+    engine._pipeline = MagicMock(side_effect=load_pipeline)
+    engine._prompt_kwargs = MagicMock(side_effect=prompt_kwargs)
+    source = io.BytesIO()
+    Image.new("RGB", (24, 16), (1, 2, 3)).save(source, "PNG")
+    open_image = Image.open
+
+    def track_open(*args, **kwargs):
+        events.append(("decode", engine._gpu.locked()))
+        return open_image(*args, **kwargs)
+
+    def track_encode(image):
+        events.append(("encode", engine._gpu.locked()))
+        return encode_webp(image)
+
+    async def run_inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    with (
+        patch("asyncio.to_thread", side_effect=run_inline) as run,
+        patch("worker.engine.Image.open", side_effect=track_open),
+        patch("worker.engine.encode_webp", side_effect=track_encode),
+    ):
+        result = asyncio.run(engine.frame(manifest, {"prompt": "frame"}, source.getvalue()))
+
+    assert events == [
+        ("decode", False),
+        ("pipeline", True),
+        ("prompt", True),
+        ("diffusion", True),
+        ("encode", False),
+    ]
+    assert result.data == expected
+    assert isinstance(result.gpu_ms, int)
+    assert result.gpu_ms >= 0
+    assert run.call_count == 3
+    engine._evict_except.assert_not_called()
+    engine._evict_poisoned.assert_not_called()
+
+
+def test_frame_oom_retries_once_without_decoding_twice():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    torch_stub = SimpleNamespace(
+        OutOfMemoryError=type("OutOfMemoryError", (Exception,), {}),
+    )
+    engine.torch = torch_stub
+    engine._gpu = asyncio.Lock()
+    engine._pick_rung = MagicMock(return_value="full")
+    engine._evict_except = MagicMock()
+    engine._evict_poisoned = MagicMock()
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+    )
+    rendered = Image.new("RGB", (32, 32), (12, 34, 56))
+    canvases: list[Image.Image] = []
+
+    def run_frame(_manifest, _params, canvas, _strength):
+        canvases.append(canvas)
+        if len(canvases) == 1:
+            raise torch_stub.OutOfMemoryError
+        return rendered, 17
+
+    engine._frame = MagicMock(side_effect=run_frame)
+    source = io.BytesIO()
+    Image.new("RGB", (24, 16), (1, 2, 3)).save(source, "PNG")
+    open_image = Image.open
+
+    async def run_inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    with (
+        patch("asyncio.to_thread", side_effect=run_inline) as run,
+        patch("worker.engine.Image.open", wraps=open_image) as decode,
+    ):
+        result = asyncio.run(engine.frame(manifest, {}, source.getvalue()))
+
+    assert decode.call_count == 1
+    assert run.call_count == 4
+    assert engine._frame.call_count == 2
+    assert canvases[0] is canvases[1]
+    engine._evict_except.assert_called_once_with(manifest.id)
+    engine._evict_poisoned.assert_not_called()
+    assert result.data == encode_webp(rendered)
+    assert result.gpu_ms == 17
+
+
 def test_calibrate_realtime_sets_slots_from_p95():
     engine = DiffusersEngine.__new__(DiffusersEngine)
     engine.device = "cuda"
@@ -580,7 +706,9 @@ def test_calibrate_realtime_sets_slots_from_p95():
     engine._calibrated_slots = None
     engine._gpu = asyncio.Lock()
     engine._select_rung = MagicMock(return_value="full")
-    engine._frame = MagicMock(return_value=b"webp")
+    engine._frame = MagicMock(
+        return_value=(Image.new("RGB", (32, 32)), 200),
+    )
 
     manifest = Manifest(
         id="vega-rt",
@@ -595,12 +723,19 @@ def test_calibrate_realtime_sets_slots_from_p95():
     def fake_monotonic():
         return next(times)
 
-    with patch("worker.engine.time.monotonic", side_effect=fake_monotonic):
+    with (
+        patch("worker.engine.time.monotonic", side_effect=fake_monotonic),
+        patch("worker.engine.encode_webp") as encode,
+    ):
         slots = engine._calibrate_realtime(manifest, configured=4)
 
     assert slots == 2
     assert engine._calibrated_slots == 2
     assert engine._frame.call_count == CALIBRATION_SAMPLES + 1
+    encode.assert_not_called()
+    canvases = [call.args[2] for call in engine._frame.call_args_list]
+    assert all(canvas is canvases[0] for canvas in canvases)
+    assert all(call.args[3] == 0.7 for call in engine._frame.call_args_list)
 
 
 def test_calibrate_realtime_p95_tolerates_one_outlier():

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -8,7 +8,10 @@ from PIL import Image
 
 from worker.engine import (
     CALIBRATION_SAMPLES,
+    CODEC_CONCURRENCY_LIMIT,
     DiffusersEngine,
+    GeneratedFrame,
+    REALTIME_SIZE,
     SimulatedEngine,
     encode_webp,
 )
@@ -581,6 +584,7 @@ def test_frame_keeps_pillow_work_outside_gpu_lock():
     )
     engine.torch = torch_stub
     engine._gpu = asyncio.Lock()
+    engine._codec = asyncio.Semaphore(CODEC_CONCURRENCY_LIMIT)
     engine._pick_rung = MagicMock(return_value="full")
     engine._evict_except = MagicMock()
     engine._evict_poisoned = MagicMock()
@@ -647,6 +651,86 @@ def test_frame_keeps_pillow_work_outside_gpu_lock():
     engine._evict_poisoned.assert_not_called()
 
 
+def test_frame_bounds_codec_concurrency():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = SimpleNamespace(
+        OutOfMemoryError=type("OutOfMemoryError", (Exception,), {}),
+    )
+    engine._gpu = asyncio.Lock()
+    engine._codec = asyncio.Semaphore(CODEC_CONCURRENCY_LIMIT)
+    engine._pick_rung = MagicMock(return_value="full")
+    engine._evict_except = MagicMock()
+    engine._evict_poisoned = MagicMock()
+    rendered = Image.new("RGB", (32, 32), (12, 34, 56))
+    engine._frame = MagicMock(return_value=(rendered, 17))
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+    )
+    call_count = CODEC_CONCURRENCY_LIMIT + 1
+    first_wave_full = asyncio.Event()
+    release_first_wave = asyncio.Event()
+    second_wave_full = asyncio.Event()
+    release_second_wave = asyncio.Event()
+    active = 0
+    maximum = 0
+    started = 0
+    kinds_seen: set[str] = set()
+
+    async def fake_to_thread(function, *args, **kwargs):
+        nonlocal active, maximum, started
+        name = getattr(function, "__name__", "")
+        if name == "prepare_canvas":
+            kind = "decode"
+            result = Image.new("RGB", (REALTIME_SIZE, REALTIME_SIZE))
+        elif function is encode_webp:
+            kind = "encode"
+            result = b"webp"
+        else:
+            return function(*args, **kwargs)
+
+        started += 1
+        wave = 1 if started <= CODEC_CONCURRENCY_LIMIT else 2
+        active += 1
+        maximum = max(maximum, active)
+        kinds_seen.add(kind)
+        if wave == 1 and active == CODEC_CONCURRENCY_LIMIT:
+            first_wave_full.set()
+        if wave == 2 and active == CODEC_CONCURRENCY_LIMIT:
+            second_wave_full.set()
+        try:
+            if wave == 1:
+                await release_first_wave.wait()
+            else:
+                await release_second_wave.wait()
+            return result
+        finally:
+            active -= 1
+
+    async def run_frames():
+        with patch("asyncio.to_thread", side_effect=fake_to_thread):
+            tasks = [
+                asyncio.create_task(engine.frame(manifest, {}, b"png"))
+                for _ in range(call_count)
+            ]
+            await first_wave_full.wait()
+            assert active == CODEC_CONCURRENCY_LIMIT
+            assert not any(task.done() for task in tasks)
+            release_first_wave.set()
+            await second_wave_full.wait()
+            assert active == CODEC_CONCURRENCY_LIMIT
+            release_second_wave.set()
+            return await asyncio.gather(*tasks)
+
+    results = asyncio.run(run_frames())
+
+    assert maximum == CODEC_CONCURRENCY_LIMIT
+    assert kinds_seen == {"decode", "encode"}
+    assert len(results) == call_count
+    assert all(result == GeneratedFrame(b"webp", 17) for result in results)
+
+
 def test_frame_oom_retries_once_without_decoding_twice():
     engine = DiffusersEngine.__new__(DiffusersEngine)
     torch_stub = SimpleNamespace(
@@ -654,6 +738,7 @@ def test_frame_oom_retries_once_without_decoding_twice():
     )
     engine.torch = torch_stub
     engine._gpu = asyncio.Lock()
+    engine._codec = asyncio.Semaphore(CODEC_CONCURRENCY_LIMIT)
     engine._pick_rung = MagicMock(return_value="full")
     engine._evict_except = MagicMock()
     engine._evict_poisoned = MagicMock()

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -598,13 +598,15 @@ class DiffusersEngine:
             )
             return 0
         canvas = Image.new("RGB", (REALTIME_SIZE, REALTIME_SIZE), (128, 128, 128))
-        payload = encode_webp(canvas)
-        params = {"prompt": "calibration", "strength": 0.7}
+        strength = 0.7
+        params = {"prompt": "calibration", "strength": strength}
         samples: list[float] = []
         # One discarded pass absorbs remaining compile/warmup cost.
         for index in range(CALIBRATION_SAMPLES + 1):
+            # Time exactly the region serialized by the GPU lock. That occupancy,
+            # rather than CPU work that can overlap it, is what the scheduler uses.
             start = time.monotonic()
-            self._frame(manifest, params, payload)
+            self._frame(manifest, params, canvas, strength)
             elapsed_ms = (time.monotonic() - start) * 1000.0
             if index > 0:
                 samples.append(elapsed_ms)
@@ -1106,11 +1108,25 @@ class DiffusersEngine:
         return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 
     async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame:
+        if "realtime" not in manifest.capabilities:
+            raise ValueError(f"model {manifest.id} does not support realtime frames")
+        if self._pick_rung(manifest) != "full":
+            raise ValueError(f"model {manifest.id} is not fully resident for realtime")
+        frame_params = dict(params)
+
+        def prepare_canvas() -> Image.Image:
+            canvas = Image.open(io.BytesIO(payload)).convert("RGB")
+            return canvas.resize((REALTIME_SIZE, REALTIME_SIZE))
+
+        canvas = await asyncio.to_thread(prepare_canvas)
+        strength = min(max(float(frame_params.get("strength", 0.7)), 0.05), 1.0)
         async with self._gpu:
+            # _pipeline can load or evict GPU weights, _prompt_kwargs can run
+            # GPU text encoders for long prompts, and diffusion uses the GPU.
+            frame_result: tuple[Image.Image, int] | None = None
             try:
-                data, gpu_ms = await asyncio.to_thread(
-                    self._frame, manifest, dict(params), payload)
-                return GeneratedFrame(data, gpu_ms)
+                frame_result = await asyncio.to_thread(
+                    self._frame, manifest, frame_params, canvas, strength)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
             except (ValueError, TypeError):
@@ -1118,19 +1134,22 @@ class DiffusersEngine:
             except Exception:
                 self._evict_poisoned(manifest.id)
                 raise
-            self._evict_except(manifest.id)
-            data, gpu_ms = await asyncio.to_thread(
-                self._frame, manifest, dict(params), payload)
-            return GeneratedFrame(data, gpu_ms)
+            if frame_result is None:
+                # The eviction mutates GPU residency, so it remains serialized.
+                self._evict_except(manifest.id)
+                frame_result = await asyncio.to_thread(
+                    self._frame, manifest, frame_params, canvas, strength)
+            image, gpu_ms = frame_result
+        data = await asyncio.to_thread(encode_webp, image)
+        return GeneratedFrame(data, gpu_ms)
 
-    def _frame(self, manifest: Manifest, params: dict, payload: bytes) -> tuple[bytes, int]:
-        if "realtime" not in manifest.capabilities:
-            raise ValueError(f"model {manifest.id} does not support realtime frames")
-        if self._pick_rung(manifest) != "full":
-            raise ValueError(f"model {manifest.id} is not fully resident for realtime")
-        canvas = Image.open(io.BytesIO(payload)).convert("RGB")
-        canvas = canvas.resize((REALTIME_SIZE, REALTIME_SIZE))
-        strength = min(max(float(params.get("strength", 0.7)), 0.05), 1.0)
+    def _frame(
+        self,
+        manifest: Manifest,
+        params: dict,
+        canvas: Image.Image,
+        strength: float,
+    ) -> tuple[Image.Image, int]:
         pipeline = self._pipeline(manifest, "i2i")
         negative_prompt = params.get("negative_prompt")
         prompt_kwargs = self._prompt_kwargs(
@@ -1150,4 +1169,4 @@ class DiffusersEngine:
             guidance_scale=0.0,
         ).images[0]
         gpu_ms = int((time.monotonic() - started) * 1000)
-        return encode_webp(image), gpu_ms
+        return image, gpu_ms

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -45,6 +45,11 @@ POISON_EVICT_COOLDOWN_S = 30.0
 # Timing samples after the discarded warmup pass; nearest-rank p95 over
 # these tolerates one outlier (19th of 20) instead of becoming the max.
 CALIBRATION_SAMPLES = 20
+# Pillow work was implicitly bounded to one operation by the GPU lock before
+# this change moved it outside that lock. Use half the logical CPUs so codec
+# work leaves room in the shared default executor, with a floor of one for
+# small hosts and a ceiling of four to limit CPU and memory pressure.
+CODEC_CONCURRENCY_LIMIT = max(1, min(4, (os.cpu_count() or 1) // 2))
 
 
 @dataclass
@@ -250,6 +255,7 @@ class DiffusersEngine:
         self._poison_evict_count: dict[str, int] = {}
         self._calibrated_slots: int | None = None
         self._gpu = asyncio.Lock()
+        self._codec = asyncio.Semaphore(CODEC_CONCURRENCY_LIMIT)
 
     def _free_vram_bytes(self) -> int:
         if self.device != "cuda":
@@ -1118,7 +1124,8 @@ class DiffusersEngine:
             canvas = Image.open(io.BytesIO(payload)).convert("RGB")
             return canvas.resize((REALTIME_SIZE, REALTIME_SIZE))
 
-        canvas = await asyncio.to_thread(prepare_canvas)
+        async with self._codec:
+            canvas = await asyncio.to_thread(prepare_canvas)
         strength = min(max(float(frame_params.get("strength", 0.7)), 0.05), 1.0)
         async with self._gpu:
             # _pipeline can load or evict GPU weights, _prompt_kwargs can run
@@ -1140,7 +1147,8 @@ class DiffusersEngine:
                 frame_result = await asyncio.to_thread(
                     self._frame, manifest, frame_params, canvas, strength)
             image, gpu_ms = frame_result
-        data = await asyncio.to_thread(encode_webp, image)
+        async with self._codec:
+            data = await asyncio.to_thread(encode_webp, image)
         return GeneratedFrame(data, gpu_ms)
 
     def _frame(


### PR DESCRIPTION
# Description

Closes #195.

The realtime frame path held `self._gpu` across the whole of `_frame`, including a WebP decode and resize on the way in and a WebP encode on the way out. Neither touches the GPU, and while the lock is held no other session can use it. Decode now happens before the lock is acquired and the encode after it is released.

# Motivation

Measured on the reference card before changing anything, using the worker's own calibration path:

| Quantity | Value |
| --- | --- |
| `vega-rt` single-frame p95 | **285.9 ms** |
| Calibrated slots earned | **1** |
| p95 needed for 2 slots | 250 ms |
| Decode plus resize | 2.39 ms |
| `encode_webp` | 16.91 ms |

So 19.3 ms of that 285.9 was CPU work sitting in a region that serializes every session.

# Functionality

- Capability and residency validation, then decode and resize, happen before the lock, off the event loop.
- The lock now holds only `_pipeline`, `_prompt_kwargs` and the diffusion call, with a comment giving the reason each one stays: loading or evicting weights, running the text encoders for a long prompt, and inference.
- The encode runs after the lock is released, also off the event loop.
- `_frame` returns the `Image` and lets the caller encode it.
- The out-of-memory retry reuses the canvas it already decoded rather than decoding twice; eviction stays inside the lock because it mutates GPU residency.
- `GeneratedFrame` and the wire behaviour are unchanged.

# Details

**Calibration had to move with it.** `_calibrate_realtime` timed the whole of `_frame` and fed `slots_from_frame_ms`. It now times the region the lock actually serializes, because that occupancy and not overlapping CPU work is what the scheduler is deciding with. Getting this wrong in either direction matters: measuring too much understates capacity, and measuring too little manufactures capacity that does not exist. A comment states what it measures and why.

**This does not on its own reach 250 ms, and the commit says so.** Arithmetic puts the result near 266.6 ms. It closes 19.3 of the 35.9 ms gap and leaves roughly a **6 percent** inference improvement for #196, which is a much smaller target than the 13 percent it looked like before this was measured.

**A separate finding, deliberately not acted on here.** `encode_webp` uses `quality=80` with Pillow's default method. Measured on a 512 px frame: the current setting is 17.49 ms at 54.6 kB, `quality=80, method=0` is 5.30 ms at 61.2 kB, and `quality=70, method=0` is 4.39 ms at 47.4 kB, which beats the current setting on both time and size. It is shared with stored thumbnails and the benchmark path, and quality is a visual decision, so it belongs in its own issue. Once the encode is outside the lock its cost no longer affects density at all, only latency and CPU.

# Verification

`make verify-worker` passes: ruff, mypy and **81 passed, 4 skipped**, up from 79.

Two tests carry the intent rather than the implementation. One records whether `_gpu` is held at each stage and asserts decode and encode happen unlocked while pipeline access, prompt preparation and diffusion happen locked, so moving work back inside fails the suite. The other asserts the out-of-memory path retries once and decodes only once.

**Not yet confirmed on hardware.** I re-ran the calibration after the change and it correctly refused to measure: another process had taken 4.89 GB of VRAM, leaving 8.4 GB free against the 8.59 GB that `min_vram_gb: 8` requires for full residency, so `_select_rung` dropped below `full` and calibration skipped itself. That is the existing residency guard behaving properly, not a regression, but it means the predicted 266.6 ms is arithmetic rather than a measurement. Worth one calibration run on a clear card before relying on the figure.