### PR TITLE
Narrow the pooled embedding before zeroing it

### DIFF
--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -907,6 +907,9 @@ class DiffusersEngine:
             and bool(getattr(pipeline.config, "force_zeros_for_empty_prompt", False))
         )
         if force_zero_negative:
+            # It implies dual_encoder, so the index-1 pass above ran with
+            # pooled=True and positive_pooled holds that encoder's embedding.
+            assert positive_pooled is not None
             negative_prompt_embeds = self.torch.zeros_like(prompt_embeds)
             negative_pooled = self.torch.zeros_like(positive_pooled)
         else:


### PR DESCRIPTION
Closes #216.

`mypy` rejected `zeros_like(positive_pooled)`: the variable is seeded as `None` and only assigned on the index-1 pass of the encoder loop.

That pass always runs on this branch. `force_zero_negative` requires `dual_encoder`, and `dual_encoder` is exactly what appends the second tokenizer and text encoder, so the loop has two iterations and the index-1 iteration ran with `pooled=True`. So this is a narrowing problem and not the latent crash the issue asked about.

Stating the invariant is cheaper than restructuring around a case that cannot occur, and it matches how the backend narrows the same shape (`backend/app/jobs.py:496,635,650`).

## Verification

`make verify` passes end to end: backend 109, worker 86, frontend build and CSP check. It has been red on `main` for the whole life of this error. The path is already covered by `worker/tests/test_engine.py:119`, which sets `force_zeros_for_empty_prompt=True`.