### PR TITLE
Add a security policy with a private disclosure path

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,13 +14,13 @@ No release is tagged yet. `main` is the only supported ref, and fixes land there
 
 ## Scope
 
-The project documents its security posture in [docs/internals/08-security-production.md](docs/internals/08-security-production.md), which separates what is shipped from what is designed and deferred. Read the deferred list before reporting: several open surfaces are recorded decisions rather than oversights, and reports about them cost you time without producing a fix.
+Read the list below before reporting. Several open surfaces here are recorded decisions rather than oversights, and reports about them cost you time without producing a fix. [docs/decisions.md](docs/decisions.md) carries the reasoning and the rejected alternatives for each.
 
 Known and deliberate, so not vulnerabilities:
 
 - **The fleet WebSocket (`/api/v1/fleet`) is unauthenticated.** Documented in [README.md](README.md) and mitigated by deployment posture: treat the host as a trusted LAN. Tracked in #206.
 - **`AUTH_MODE=none` is the shipped default** and resolves every request to one local user. Only that mode exists; `local` and `oauth` are seams, not implementations. Tracked in #5 and #9.
-- **There is no rate limiting.** Deferred by recorded decision.
+- **There is no rate limiting.** Deferred by recorded decision, see [docs/decisions.md](docs/decisions.md).
 - **Pull requests execute contributor code on a self-hosted runner.** Accepted for a solo org and documented in [docs/self-hosted-runner.md](docs/self-hosted-runner.md).
 
 In scope, and worth reporting:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security
+
+## Reporting a vulnerability
+
+Report privately through GitHub: open the [Security tab](https://github.com/Portocolom-Studio/potocolom/security/advisories/new) and use **Report a vulnerability**. That opens a private advisory visible only to you and the maintainers. Do not open a public issue for a vulnerability.
+
+A useful report says what an attacker can do, which files or endpoints are involved, and how you confirmed it. A proof of concept helps but is not required.
+
+potocolom is maintained by one person. Expect acknowledgement within a few days rather than a few hours. There is no response-time commitment and no bug bounty.
+
+## Supported versions
+
+No release is tagged yet. `main` is the only supported ref, and fixes land there.
+
+## Scope
+
+The project documents its security posture in [docs/internals/08-security-production.md](docs/internals/08-security-production.md), which separates what is shipped from what is designed and deferred. Read the deferred list before reporting: several open surfaces are recorded decisions rather than oversights, and reports about them cost you time without producing a fix.
+
+Known and deliberate, so not vulnerabilities:
+
+- **The fleet WebSocket (`/api/v1/fleet`) is unauthenticated.** Documented in [README.md](README.md) and mitigated by deployment posture: treat the host as a trusted LAN. Tracked in #206.
+- **`AUTH_MODE=none` is the shipped default** and resolves every request to one local user. Only that mode exists; `local` and `oauth` are seams, not implementations. Tracked in #5 and #9.
+- **There is no rate limiting.** Deferred by recorded decision.
+- **Pull requests execute contributor code on a self-hosted runner.** Accepted for a solo org and documented in [docs/self-hosted-runner.md](docs/self-hosted-runner.md).
+
+In scope, and worth reporting:
+
+- Anything that crosses a boundary the documentation claims holds. If a document says a check is enforced and it is not, that is a finding regardless of how small it looks.
+- Anything reachable by a client that is not on the trusted LAN, including a web page the operator merely visits.
+- Anything that lets one user reach another user's jobs, assets or sessions.
+- Anything that lets a worker corrupt or forge state the API treats as authoritative.
+- Anything in the shipped container images, compose stack or release artifacts.
+
+Out of scope: findings in `design-sketches/` or other untracked local scratch, issues that require an already-compromised host, and results from automated scanners submitted without a working path to impact.
+
+## Disclosure
+
+Coordinated. Report privately, and we agree on a disclosure date once a fix exists or the issue is confirmed as won't-fix. Reporters are credited in the advisory unless they ask not to be.
+
+## Self-hosting
+
+Deployment posture is part of the security model for the self-hosted profile. [docs/self-hosting.md](docs/self-hosting.md) covers what to expose and what to keep on a trusted network. A misconfigured deployment is an ordinary issue, not an advisory.


### PR DESCRIPTION
Closes #208.

Adds `SECURITY.md` and enables GitHub private vulnerability reporting on the repository, so a reporter has a channel that is not a public issue.

The scope section is the part worth reviewing. The project documents several deliberate deferrals, and without saying so a reporter cannot distinguish them from oversights. The policy lists them with links: the unauthenticated fleet WebSocket in the trusted-LAN profile (#206), `AUTH_MODE=none` as the shipped default (#5, #9), no rate limiting, and contributor code on the self-hosted runner. It then states what is worth reporting, with the useful case called out first: anything that crosses a boundary the documentation claims holds.

Supported ref is `main`, since no release is tagged yet.

Deliberately excluded: a security contact email, a PGP key, a response-time SLA, and a bounty. Each is either infrastructure to maintain or a promise a solo maintainer cannot keep.

Also excluded from this PR: issue templates carrying the `# Description` / `# Motivation` / `# Functionality` / `# Details` convention. Worth doing, separate concern.

## Verification

`make verify` passes on the backend (108 tests) and the frontend. `verify-worker` fails on `worker/engine.py:903`, which is pre-existing on `main` and unrelated to this change; details in the PR thread.

No workflow triggers on this PR: no path filter matches a root-level `SECURITY.md`.
