### PR TITLE
Pin ip-address above every advisory, not just the reported two

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2739,9 +2739,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.2.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-			"integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+			"integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,6 +50,7 @@
 		"vite": "^8.0.16"
 	},
 	"overrides": {
+		"ip-address": "^10.3.1",
 		"postcss": "^8.5.24"
 	}
 }


### PR DESCRIPTION
# Description

Adds an `ip-address` entry to the existing `overrides` block in `frontend/package.json`, floored at `^10.3.1`. The lockfile resolves 10.4.0 and no other package moves.

# Motivation

Dependabot reported two medium advisories against `ip-address`, reached transitively:

`puppeteer-core -> @puppeteer/browsers -> proxy-agent -> socks-proxy-agent -> socks -> ip-address`

Build-time only; none of it reaches the published artifact.

**The reported two were not all of them.** GitHub's advisory database lists four, and the one Dependabot did not surface is the most serious:

| Advisory | Severity | Affected | First patched |
| --- | --- | --- | --- |
| GHSA-mwp4-54f8-5fhr | **high** | `<= 10.3.0` | **10.3.1** |
| GHSA-4xrf-jv44-h6hh | medium | `>= 10.1.1, <= 10.2.1` | 10.2.2 |
| GHSA-22jq-vg5j-6vgg | medium | `>= 10.1.1, <= 10.2.0` | 10.2.1 |
| GHSA-v2v4-37r5-5v8g | medium | `<= 10.1.0` | 10.1.1 |

A floor of `^10.2.2`, which is what the two reported advisories imply, would have admitted 10.2.2 through 10.3.0, every one of them affected by the high-severity issue. That was the first version of this change, and review caught it.

# Functionality

`"ip-address": "^10.3.1"` in `overrides`, alongside the `postcss` entry added for the same class of problem. 10.3.1 is the first release patched against all four, and the caret stays below 11 so it admits patches but not a future major. `socks` accepts `^10.1.1`, so nothing above it in the chain is disturbed.

# Details

**Deliberately not `npm audit fix`.** It previously carried `@sveltejs/kit` and `layerchart` along with it, which is a framework bump plus a change to the library drawing the metrics charts.

**The lockfile was checked by parsing, not by reading the diff.** Comparing the `packages` map against `origin/main`: exactly one version change, `ip-address` 10.2.0 to 10.4.0, nothing added, nothing removed.

# Verification

`make verify-frontend` passes: prettier, svelte-check, 9 node tests, build and `verify-csp`.

`npm ci` from an empty `node_modules` leaves the lockfile byte-identical, so the resolution is reproducible rather than something only one machine produces.

`npm audit` reports **0 high, 0 moderate**. Seven low remain in the `@sveltejs/kit` and `bits-ui` chain, which needs a framework upgrade rather than a version bump and is out of scope here.