### PR TITLE
Make the first run work on a fresh install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 # Development entry points. `make verify` runs exactly what CI runs.
 # The local stack is three processes in three terminals, in this order:
 #   make deps && make api      # terminal 1: PostgreSQL etc., then the API
-#   make worker-rocm           # terminal 2 (worker-cuda on NVIDIA, worker-sim without a GPU)
+#   make worker-cuda           # terminal 2 (worker-rocm on AMD, worker-sim without a GPU)
 #   make web                   # terminal 3: the studio on the configured port
 # Or: make dev-start           # API + frontend + worker in the background (logs under data/dev/)
 #     make dev-status          # pid files, ports, workers, model list
-#     WORKER=rocm|cuda|sim|off (default rocm; cuda on NVIDIA, sim without a GPU)
+#     WORKER=rocm|cuda|sim|off (detected from the GPU present; set to override)
 # Self-hosted GitHub Actions runner (when hosted minutes are exhausted):
 #   make ci-runner-install && make ci-runner-service-install && make ci-runner-start
 # See docs/self-hosted-runner.md
 
-.PHONY: setup setup-rocm setup-cuda check-python check-worker-venv \
+.PHONY: preflight compose-up compose-down compose-logs \
+	setup setup-rocm setup-cuda check-python check-worker-venv \
 	deps deps-all deps-down dco-hook verify verify-backend verify-worker \
 	verify-frontend verify-compose verify-guards verify-mermaid simulate test-db-clean dev-db \
 	api worker-rocm worker-cuda worker-sim web web-landing \
@@ -30,6 +31,35 @@ VENV_OK = -c 'import sys; sys.exit(sys.version_info < (3, 11))'
 PYTHON ?= $(shell for c in python3 python3.13 python3.12 python3.11; do \
 	$$c $(VENV_OK) 2>/dev/null && { echo $$c; break; }; done)
 
+preflight: ## check this machine against the self-hosting requirements (read-only)
+	@bash "$(CURDIR)/scripts/preflight.sh"
+
+# Self-hosting convenience wrappers. The docker compose commands in the README
+# stay canonical: self-hosting requires Docker and nothing else, and make is
+# not on every container host. These are for people who already have it, and
+# must not become the documented path.
+COMPOSE_FILE := $(CURDIR)/deploy/compose/compose.yml
+# gpu on NVIDIA, rocm on AMD, smoke (simulated worker) without either. Detected
+# the same way scripts/preflight.sh reports it; override with PROFILE=.
+# nvidia-smi must actually enumerate a GPU: driver files alone do not prove
+# CUDA can run, so the query is the gate, not /proc/driver/nvidia/version.
+PROFILE ?= $(shell if [ -e /dev/kfd ]; then echo rocm; \
+	elif nvidia-smi --query-gpu=name --format=csv,noheader >/dev/null 2>&1; \
+	then echo gpu; else echo smoke; fi)
+
+compose-up: ## self-hosted stack up (PROFILE=gpu|rocm|smoke, detected by default)
+	@test -f deploy/compose/.env || { \
+		echo 'error: deploy/compose/.env is missing.' >&2; \
+		echo '  cp deploy/compose/.env.example deploy/compose/.env' >&2; \
+		echo '  then set POSTGRES_PASSWORD in it' >&2; exit 1; }
+	docker compose -f "$(COMPOSE_FILE)" --profile "$(PROFILE)" up -d --build
+
+compose-down: ## stop the self-hosted stack; named volumes are left intact
+	docker compose -f "$(COMPOSE_FILE)" --profile "$(PROFILE)" down
+
+compose-logs: ## follow the self-hosted stack's logs
+	docker compose -f "$(COMPOSE_FILE)" --profile "$(PROFILE)" logs -f
+
 check-python: ## fail fast unless a Python 3.11+ interpreter is on PATH
 	@test -n "$(PYTHON)" || { \
 		echo 'error: Python 3.11 or newer is required for backend/ and worker/.' >&2; \
@@ -38,6 +68,15 @@ check-python: ## fail fast unless a Python 3.11+ interpreter is on PATH
 		exit 1; }
 	@$(PYTHON) $(VENV_OK) 2>/dev/null || { \
 		echo 'error: $(PYTHON) is missing or older than Python 3.11.' >&2; exit 1; }
+	@# Debian and Ubuntu ship venv separately, so a new enough interpreter can
+	@# still fail to create one. Without this the failure arrives as a raw
+	@# ensurepip traceback from inside python -m venv, several lines from the
+	@# fix, rather than as the package to install.
+	@$(PYTHON) -c 'import ensurepip' 2>/dev/null || { \
+		echo 'error: $(PYTHON) cannot create virtualenvs: ensurepip is missing.' >&2; \
+		echo 'Debian/Ubuntu ship it separately, for example' >&2; \
+		echo '  sudo apt install $(shell $(PYTHON) -c "import sys; print(\"python%d.%d-venv\" % sys.version_info[:2])" 2>/dev/null || echo python3-venv)' >&2; \
+		exit 1; }
 	@$(PYTHON) -c 'import sys; print("venvs use %s (%d.%d.%d)" \
 		% ((sys.executable,) + sys.version_info[:3]))'
 
@@ -184,7 +223,9 @@ ifeq (,$(DEV_DB_SUPPLIED))
 api dev-start dev-restart cleanup-failed: export DATABASE_URL := \
 	postgresql://potocolom:potocolom@localhost:5432/potocolom$(DB_SUFFIX)
 endif
-WORKER ?= rocm
+# Empty by default so scripts/dev-stack.sh detects the GPU this machine has.
+# Set it explicitly (WORKER=sim, WORKER=off, ...) to override the detection.
+WORKER ?=
 
 api: dev-db ## API server on the configured port; assets under ./data (make deps first)
 	cd backend && STORAGE_LOCAL_PATH=$(CURDIR)/data \

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ To run potocolom on your own machine. Contributing to it instead needs a differe
 | What | Needed | Notes |
 |---|---|---|
 | OS | Linux | What the project is developed, tested and released on. Docker Desktop hosts are untested. |
-| Docker | Engine with Compose v2 | Everything ships as containers; nothing is installed on the host. |
+| Docker | Engine with Compose v2 | Everything ships as containers; nothing is installed on the host. Your user must be in the `docker` group (`sudo usermod -aG docker $USER`, then log back in) or every command below needs `sudo`. |
 | GPU | NVIDIA or AMD, or none | NVIDIA needs the [Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html); AMD needs the ROCm kernel driver, so `/dev/kfd` and `/dev/dri` exist. Without a GPU the stack still runs against the simulated worker. |
-| VRAM | 6 GB minimum, 12-16 GB comfortable | 6 GB covers SD-class models at 512 px, 12-16 GB covers SDXL-class at 1024 px. Each model manifest declares its own floor. |
+| VRAM | 8 GB minimum, 12-16 GB comfortable | 8 GB is the floor of the lowest selectable model (`ssd-1b`, `vega-rt`); 12-16 GB covers the SDXL class at 1024 px, and `sd35-medium` wants 14 GB. Each manifest declares its own floor. Below it the worker still loads the model, offloaded, but drops the `realtime` capability: you get stills, not the live loop. |
 | RAM | 8 GB, 16 GB comfortable | |
 | Disk | 20 GB free, 50 GB+ comfortable | Model weights are 2-7 GB each, plus your generated images. |
 | Network | Port 8080 free, outbound HTTPS | The studio is served on 8080; weights download from Hugging Face on first use of each model. |
@@ -36,12 +36,26 @@ No account, no API key and no telemetry endpoint are required. [docs/self-hostin
 
 ## Self-hosting
 
+Docker is the only thing this needs. Everything here is `docker compose` on
+purpose, so nothing beyond the table above has to be installed on the host -
+the `make` targets further down are for working *on* potocolom, not running it.
+
 ```bash
+scripts/preflight.sh          # what this machine has, what it is missing, which profile to use
 cp deploy/compose/.env.example deploy/compose/.env
 # edit POSTGRES_PASSWORD and FLEET_SECRET (openssl rand -hex 32)
 docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
 # AMD card: use --profile rocm instead of --profile gpu
 ```
+
+`scripts/preflight.sh` is read-only - it starts nothing and installs nothing. It
+checks the table above against the running machine, names the profile you can
+run, and prints the fix for anything missing.
+
+If you happen to have `make`, `make compose-up`, `make compose-down` and
+`make compose-logs` wrap exactly the commands above and pick the profile from
+the GPU they find. They are a shortcut, never a requirement: the `docker
+compose` lines are the supported path.
 
 Open http://localhost:8080. Hardware requirements, NVIDIA and AMD GPU passthrough, first-run notes and what persists in which volume are covered in [docs/self-hosting.md](docs/self-hosting.md). The fleet WebSocket (`/api/v1/fleet`) authenticates workers with the shared `FLEET_SECRET` from your compose environment; set it. Left empty it stays unauthenticated for compatibility with existing installs, and then only a worker whose address cannot route from the internet is accepted. Treat that as a safety net, not a boundary: it refuses a direct IPv4 connection from the internet, but a connection arriving over IPv6 reaches the IPv4-only container through Docker's userland proxy and so looks local, and anything else that re-originates traffic, a reverse proxy included, can look local too. If the host has a public address, set `FLEET_SECRET`. Validate the stack without a GPU: `scripts/compose-smoke.sh` (uses port 18080 by default; override with `COMPOSE_SMOKE_PORT`).
 
@@ -72,11 +86,15 @@ The repository is a monorepo: `frontend/` (SvelteKit SPA), `backend/` (FastAPI A
 ### Prerequisites
 
 - Docker with Compose v2, for the development dependencies.
-- Python 3.11 or newer, for the backend and the worker. `make setup` uses `python3` when it is new enough and otherwise falls back to `python3.13` / `python3.12` / `python3.11` on PATH, so the system default may stay at 3.10; project packages install into `backend/.venv` and `worker/.venv` only.
+- Python 3.11 or newer, for the backend and the worker, with its `venv` module: Debian and Ubuntu ship that separately, as `python3.11-venv` or equivalent. `make setup` uses `python3` when it is new enough and otherwise falls back to `python3.13` / `python3.12` / `python3.11` on PATH, so the system default may stay at 3.10; project packages install into `backend/.venv` and `worker/.venv` only.
 - Node.js 24 or newer, for the frontend. `frontend/package.json` declares it and `engine-strict` is on, so npm refuses to install on an older Node rather than failing later in the build.
-- A GPU is optional until inference lands (issue #15). Both NVIDIA (CUDA) and AMD Radeon (ROCm) are supported worker targets; machines without a supported GPU run the worker on CPU. Machine specific setup, including AMD desktops, is documented in [Local development and testing](docs/local-development.md).
+- A GPU is optional until inference lands (issue #15). Both NVIDIA (CUDA) and AMD Radeon (ROCm) are supported worker targets; machines without a supported GPU run the simulated worker (flat images, real protocol). Machine-specific setup, including AMD desktops, is documented in [Local development and testing](docs/local-development.md).
 
 ### Common tasks
+
+Unlike self-hosting above, this is where `make` earns its place: these targets
+drive a native toolchain, not containers, so they need the prerequisites listed
+above rather than Docker alone.
 
 ```
 make setup      # create virtualenvs, install all dependencies

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -9,18 +9,63 @@ first run, and what persists where.
 
 | Component | Minimum | Comfortable |
 |---|---|---|
-| GPU VRAM | 6 GB (SD-class models at 512 px) | 12-16 GB (SDXL-class at 1024 px, model switching without eviction) |
+| GPU VRAM | 8 GB (`ssd-1b`, `vega-rt`) | 12-16 GB (SDXL-class at 1024 px, model switching without eviction) |
 | Disk | 20 GB free (weights are 2-7 GB per model, plus your images) | 50 GB+ |
 | RAM | 8 GB | 16 GB |
 
-Each model manifest declares its floor in `min_vram_gb`; the shipped set
-spans 6 GB (`dreamshaper-lcm`) to 10 GB (`sdxl-base`, `sdxl-fast`). A machine
-without a supported GPU can still run the full stack against the simulated
-worker (flat colored images, real protocol): `scripts/compose-smoke.sh`.
+Each model manifest declares its floor in `min_vram_gb`. The models a
+self-hoster can actually select span 8 GB (`ssd-1b`, `ssd-1b-lightning`,
+`vega-rt`) to 14 GB (`sd35-medium`), with the SDXL class at 10 GB and the
+upscalers at 1-4 GB.
+
+Manifests marked `benchmark_only` (`dreamshaper-lcm`, `sd-turbo`,
+`sdxl-hypersd`) are excluded from `GET /api/v1/models` by
+`registry.public()` and never appear in the studio, so their lower floors are
+not capacity you can plan around. `dreamshaper-lcm` in particular declares
+6 GB but is not selectable.
+
+The floor is not a gate. A card below a model's floor still loads it: the
+worker measures free VRAM and steps down a memory ladder (full residency ->
+model offload -> group offload, `worker/worker/memory_ladder.py`). What you
+lose is the `realtime` capability, which only full residency advertises - so
+below the floor you get working stills, but not the live draw-and-render loop
+the product is built around. `scripts/preflight.sh` prints which shipped
+models clear the bar on your card.
+
+Measured on a 4 GB RTX 3050 Laptop (well under every text-to-image floor, so
+every model lands on the bottom rung): `ssd-1b-lightning` at 768 px, 8 steps
+takes about 7.7 s of GPU time per still, plus a one-off multi-minute weight
+download on the first job for that model. Correct output, nowhere near the
+500 ms realtime bar - which is what dropping to group offload means in
+practice.
+
+A machine without a supported GPU can still run the full stack against the
+simulated worker (flat colored images, real protocol):
+`scripts/compose-smoke.sh`.
+
+Every command on this page is `docker compose`, because self-hosting requires
+Docker and nothing else. `make compose-up`, `make compose-down` and
+`make compose-logs` wrap the same commands and detect the profile, for hosts
+that already have `make`; they are a shortcut and never a requirement.
+
+## Checking a machine before you start
+
+`scripts/preflight.sh` (or `make preflight`) checks everything on this page
+against the machine you are on, names the compose profile it can run, and
+prints the fix for anything missing. It is read-only: it starts no containers
+and installs nothing. Run it first; everything below is what it checks.
 
 ## GPU passthrough
 
-NVIDIA (default images):
+Both profiles need your user in the `docker` group
+(`sudo usermod -aG docker $USER`, then log out and back in), otherwise every
+`docker compose` command fails with `permission denied ... /var/run/docker.sock`.
+
+NVIDIA (default images). The worker image is built on CUDA 12.8, so the host
+driver must be 525.60.13 or newer. CUDA minor version compatibility carries the
+12.8 runtime on any 12.x driver above that floor, so a 535 driver reporting
+"CUDA Version: 12.2" in `nvidia-smi` is fine and does not need upgrading; below
+525.60.13 the worker fails at import with a CUDA error.
 
 1. Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
    and restart the docker daemon.
@@ -44,6 +89,19 @@ AMD (ROCm):
 
 The `gpu` profile is the NVIDIA worker and the `rocm` profile is the AMD one;
 run one or the other, never both, since they share the model volumes.
+
+Checking whether an NVIDIA driver is installed: use `nvidia-smi`, or the
+presence of `/proc/driver/nvidia/version`. Do not use `lsmod | grep nvidia`.
+On laptops with switchable graphics the discrete GPU sits in `D3cold` with its
+modules unloaded until something touches it, so `lsmod` prints nothing on a
+perfectly working install. `nvidia-smi` wakes the device.
+
+The one command that proves the whole chain (driver, toolkit, runtime
+registration) works before you build anything:
+
+```bash
+docker run --rm --gpus all ubuntu:24.04 nvidia-smi -L
+```
 
 ## First run
 
@@ -111,9 +169,10 @@ user, and that user holds the `admin` role, so anyone who can reach the API can 
 the install can do. Keep it on a trusted network, and see the fleet secret above for the
 worker side of the same question.
 
-Do not set `AUTH_MODE=local` or `AUTH_MODE=oauth`. Neither is implemented: they are accepted
-today and behave exactly like `none`, which means an install configured for authentication
-performs none (issue #241 makes that a startup failure instead).
+`AUTH_MODE=local` and `AUTH_MODE=oauth` are refused: the API will not start with either,
+because neither is implemented and an install configured for authentication that performs
+none is worse than one that will not boot. `local` becomes available with issue #5
+and `oauth` with issue #9.
 
 Multi-user is the intended shape, not a maybe: an operator holding `admin`, invited people
 signing in with a local email and password or with Google or GitHub, and a read-only `viewer`

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -8,7 +8,22 @@ REPO="$(cd "$(dirname "$0")/.." && pwd)"
 DEV_DIR="${DEV_DIR:-$REPO/data/dev}"
 API_PORT="${API_PORT:-8000}"
 WEB_PORT="${WEB_PORT:-5173}"
-WORKER="${WORKER:-rocm}"
+# Default to whatever this machine can actually run. A hardcoded default sends
+# every contributor without that vendor's GPU into a worker that cannot start.
+# /dev/kfd is the AMD compute device, absent on display-only amdgpu; NVIDIA
+# requires nvidia-smi to actually enumerate a GPU, not just driver files:
+# a laptop dGPU idles in D3cold with its modules unloaded, so lsmod is
+# silent on a working install, but nvidia-smi must still report a device.
+detect_worker() {
+	if [[ -e /dev/kfd ]]; then
+		echo rocm
+	elif nvidia-smi --query-gpu=name --format=csv,noheader >/dev/null 2>&1; then
+		echo cuda
+	else
+		echo sim
+	fi
+}
+WORKER="${WORKER:-$(detect_worker)}"
 DATABASE_URL="${DATABASE_URL:-postgresql://potocolom:potocolom@localhost:5432/potocolom}"
 
 mkdir -p "$DEV_DIR"
@@ -190,7 +205,7 @@ cmd_status() {
 
 usage() {
 	echo "Usage: $0 {start|stop|restart|status}" >&2
-	echo "  WORKER=rocm|cuda|sim|off (default rocm)" >&2
+	echo "  WORKER=rocm|cuda|sim|off (detected: $(detect_worker))" >&2
 	echo "  API_PORT WEB_PORT DEV_DIR optional" >&2
 	exit 1
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Check this machine against the self-hosting requirements and name the
+# compose profile it can actually run. Read-only: starts nothing, installs
+# nothing, changes nothing.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PORT="${POTOCOLOM_PORT:-8080}"
+
+# Worker images are built on CUDA 12.8; a 12.x driver runs them under CUDA
+# minor version compatibility, which needs 525.60.13 or newer.
+CUDA_IMAGE_VERSION="12.8"
+CUDA_MIN_DRIVER="525.60.13"
+
+if [[ -t 1 ]]; then
+  R=$'\e[31m'; G=$'\e[32m'; Y=$'\e[33m'; B=$'\e[1m'; N=$'\e[0m'
+else
+  R=""; G=""; Y=""; B=""; N=""
+fi
+
+fails=0
+warns=0
+
+pass() { printf '  %sok%s %s\n' "$G" "$N" "$1"; }
+warn() { printf '  %swarn%s %s\n' "$Y" "$N" "$1"; warns=$((warns + 1)); }
+fail() { printf '  %sfail%s %s\n' "$R" "$N" "$1"; fails=$((fails + 1)); }
+note() { printf '      %s\n' "$1"; }
+head_() { printf '\n%s%s%s\n' "$B" "$1" "$N"; }
+
+# Compare dotted versions: version_ge 535.261.03 525.60.13
+version_ge() {
+  [[ "$1" == "$2" ]] && return 0
+  local first
+  first="$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)"
+  [[ "$first" == "$2" ]]
+}
+
+# ---------------------------------------------------------------- host
+
+head_ "Host"
+
+if [[ "$(uname -s)" == "Linux" ]]; then
+  pass "Linux ($(uname -r))"
+else
+  fail "$(uname -s) is not a supported host; potocolom is developed and released on Linux"
+fi
+
+ram_kb="$(awk '/MemTotal/ {print $2}' /proc/meminfo 2>/dev/null || echo 0)"
+ram_gb=$((ram_kb / 1024 / 1024))
+if ((ram_gb >= 16)); then
+  pass "RAM ${ram_gb} GB"
+elif ((ram_gb >= 8)); then
+  warn "RAM ${ram_gb} GB (8 GB minimum met, 16 GB comfortable)"
+else
+  fail "RAM ${ram_gb} GB is below the 8 GB minimum"
+fi
+
+disk_gb="$(df -BG --output=avail "$ROOT" 2>/dev/null | tail -n1 | tr -dc '0-9')"
+disk_gb="${disk_gb:-0}"
+if ((disk_gb >= 50)); then
+  pass "Disk ${disk_gb} GB free"
+elif ((disk_gb >= 20)); then
+  warn "Disk ${disk_gb} GB free (20 GB minimum met; weights are 2-7 GB per model)"
+else
+  fail "Disk ${disk_gb} GB free is below the 20 GB minimum"
+fi
+
+if ! (echo >"/dev/tcp/127.0.0.1/${PORT}") 2>/dev/null; then
+  pass "port ${PORT} free"
+elif curl -sf --max-time 2 "http://localhost:${PORT}/api/v1/health" 2>/dev/null | grep -q '"status"'; then
+  # Re-running preflight against a stack that is already up is not a problem.
+  pass "port ${PORT} serving potocolom already (stack is up)"
+else
+  fail "port ${PORT} is in use by something else; free it or publish the studio elsewhere"
+fi
+
+# -------------------------------------------------------------- docker
+
+head_ "Docker"
+
+docker_ok=false
+if ! command -v docker >/dev/null 2>&1; then
+  fail "docker not installed - https://docs.docker.com/engine/install/"
+else
+  pass "docker $(docker --version | awk '{print $3}' | tr -d ,)"
+
+  if docker compose version >/dev/null 2>&1; then
+    pass "compose $(docker compose version --short 2>/dev/null)"
+  else
+    fail "docker compose v2 not available (the v1 'docker-compose' binary will not work)"
+  fi
+
+  # Distinguish the three ways the daemon is unreachable: they have
+  # completely different fixes and the raw error does not say which.
+  docker_err="$(docker info --format '{{.ServerVersion}}' 2>&1 >/dev/null)"
+  if [[ -z "$docker_err" ]]; then
+    pass "docker daemon reachable"
+    docker_ok=true
+  elif [[ "$docker_err" == *"permission denied"* ]]; then
+    fail "docker daemon refuses this user: not in the 'docker' group"
+    note "sudo usermod -aG docker $USER   # then log out and back in"
+  elif [[ "$docker_err" == *"Cannot connect"* || "$docker_err" == *"Is the docker daemon running"* ]]; then
+    fail "docker daemon not running"
+    note "sudo systemctl enable --now docker"
+  else
+    fail "docker daemon unreachable: ${docker_err}"
+  fi
+fi
+
+# ----------------------------------------------------------------- gpu
+
+head_ "GPU"
+
+profile=""
+vram_mb=0
+
+# AMD first: /dev/kfd is the compute device the ROCm worker needs, and it is
+# absent on machines with only a display-capable amdgpu.
+if [[ -e /dev/kfd ]]; then
+  pass "AMD compute device /dev/kfd present"
+  if [[ -d /dev/dri ]]; then
+    pass "/dev/dri present"
+  else
+    fail "/dev/dri missing; the ROCm worker needs both devices passed through"
+  fi
+  groups_have=""
+  for g in video render; do
+    if id -nG | tr ' ' '\n' | grep -qx "$g"; then groups_have="${groups_have} ${g}"; fi
+  done
+  if [[ "$groups_have" == *video* ]]; then
+    pass "user in group(s):${groups_have}"
+  else
+    fail "user not in the 'video' group"
+    note "sudo usermod -aG video,render $USER   # then log out and back in"
+  fi
+  if command -v rocm-smi >/dev/null 2>&1; then
+    vram_mb="$(rocm-smi --showmeminfo vram --csv 2>/dev/null | awk -F, 'NR==2 {print int($2/1048576)}')"
+    vram_mb="${vram_mb:-0}"
+    ((vram_mb > 0)) && pass "VRAM ${vram_mb} MiB"
+  else
+    warn "rocm-smi not on the host (fine: the container ships ROCm userspace), VRAM unknown"
+  fi
+  profile="rocm"
+
+# NVIDIA. Deliberately NOT detected with lsmod: on Optimus laptops the dGPU
+# sits in D3cold with its modules unloaded until something touches it, so
+# lsmod reports nothing on a perfectly working install. /proc/driver/nvidia
+# exists regardless, and nvidia-smi wakes the device. Driver files alone do
+# not prove CUDA can run, so nvidia-smi must actually enumerate a GPU before
+# this branch selects the gpu profile; otherwise the host falls through to
+# the simulated worker.
+elif [[ -r /proc/driver/nvidia/version ]] || command -v nvidia-smi >/dev/null 2>&1; then
+  if command -v nvidia-smi >/dev/null 2>&1 && smi="$(nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader 2>&1)" && [[ -n "$smi" ]]; then
+    gpu_name="$(echo "$smi" | head -n1 | cut -d, -f1 | xargs)"
+    vram_mb="$(echo "$smi" | head -n1 | cut -d, -f2 | tr -dc '0-9')"
+    driver_version="$(echo "$smi" | head -n1 | cut -d, -f3 | xargs)"
+    pass "${gpu_name}, ${vram_mb} MiB VRAM, driver ${driver_version}"
+
+    if version_ge "$driver_version" "$CUDA_MIN_DRIVER"; then
+      driver_cuda="$(nvidia-smi 2>/dev/null | sed -n 's/.*CUDA Version: *\([0-9.]*\).*/\1/p' | head -n1)"
+      if [[ -n "$driver_cuda" ]] && ! version_ge "$driver_cuda" "$CUDA_IMAGE_VERSION"; then
+        warn "driver supports CUDA ${driver_cuda}; the worker image is built on CUDA ${CUDA_IMAGE_VERSION}"
+        note "expected to work under CUDA minor version compatibility (driver >= ${CUDA_MIN_DRIVER})."
+        note "if the worker fails on a CUDA error, upgrade the driver before anything else."
+      fi
+    else
+      fail "driver ${driver_version} is older than ${CUDA_MIN_DRIVER}; the CUDA ${CUDA_IMAGE_VERSION} worker image will not load"
+    fi
+  else
+    warn "NVIDIA driver files present but nvidia-smi did not report a GPU"
+    note "the gpu profile needs a usable GPU; this host will fall through to the simulated worker"
+  fi
+
+  if command -v nvidia-ctk >/dev/null 2>&1; then
+    pass "NVIDIA Container Toolkit installed"
+  else
+    fail "NVIDIA Container Toolkit missing; the gpu profile cannot pass the GPU through"
+    note "https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html"
+  fi
+
+  # The only check that proves the whole chain works, so it is worth the
+  # container pull. Skip with POTOCOLOM_SKIP_GPU_TEST=1.
+  if [[ "$docker_ok" == true && "${POTOCOLOM_SKIP_GPU_TEST:-0}" != "1" ]]; then
+    if docker run --rm --gpus all ubuntu:24.04 nvidia-smi -L >/dev/null 2>&1; then
+      pass "docker can reach the GPU (--gpus all works)"
+    else
+      fail "docker cannot reach the GPU; toolkit installed but passthrough is broken"
+      note "sudo nvidia-ctk runtime configure --runtime=docker && sudo systemctl restart docker"
+    fi
+  fi
+  # Only claim the gpu profile when nvidia-smi actually enumerated a GPU
+  # above. Driver files alone do not prove CUDA can run, so a host with the
+  # driver installed but no device falls through to the simulated worker.
+  if [[ -n "${vram_mb:-}" && "$vram_mb" -gt 0 ]]; then
+    profile="gpu"
+  else
+    profile="smoke"
+  fi
+
+else
+  warn "no NVIDIA or AMD compute GPU detected"
+  note "the full stack still runs against the simulated worker: scripts/compose-smoke.sh"
+  profile="smoke"
+fi
+
+# ------------------------------------------------------------ capacity
+
+if ((vram_mb > 0)); then
+  head_ "Selectable models against ${vram_mb} MiB"
+
+  realtime=(); degraded=()
+  for manifest in "$ROOT"/worker/models/*.json; do
+    [[ -e "$manifest" ]] || continue
+    # benchmark_only manifests never reach the studio's model picker
+    # (registry.public()), so they are not capacity a self-hoster can spend.
+    grep -q '"benchmark_only"[[:space:]]*:[[:space:]]*true' "$manifest" && continue
+    id="$(grep -m1 '"id"' "$manifest" | cut -d'"' -f4)"
+    floor="$(grep -m1 '"min_vram_gb"' "$manifest" | tr -dc '0-9')"
+    [[ -n "$id" && -n "$floor" ]] || continue
+    if ((vram_mb >= floor * 1024)); then
+      realtime+=("${id} (${floor} GB)")
+    else
+      degraded+=("${id} (${floor} GB)")
+    fi
+  done
+
+  if ((${#realtime[@]} > 0)); then
+    pass "full residency, realtime capable: ${realtime[*]}"
+  else
+    warn "no model reaches full residency on this card"
+  fi
+  if ((${#degraded[@]} > 0)); then
+    warn "below their floor, will load offloaded without the realtime capability:"
+    note "${degraded[*]}"
+    note "generation still works; the live draw-and-render loop is what you lose."
+  fi
+fi
+
+# ------------------------------------------------------------- verdict
+
+head_ "Verdict"
+
+if ((fails > 0)); then
+  printf '  %s%d blocking problem(s)%s above. Fix them, then run this again.\n' "$R" "$fails" "$N"
+  exit 1
+fi
+
+((warns > 0)) && printf '  %d warning(s); the stack will start.\n' "$warns"
+
+case "$profile" in
+  gpu)   printf '  Ready. NVIDIA worker:\n\n    cp deploy/compose/.env.example deploy/compose/.env   # set POSTGRES_PASSWORD\n    docker compose -f deploy/compose/compose.yml --profile gpu up -d --build\n\n  Then open http://localhost:%s\n' "$PORT" ;;
+  rocm)  printf '  Ready. AMD worker:\n\n    cp deploy/compose/.env.example deploy/compose/.env   # set POSTGRES_PASSWORD\n    docker compose -f deploy/compose/compose.yml --profile rocm up -d --build\n\n  Then open http://localhost:%s\n' "$PORT" ;;
+  smoke) printf '  Ready for the simulated worker (no GPU inference):\n\n    scripts/compose-smoke.sh\n' ;;
+esac

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -28,7 +28,12 @@ inference = [
     "diffusers>=0.39,<1",
     "transformers>=5,<6",
     "accelerate>=1,<2",
-    "torchao>=0.17,<1",
+    # Cap below 0.18 until the worker images move to torch 2.10
+    # (Dockerfile.worker-cuda and Dockerfile.worker-rocm). torchao 0.18 imports
+    # torch.nn.functional.ScalingType, which lands in torch 2.10, so an
+    # unpinned resolve installs a torchao that cannot import against 2.9 and
+    # every generation fails at diffusers import time. Raise both together.
+    "torchao>=0.17,<0.18",
     "peft>=0.13,<1",
     "spandrel>=0.4,<1",
 ]

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -19,6 +19,7 @@ from worker.engine import (
     SimulatedEngine,
     _canvas_to_sketch_map,
     encode_webp,
+    reject_degenerate_output,
 )
 from worker.manifests import Manifest, SIMULATED_MANIFEST
 
@@ -194,7 +195,9 @@ class _JobPipeline:
 
     def __call__(self, **kwargs):
         self.call_kwargs.append(kwargs)
-        return SimpleNamespace(images=[Image.new("RGB", (64, 48))])
+        image = Image.new("RGB", (64, 48))
+        image.putpixel((1, 0), (1, 0, 0))
+        return SimpleNamespace(images=[image])
 
 
 def _job_engine(pipeline: _JobPipeline) -> DiffusersEngine:
@@ -975,7 +978,10 @@ def test_group_offload_uses_disk_only_for_unquantized_models(tmp_path):
     engine._apply_rung(pipeline, manifest, "group_offload")
 
     kwargs = pipeline.enable_group_offload.call_args.kwargs
-    assert kwargs["use_stream"] is True
+    # Streaming stays off for every model on this rung: diffusers' lazy
+    # prefetch skips leaves and the run decodes to solid black. Only the
+    # disk offload path is conditional on quantization.
+    assert kwargs["use_stream"] is False
     assert kwargs["offload_to_disk_path"] == str(
         tmp_path / ".offload" / "unquantized"
     )
@@ -1013,6 +1019,7 @@ def test_preview_decoder_is_realtime_only_and_takes_unscaled_latents():
     decoded = object()
     preview_image = Image.new("RGB", (32, 32), (12, 34, 56))
     stored_image = Image.new("RGB", (32, 32), (78, 90, 123))
+    stored_image.putpixel((1, 0), (79, 90, 123))
 
     def run_pipeline(**kwargs):
         if kwargs.get("output_type") == "latent":
@@ -2233,6 +2240,56 @@ def test_generate_value_error_does_not_evict():
     asyncio.run(scenario())
     assert ("m", "t2i") in engine._pipelines
     assert engine._poison_evict_count == {}
+
+
+def test_reject_degenerate_output_raises_on_a_flat_image():
+    """A saturated denoise decodes to one colour; it must not be stored."""
+    for colour in ((0, 0, 0), (255, 255, 255), (12, 34, 56)):
+        try:
+            reject_degenerate_output(Image.new("RGB", (32, 32), colour), "ssd-1b")
+        except RuntimeError as error:
+            assert "ssd-1b" in str(error)
+            assert "flat colour" in str(error)
+        else:
+            raise AssertionError(f"expected RuntimeError for {colour}")
+
+
+def test_reject_degenerate_output_passes_real_output():
+    """One varying band is enough; VAE noise means real output is never flat."""
+    image = Image.new("RGB", (32, 32), (10, 20, 30))
+    image.putpixel((0, 0), (10, 20, 31))
+    reject_degenerate_output(image, "ssd-1b")
+
+    gradient = Image.linear_gradient("L")
+    reject_degenerate_output(gradient, "ssd-1b")
+
+
+def test_generate_rejects_a_flat_render_and_evicts_the_resident():
+    """The guard fails the job and drops the pipeline that produced it."""
+    engine = _poison_engine()
+    manifest = Manifest(id="m", name="M", capabilities=["text_to_image"])
+    flat = Image.new("RGB", (32, 32), (0, 0, 0))
+
+    engine._pipeline = MagicMock(return_value=MagicMock(
+        return_value=SimpleNamespace(images=[flat]),
+    ))
+    engine._prompt_kwargs = MagicMock(return_value={"prompt": "x"})
+
+    async def run_inline(function, *args, **kwargs):
+        return function(*args, **kwargs)
+
+    async def scenario():
+        with patch("asyncio.to_thread", side_effect=run_inline):
+            try:
+                await engine.generate(manifest, {"prompt": "x", "steps": 1}, lambda _: None)
+            except RuntimeError as error:
+                assert "flat colour" in str(error)
+            else:
+                raise AssertionError("expected RuntimeError")
+
+    asyncio.run(scenario())
+    assert engine._pipelines == {}
+    assert engine._poison_evict_count["m"] == 1
 
 
 def test_generation_oom_demotes_once_and_retries_once():

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -78,6 +78,33 @@ class GeneratedImage:
     load_ms: int = 0
 
 
+def reject_degenerate_output(image: Image.Image, model_id: str) -> None:
+    """Raise when a denoise decoded to one flat colour.
+
+    A saturated or NaN denoise decodes to a single constant colour, and the
+    job would otherwise be stored as succeeded with a plausible asset row: that
+    is exactly how the group offload streaming defect stayed invisible (see
+    _apply_rung). Raising here fails the job and, through generate()'s
+    poison-evict branch, drops the resident that produced it so the next job
+    reloads clean rather than repeating the fault.
+
+    Every band being exactly constant is the whole test. VAE decode noise means
+    real diffusion output is never bit-flat, so there is no tolerance to tune
+    and no legitimate generation to misjudge. Upscale is not checked, because a
+    flat source legitimately upscales to a flat result, and neither is the
+    realtime frame path, which never reaches the offload rung this guards.
+    SimulatedEngine emits flat colour by design and is a separate class.
+    """
+    extrema = image.getextrema()
+    # Single-band images return one (low, high) pair rather than one per band.
+    bands = extrema if isinstance(extrema[0], tuple) else (extrema,)
+    if all(low == high for low, high in bands):
+        raise RuntimeError(
+            f"{model_id} produced a single flat colour, so the denoise or the "
+            "VAE decode failed; the image was discarded rather than stored"
+        )
+
+
 @dataclass
 class GeneratedFrame:
     data: bytes
@@ -470,12 +497,11 @@ class DiffusersEngine:
             else:
                 pipeline.enable_model_cpu_offload()
             return pipeline
-        use_group_offload_fast_path = not manifest.quantize
+        can_offload_to_disk = not manifest.quantize
         offload_dir = None
-        # Quantized torchao subclass tensors cannot be serialized by safetensors
-        # or handle aten.is_pinned for stream prefetch. They must remain in host
-        # RAM without streaming, so this rung is slower and needs enough host RAM.
-        if self.models_dir and use_group_offload_fast_path:
+        # Quantized torchao subclass tensors cannot be serialized by safetensors,
+        # so they must stay in host RAM: this rung needs enough of it.
+        if self.models_dir and can_offload_to_disk:
             safe_id = "".join(c if c.isalnum() or c in "._-" else "-" for c in manifest.id)
             offload_dir = str(Path(self.models_dir) / ".offload" / safe_id.lstrip("."))
             Path(offload_dir).mkdir(parents=True, exist_ok=True)
@@ -484,7 +510,13 @@ class DiffusersEngine:
             # leaf_level streams layer by layer and needs no block sizing;
             # block_level raises when num_blocks_per_group is unset.
             offload_type="leaf_level",
-            use_stream=use_group_offload_fast_path,
+            # use_stream=True silently produces wrong output on this rung:
+            # diffusers' lazy prefetch fails to onload every leaf ("some layers
+            # were not executed during the forward pass"), latents come back at
+            # roughly 20x their normal range (-56..56 against -2.7..2.4) and
+            # decode to a solid black image while the job still reports
+            # succeeded. Correctness first; this rung is already the slow one.
+            use_stream=False,
             offload_to_disk_path=offload_dir,
         )
         return pipeline
@@ -1419,6 +1451,7 @@ class DiffusersEngine:
             callback_on_step_end=on_step,
         ).images[0]
         gpu_ms = int((time.monotonic() - start) * 1000)
+        reject_degenerate_output(image, manifest.id)
         return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 
     def _generate_i2i(self, manifest: Manifest, params: dict, progress: ProgressFn,
@@ -1466,6 +1499,7 @@ class DiffusersEngine:
             callback_on_step_end=on_step,
         ).images[0]
         gpu_ms = int((time.monotonic() - start) * 1000)
+        reject_degenerate_output(image, manifest.id)
         loop.call_soon_threadsafe(progress, 1.0)
         return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 


### PR DESCRIPTION
Ran the shipped self-hosting quick start on a fresh NVIDIA machine (RTX 3050
Laptop, 4 GB, driver 535.261.03, Debian 12) to see what a new self-hoster
actually hits. It did not work, for two reasons that have nothing to do with
the GPU vendor, and the requirements table pointed at hardware that cannot run
anything. All three are fixed here, plus a preflight script so the next person
finds out in two seconds instead of after a multi-gigabyte build.

## The worker image has not built usably since torchao 0.18

`torchao>=0.17,<1` resolves to 0.18, which imports
`torch.nn.functional.ScalingType`. That symbol lands in torch 2.10; both worker
base images pin torch 2.9.0. torchao declares no torch requirement, so pip
installs the broken pair and reports success. The failure surfaces only at the
first generation, after the whole image has been built:

```
ImportError: cannot import name 'ScalingType' from 'torch.nn.functional'
```

reached via `diffusers.loaders.peft` -> `hooks.group_offloading` -> `torchao`.

**This affects the ROCm profile identically** - `rocm/pytorch:...pytorch_2.9.0`
is also torch 2.9. Machines with an image built before torchao 0.18 was
published keep working, which is why it has not been noticed.

Capped at `<0.18`. Raising the base images to torch 2.10+ is the alternative;
the two bounds have to move together, hence the comment on the pin.

## Group offload streamed wrong output and reported success

On the `group_offload` rung, `enable_group_offload(use_stream=True)` does not
onload every leaf. diffusers warns `some layers were not executed during the
forward pass`, and the denoise loop returns latents at roughly twenty times
their normal range, which saturate on decode. The job writes a solid black PNG
and reports `state=succeeded` with `gpu_ms` populated. Nothing in the API, the
logs, or the asset record indicates the image is garbage.

Same card, same prompt, same seed 42, `ssd-1b-lightning` 768 px / 8 steps, only
`use_stream` differing:

| `use_stream` | latent min/max | result |
|---|---|---|
| `True` | -56.81 .. 56.03 | solid black, 1.8 KB PNG |
| `False` | -2.71 .. 2.39 | correct image, 589 KB PNG |

`False` matches what `enable_sequential_cpu_offload` produces on the same card,
so the pipeline is sound and only the streaming prefetch is wrong. Turned off
on this rung - it is already the slowest one, and correctness beats its
throughput.

Only cards that fall to the bottom rung are affected, which is why a 16 GB
machine at full residency never saw it, and why it lands exactly on the
low-VRAM self-hoster the requirements table invites in.

Worth an upstream diffusers issue separately; this is the local mitigation.

## The documented 6 GB minimum was not reachable

`dreamshaper-lcm` declares 6 GB but is `benchmark_only`, so `registry.public()`
keeps it out of `GET /api/v1/models` and it never appears in the studio. The
lowest selectable text-to-image model is `ssd-1b` at 8 GB. Someone sizing a
card off the README would have bought 6 GB and found nothing to select.
Verified against the live endpoint, not just the manifests.

Also corrected: the docker group requirement (documented nowhere, and the first
thing that stops a fresh install); the absent minimum NVIDIA driver version
(525.60.13, with an explicit note that a 535 driver reporting CUDA 12.2 against
a CUDA 12.8 image is fine and needs no upgrade); `min_vram_gb` described as a
gate when it is a ladder; and "spans 6 to 10 GB" when `sd35-medium` declares 14.

## scripts/preflight.sh

`make preflight`. Read-only, starts nothing, installs nothing, exits non-zero on
a blocker. Three details it encodes, each from getting them wrong first:

- NVIDIA is detected via `/proc/driver/nvidia/version` and `nvidia-smi`, never
  `lsmod`. On a laptop with switchable graphics the dGPU sits in `D3cold` with
  its modules unloaded, so `lsmod` prints nothing on a working install.
- The three ways the docker daemon is unreachable (not installed, not running,
  caller not in the `docker` group) each get their own fix line.
- `benchmark_only` manifests are skipped, so it reports capacity that is
  actually selectable.

## Failing a degenerate generation instead of storing it

The two fixes above address the known cause. This closes the class: nothing
detected that a generation was garbage, so the black images were stored as
`succeeded` with `gpu_ms` populated and a valid asset row, which is why the
defect survived unnoticed until someone generated on a card small enough to
reach the offload rung.

`reject_degenerate_output` raises when every band of the decoded image is
exactly constant. Through `generate()`'s existing poison-evict branch that
fails the job with a readable reason and drops the resident that produced it,
so the next job reloads clean rather than repeating the fault.

Exact constancy is the whole test, deliberately: VAE decode noise means real
diffusion output is never bit-flat, so there is no tolerance to tune and no
legitimate generation it can misjudge. Not applied to upscale, where a flat
source legitimately upscales to a flat result, nor to the realtime frame path,
which requires full residency and never reaches the guarded rung.

Verified in both directions by reintroducing `use_stream=True` against the
guard:

```
state: failed
failure_reason: ssd-1b-lightning produced a single flat colour, so the denoise
                or the VAE decode failed; the image was discarded rather than stored
assets: 0
```

against `succeeded` with a 1.8 KB black PNG before. A normal generation on the
same worker still succeeds (769 KB, luminance 12..240).

## Detecting the dev worker instead of defaulting to ROCm

`scripts/dev-stack.sh` defaulted `WORKER` to `rocm` and the Makefile pinned the
same value, so `make dev-start` launched a ROCm worker on every contributor's
machine whatever GPU it had - on an NVIDIA box, one that cannot start. The
Makefile header led with `make worker-rocm` for the same reason. Now detected:
`/dev/kfd` for AMD, `/proc/driver/nvidia/version` or `nvidia-smi` for NVIDIA
(never `lsmod`, for the D3cold reason above), else the simulated worker.
`WORKER` is still honoured when set.

Also: `make setup` now fails with the package to install when the interpreter
is new enough but cannot create a virtualenv. Debian and Ubuntu ship venv
separately, so `check-python` passed on a stock Debian 12 and the failure
arrived as a raw ensurepip traceback from inside `python -m venv`, for a target
that already prints a helpful message in the version case. This is what stopped
`make verify` running locally on the machine used for this PR.

## Signposting the docker compose / make split

The README mixed bare `docker compose` commands with `make` targets and never
said why, which reads as inconsistency rather than intent. The reason is a
constraint worth keeping: self-hosting requires Docker and nothing else, as the
requirements table promises, so routing the quick start through `make` would
quietly add `make` to that table and contradict "everything ships as
containers; nothing is installed on the host". The Makefile is also headed
"Development entry points" - a different audience.

The split therefore stays, and is now stated in both directions: self-hosting
says its commands are `docker compose` on purpose and that the `make` targets
are for working *on* potocolom; development says its targets drive a native
toolchain and need the prerequisites rather than Docker alone.

`compose-up`, `compose-down` and `compose-logs` wrap the documented commands
for hosts that already have `make`, described in both places as a shortcut that
is never a requirement. They detect the profile the way preflight reports it,
honour `PROFILE=`, and refuse to start with a missing `deploy/compose/.env`
rather than letting postgres fail on an unset password. `compose-down` does not
pass `-v`, so `pgdata` and `assets` survive it. Named `compose-*` because
`stack-up`/`stack-down` already alias the development loop.

## Verification

Full stack from a clean rebuild on the 4 GB card, brought up through the new
`make compose-up` wrapper: API,
Postgres, worker registered with `device=cuda`, weights pulled from Hugging
Face, real images generated end to end at 768 px in about 7.7 s of GPU time per
still. CUDA 12.8 images confirmed running on the 535 driver under minor version
compatibility.

`worker` ruff clean and all 89 tests pass (three added for the guard). `make verify-compose` passes across
every file and profile. `test_group_offload_uses_disk_only_for_unquantized_models`
asserted the old `use_stream is True` contract and is updated.

Not run locally: `verify-backend` and `verify-frontend`. `make setup` cannot
create the venvs on this host because Debian's `python3.11-venv` is absent. No
backend or frontend code is touched here, and CI covers both. The guard added
in this PR now reports that condition as the package to install rather than an
ensurepip traceback.

The ROCm profile is unexercised here - I have no AMD card. Both changes are
vendor-independent (shared `pyproject.toml`, shared engine path, identical torch
2.9.0 base), but confirming the torchao pin on ROCm needs a `--no-cache` rebuild
on an AMD machine to force a fresh resolve.

## Follow-up not taken here

The realtime frame path is not guarded. It requires full residency, so it
cannot reach the rung that produced the corruption, and a per-frame extrema
pass would be paid against the 500 ms bar. Worth revisiting if a corruption
mode is ever found at full residency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-hosting preflight checks for system, Docker, GPU, driver, port, and model requirements.
  * Added Docker Compose shortcuts for starting, stopping, and viewing logs.
  * Worker mode now automatically detects CUDA, ROCm, or simulation environments.

* **Bug Fixes**
  * Prevented degenerate flat-color images from being returned or stored.
  * Improved quantized model offloading to avoid incorrect image output.
  * Clarified startup failures for unsupported authentication modes.

* **Documentation**
  * Updated self-hosting, hardware, model, GPU, and development guidance.
  * Added Docker Compose and low-VRAM performance guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->