### PR TITLE
Reject non-finite worker floats and unresolvable schema references

### DIFF
--- a/backend/app/gpu_samples.py
+++ b/backend/app/gpu_samples.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from datetime import datetime, time, timedelta, timezone
 from typing import Any, Literal
 
@@ -58,7 +59,11 @@ def _float_or_none(value: Any) -> float | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
-        return float(value)
+        number = float(value)
+        # NaN and infinities survive json.loads and persist in PostgreSQL, but
+        # Starlette refuses to serialize them: one poisoned sample would 500
+        # every history range that contains it, rollups included (issue #203).
+        return number if math.isfinite(number) else None
     return None
 
 

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -12,6 +12,7 @@ import asyncio
 import heapq
 import json
 import logging
+import math
 import re
 import time
 import unicodedata
@@ -558,9 +559,17 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     if current is None or current.worker is not worker:
         return  # stale report from a previous incarnation or attempt
     if control["type"] == "job_progress":
-        live_progress[job_id] = float(control.get("progress") or 0.0)
+        progress = float(control.get("progress") or 0.0)
+        if not math.isfinite(progress):
+            # Stored, it breaks every generation list and detail response that
+            # carries it; published, it emits the non-standard NaN token into
+            # the SSE stream (issue #203). Progress is display only, so drop it.
+            logger.warning("worker %s sent non-finite progress for job %s; ignored",
+                           worker.id, job_id)
+            return
+        live_progress[job_id] = progress
         last_progress_at[job_id] = time.monotonic()
-        publish(job_id, {"state": "running", "progress": control.get("progress")})
+        publish(job_id, {"state": "running", "progress": progress})
         return
     entry = inflight.pop(job_id, None)
     live_progress.pop(job_id, None)

--- a/backend/app/manifests.py
+++ b/backend/app/manifests.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 
 import jsonschema
 from jsonschema import Draft202012Validator
+from referencing.exceptions import Unresolvable
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 logger = logging.getLogger("potocolom.manifests")
@@ -67,6 +68,14 @@ def validate_params(manifest: Manifest, params: dict) -> str | None:
         validator.validate(params)
     except jsonschema.ValidationError as error:
         return error.message
+    except Unresolvable:
+        # A $ref naming something the schema does not define raises past
+        # ValidationError, so it would reach the request handler as a 500.
+        # A manifest is worker-supplied, not user-supplied, so treat it like
+        # the invalid-schema case above and blame the log, not the caller.
+        logger.warning("model %s has an unresolvable schema reference; "
+                       "accepting params unchecked", manifest.id)
+        return None
     return None
 
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -11,7 +11,7 @@ import pytest
 from sqlalchemy import delete, func, select
 from fastapi.testclient import TestClient
 
-from app import db
+from app import db, jobs, realtime
 from app.jobs import generation_download_name
 from app.main import app
 from app.realtime import PROTOCOL_VERSION
@@ -971,3 +971,27 @@ def test_dispatch_depth_one_while_realtime_session_open(monkeypatch):
                 first = _wait_for_dispatch(worker, {first_id})
                 assert client.get(f"/api/v1/generations/{second_id}").json()["state"] == "queued"
                 _finish_job(client, worker, first)
+
+
+
+def test_non_finite_progress_is_ignored():
+    # A stored NaN breaks every generation response that carries it, and
+    # publish() would emit the non-standard NaN token into SSE (issue #203).
+    worker = realtime.Worker(id="w-nan", ws=None, manifests=[], realtime_slots=1)
+    job_id = uuid.uuid4()
+    jobs.inflight[job_id] = jobs.InFlight(
+        worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
+    )
+    try:
+        asyncio.run(jobs.on_worker_message(worker, {
+            "type": "job_progress", "job_id": str(job_id), "progress": float("nan"),
+        }))
+        assert job_id not in jobs.live_progress
+        asyncio.run(jobs.on_worker_message(worker, {
+            "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
+        }))
+        assert jobs.live_progress[job_id] == 0.5
+    finally:
+        jobs.inflight.pop(job_id, None)
+        jobs.live_progress.pop(job_id, None)
+        jobs.last_progress_at.pop(job_id, None)

--- a/backend/tests/test_manifests.py
+++ b/backend/tests/test_manifests.py
@@ -72,3 +72,14 @@ def test_parse_manifests_rejects_upscale_mixed_with_diffusion():
         assert "upscale cannot combine" in str(error)
     else:
         raise AssertionError("expected ValueError")
+
+
+def test_unresolvable_schema_reference_does_not_escape():
+    # jsonschema raises Unresolvable past ValidationError, so an unhandled one
+    # would reach the request handler as a 500 (issue #203).
+    manifest = Manifest(
+        id="broken", name="broken", capabilities=["text_to_image"],
+        parameters={"type": "object",
+                    "properties": {"prompt": {"$ref": "https://example.com/a.json"}}},
+    )
+    assert validate_params(manifest, {"prompt": "x"}) is None

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -433,3 +433,15 @@ def test_job_dispatch_and_finish_timestamps():
                     break
                 time.sleep(0.05)
             assert job.finished_at is not None
+
+
+def test_non_finite_telemetry_is_dropped():
+    # NaN and infinities round-trip through json.loads and PostgreSQL, but
+    # Starlette refuses to serialize them: one sample would 500 every history
+    # range that contains it (issue #203).
+    from app.gpu_samples import _float_or_none
+
+    assert _float_or_none(42) == 42.0
+    assert _float_or_none(float("nan")) is None
+    assert _float_or_none(float("inf")) is None
+    assert _float_or_none(float("-inf")) is None


### PR DESCRIPTION
Closes #203.

## The half that was wrong

The issue as filed claimed the `$ref` path was an SSRF, because the codex scan asserted that the default `jsonschema` registry retrieves unknown URIs with `urllib.request.urlopen`. That was the legacy `RefResolver`. Resolution has been `referencing`-based since 4.18 and `pyproject.toml` pins `jsonschema>=4.21,<5`, so no accepted version can fetch. Tested across four ref shapes against the installed 4.26.0; none attempts a fetch. The issue body and title are corrected, with the evidence in a comment there.

## The defect that is actually there

`_WrappedReferencingError` inherits from `referencing.exceptions.Unresolvable`, not `ValidationError`, so `validate_params` never caught it and it escaped to the request handler as a 500. A manifest is worker-supplied rather than caller-supplied, so it now takes the same path as an invalid schema: log the broken manifest, accept the params unchecked. That deliberately does not re-litigate the documented soft-fail, which is a separate decision.

## Non-finite floats, confirmed as filed

`json.loads` accepts `NaN` and `Infinity`, `_float_or_none` never checked `isfinite`, and PostgreSQL stores both. Starlette then refuses to serialize them:

```
ValueError: Out of range float values are not JSON compliant
```

One poisoned telemetry sample made every GPU history range containing it answer 500, with the five-minute rollups carrying it forward. The same value on `job_progress` broke generation list and detail responses and put the non-standard `NaN` token into the SSE stream. Both ingest points now drop non-finite values; progress is display only and the job row is the truth.

## Verification

Three tests, each checked against a neutered version of its own fix. Disabling all three (`if False:`, dropping the `isfinite` guard, catching the wrong exception type) fails exactly 3.

`make verify` is green on the backend at 112 and on the frontend. `verify-worker` fails on #216, fixed in #218, unrelated.