### PR TITLE
Refuse WebSocket handshakes from an unlisted browser origin

### DIFF
--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, HTTPException, WebSocket
 from starlette.websockets import WebSocketDisconnect, WebSocketState
 
 from app.manifests import Manifest, parse_manifests, validate_params
+from app.settings import get_settings
 from app import db
 
 logger = logging.getLogger("potocolom.realtime")
@@ -42,6 +43,25 @@ SESSION_READY_TIMEOUT = 10.0
 WORKER_DEAD_SECONDS = 90.0  # 3 missed heartbeats, docs/connection-handling.md
 
 router = APIRouter()
+
+
+def origin_allowed(ws: WebSocket) -> bool:
+    """Neither socket authenticates its peer; the documented mitigation is a
+    trusted LAN (README.md). WebSocket handshakes ignore the same-origin policy
+    and send no preflight, so without this a page the operator merely visits
+    reaches both sockets from outside that LAN. Browsers always send Origin and
+    cannot forge it; worker processes send none (issue #201)."""
+    origin = ws.headers.get("origin")
+    if origin is None:
+        return True
+    settings = get_settings()
+    allowed = {settings.public_url.rstrip("/")}
+    allowed.update(
+        candidate.strip().rstrip("/")
+        for candidate in settings.allowed_origins.split(",")
+        if candidate.strip()
+    )
+    return origin.rstrip("/") in allowed
 
 
 class ProtocolError(Exception):
@@ -257,6 +277,10 @@ async def reap_dead_workers() -> None:
 
 @router.websocket("/api/v1/fleet")
 async def fleet(ws: WebSocket) -> None:
+    if not origin_allowed(ws):
+        logger.warning("fleet handshake refused from origin %s", ws.headers.get("origin"))
+        await ws.close()  # before accept: the handshake fails with HTTP 403
+        return
     await ws.accept()
     try:
         hello = parse_control(await ws.receive_text())
@@ -361,6 +385,10 @@ async def fleet(ws: WebSocket) -> None:
 
 @router.websocket("/api/v1/realtime")
 async def realtime(ws: WebSocket) -> None:
+    if not origin_allowed(ws):
+        logger.warning("realtime handshake refused from origin %s", ws.headers.get("origin"))
+        await ws.close()  # before accept: the handshake fails with HTTP 403
+        return
     await ws.accept()
     try:
         opening = parse_control(await ws.receive_text())

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -20,6 +20,12 @@ class Settings(BaseSettings):
     # Defaults to PUBLIC_URL for native dev (docs/blueprint.md).
     internal_url: str = ""
 
+    # Extra browser origins allowed to open the WebSocket endpoints, comma
+    # separated. PUBLIC_URL is always allowed; this is for the dev loop, where
+    # the vite server proxies /api/v1 and the browser's origin is its own
+    # (issue #201).
+    allowed_origins: str = ""
+
     # Defaults match deploy/compose/dev.yml for the native dev loop.
     database_url: str = "postgresql://potocolom:potocolom@localhost:5432/potocolom"
 

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -10,7 +10,8 @@ from starlette.websockets import WebSocketDisconnect
 from app import db, realtime
 from app.main import app
 from app.manifests import Manifest
-from app.realtime import CANVAS_FRAME, GENERATED_FRAME, MIN_SUPPORTED_VERSION, PROTOCOL_VERSION
+from app.realtime import CANVAS_FRAME, origin_allowed, GENERATED_FRAME, MIN_SUPPORTED_VERSION, PROTOCOL_VERSION
+from app.settings import get_settings
 from app.tables import UsageEvent
 
 client = TestClient(app)
@@ -18,6 +19,13 @@ client = TestClient(app)
 
 def manifest(model_id="sd-sim") -> dict:
     return {"id": model_id, "name": model_id, "capabilities": ["realtime"], "parameters": {}}
+
+
+class FakeHeaders:
+    """Stands in for a WebSocket when only the Origin header matters."""
+
+    def __init__(self, origin):
+        self.headers = {} if origin is None else {"origin": origin}
 
 
 class FakeSocket:
@@ -294,3 +302,32 @@ def test_reaper_closes_silent_workers():
     finally:
         realtime.workers.pop("w-stale", None)
         realtime.workers.pop("w-fresh", None)
+
+
+
+def test_origin_allowed_only_for_no_origin_and_configured_origins():
+    # Browsers always send Origin and cannot forge it; workers send none.
+    settings = get_settings()
+    assert origin_allowed(FakeHeaders(None))
+    assert origin_allowed(FakeHeaders(settings.public_url))
+    assert origin_allowed(FakeHeaders(settings.public_url + "/"))
+    assert not origin_allowed(FakeHeaders("https://evil.example"))
+    assert not origin_allowed(FakeHeaders("http://localhost:5173"))
+
+
+def test_origin_allowed_honours_the_configured_extra_origins(monkeypatch):
+    settings = get_settings()
+    monkeypatch.setattr(settings, "allowed_origins", "http://localhost:5173, https://ok.example")
+    assert origin_allowed(FakeHeaders("http://localhost:5173"))
+    assert origin_allowed(FakeHeaders("https://ok.example"))
+    assert not origin_allowed(FakeHeaders("https://evil.example"))
+
+
+def test_foreign_origin_cannot_register_a_worker():
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect(
+            "/api/v1/fleet", headers={"origin": "https://evil.example"},
+        ) as ws:
+            ws.send_json(hello(worker_id="w-evil"))
+            ws.receive_json()
+    assert "w-evil" not in realtime.workers

--- a/docs/api.md
+++ b/docs/api.md
@@ -82,6 +82,8 @@ The SPA's first call. One build artifact serves every deployment; this response 
 
 The drawing tool's connection. Text messages are JSON control, binary messages are image frames (17 byte header, then payload); framing, timeouts and close codes are specified in [connection-handling.md](connection-handling.md).
 
+Both WebSocket endpoints refuse a handshake carrying an `Origin` that is not `PUBLIC_URL` or one of `ALLOWED_ORIGINS`; the connection fails as HTTP 403 before any close code applies (see [connection-handling.md](connection-handling.md)).
+
 Browser to API: `{"type": "open", "model_id": "sd-sim"}` first, then binary canvas frames carrying the session id, then `{"type": "close"}`.
 
 API to browser: `{"type": "ready", "session_id": "..."}`, generated frames as binary, and during recovery `{"type": "interrupted"}` then `{"type": "resumed"}` (re-send the current canvas). Terminal failures arrive as `error` messages before the close. Issue #19 adds `queued` with a live position, `idle` and `resuming` for slot release, prompt updates, `credits_tick`, and an out of credits close (an `error` message then the close) when a session's chunked reservation cannot be extended.

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -25,6 +25,7 @@ QUOTA_SERVICE_URL    = ""                        # empty: unlimited default impl
 FLEET_TOKEN_KEY      = ...                       # verifies worker tokens; self-host uses a static shared secret
 EMAIL_BACKEND        = none | smtp | ses
 PUBLIC_URL           = https://app.potocolom.com
+ALLOWED_ORIGINS      = ""                      # extra browser origins for the WebSocket endpoints; PUBLIC_URL is always allowed
 JOB_STALL_SECONDS    = 600                      # requeue or fail running jobs with no progress
 ```
 

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -147,6 +147,14 @@ stateDiagram-v2
     Holding --> [*]: close_session
 ```
 
+## Origin check
+
+Both endpoints refuse a handshake whose `Origin` header is present and not allowed, before the socket is accepted. The connection fails as HTTP 403, so no close code applies. A request with no `Origin` is accepted: worker processes and other non-browser clients send none, while browsers always send one and cannot forge it.
+
+Allowed origins are `PUBLIC_URL` plus anything in `ALLOWED_ORIGINS`. The dev loop needs the latter, because the vite server proxies `/api/v1` and the browser's origin is its own.
+
+This is a boundary control, not authentication. WebSocket handshakes ignore the same-origin policy and send no preflight, so without it any page the operator visits can reach both sockets and the trusted-LAN posture in [README.md](../README.md) does not hold. Worker authentication is separate and still deferred (`FLEET_TOKEN_KEY`).
+
 ## Close codes
 
 | Code | Meaning | Sent to |


### PR DESCRIPTION
Closes #201.

Both sockets are unauthenticated and the mitigation on record is deployment posture: treat the host as a trusted LAN. That assumes an attacker needs a network position on that LAN. Browsers do not apply the same-origin policy to WebSocket connections and send no preflight, so any page the operator visits while the stack is running could open `ws://localhost:8080/api/v1/fleet`, complete the `hello`, and register as a worker: advertising models and slots, receiving dispatched prompts and presigned source URLs, sending privileged control messages. No LAN access needed, only a tab.

`Origin` is now checked before `accept()` on both endpoints. Absent `Origin` is accepted, because worker processes and other non-browser clients send none, while browsers always send it and cannot forge it. Closing before accept fails the handshake with HTTP 403, so no close code is added and the wire protocol is unchanged.

Allowed origins are `PUBLIC_URL` plus the new `ALLOWED_ORIGINS`. The second is not speculative: the dev loop proxies `/api/v1` through the vite server, so the browser origin differs from `PUBLIC_URL` and the realtime client in M3 would break without it.

This is a boundary control, not authentication. It does not replace `FLEET_TOKEN_KEY` (#206); it restores the trusted-LAN property the docs already claim, at a fraction of the cost.

## Verification

Three tests, and I checked they are not vacuous: with the guard short-circuited to `return True`, all three fail. Two cover `origin_allowed` directly (absent, matching, trailing slash, foreign, configured extras) and one drives the socket, asserting a foreign origin cannot register a worker.

An earlier version of the socket test passed with the guard disabled, because exiting the context manager raises `WebSocketDisconnect` on its own. That is why the unit-level tests exist rather than socket tests alone.

`make verify` is green on the backend at 112 and on the frontend; `make verify-mermaid` passes at 35 diagrams. `verify-worker` fails on #216, which is fixed in #218 and unrelated.

## Docs

`docs/connection-handling.md` gets an Origin-check section next to the close codes, since the rejection deliberately has no close code. `docs/api.md` notes it on the endpoint, and `docs/blueprint.md` gains `ALLOWED_ORIGINS` in the config surface.