### PR TITLE
Rebuild the test database when it is stamped ahead of this checkout

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,11 +8,14 @@ Tests marked db skip when PostgreSQL is unreachable; `make deps` starts it.
 import asyncio
 import atexit
 import os
+import pathlib
 import shutil
 import tempfile
 from urllib.parse import urlsplit
 
 import pytest
+
+_VERSIONS = pathlib.Path(__file__).resolve().parents[1] / "migrations" / "versions"
 
 os.environ.setdefault("DATABASE_URL",
                       "postgresql://potocolom:potocolom@localhost:5432/potocolom_test")
@@ -22,11 +25,31 @@ os.environ.setdefault("STORAGE_LOCAL_PATH", _storage_root)
 atexit.register(shutil.rmtree, _storage_root, ignore_errors=True)
 
 
+def _local_revisions() -> set[str]:
+    """Revision ids this checkout can migrate through. Every migration names its
+    revision after its filename prefix: 0011_usage_event_rollups.py declares
+    revision = "0011". test_migrations.py keeps that assumption honest."""
+    return {path.name.split("_", 1)[0] for path in _VERSIONS.glob("[0-9]*.py")}
+
+
 def _prepare_database() -> bool:
     import asyncpg
 
     url = urlsplit(os.environ["DATABASE_URL"])
     database = url.path.lstrip("/")
+
+    async def stamped_ahead() -> bool:
+        conn = await asyncpg.connect(host=url.hostname, port=url.port or 5432,
+                                     user=url.username, password=url.password,
+                                     database=database, timeout=3)
+        try:
+            if await conn.fetchval("SELECT to_regclass($1)",
+                                   "public.alembic_version") is None:
+                return False
+            stamped = await conn.fetchval("SELECT version_num FROM alembic_version")
+            return stamped is not None and stamped not in _local_revisions()
+        finally:
+            await conn.close()
 
     async def prepare() -> None:
         conn = await asyncpg.connect(host=url.hostname, port=url.port or 5432,
@@ -35,6 +58,13 @@ def _prepare_database() -> bool:
         try:
             exists = await conn.fetchval("SELECT 1 FROM pg_database WHERE datname = $1",
                                          database)
+            # Worktrees share this database. One carrying a newer migration
+            # leaves it stamped at a revision this checkout cannot resolve, and
+            # alembic then refuses to start: every db test fails for a reason
+            # that looks like broken application code. Rebuild, don't truncate.
+            if exists and await stamped_ahead():
+                await conn.execute(f'DROP DATABASE "{database}" WITH (FORCE)')
+                exists = None
             if not exists:
                 await conn.execute(f'CREATE DATABASE "{database}"')
         finally:

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,16 @@
+"""conftest decides whether the shared test database is stamped ahead of this
+checkout by reading revision ids off migration filenames. Keep that true."""
+
+import re
+
+from conftest import _VERSIONS, _local_revisions
+
+
+def test_local_revisions_match_declared_revisions():
+    declared = set()
+    for path in _VERSIONS.glob("[0-9]*.py"):
+        match = re.search(r'^revision = "([^"]+)"', path.read_text(), re.MULTILINE)
+        assert match, f"{path.name} declares no revision"
+        declared.add(match.group(1))
+    assert declared, "no migrations found"
+    assert _local_revisions() == declared


### PR DESCRIPTION
Closes #215.

`conftest.py` created and truncated `potocolom_test` but never touched `alembic_version`. Every worktree shares that database by default, so a worktree carrying a new migration left it stamped at a revision other checkouts cannot resolve. Alembic then refused to start and 35 database tests failed with `KeyError: 'job_id'` and `assert None is not None`, which read like broken application code. The only line that explained it was a warning well up the output:

```
WARNING potocolom.db: database unavailable (Can't locate revision identified by '0012')
```

Now the stamp is compared against the revision ids in `migrations/versions/`, and the database is dropped and recreated when it names one this checkout does not have. The existing truncate path is untouched for a stamp we recognise.

Revision ids are read from filename prefixes, which keeps alembic configuration out of test bootstrap. `test_migrations.py` fails if a migration ever declares a revision its filename does not match, which is the only fragile part of that shortcut.

## Verification

Stamped `potocolom_test` at a revision that does not exist (`0099`) and ran the suite: the database was rebuilt, tests passed, and the stamp came back at `0011`. The same scenario produced 35 failures before this change.

`make verify` passes on the backend at 109 tests and on the frontend. `verify-worker` fails on `worker/engine.py:911`, which is #216, pre-existing on `main` and unrelated.
