### PR TITLE
Pin actions/checkout to a commit SHA

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -47,7 +47,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: python3.11 -m venv .venv
       - run: .venv/bin/pip install -e ".[dev]"
       # The Makefile target is the single definition of what the job checks.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
     # Self-hosted: docs/self-hosted-runner.md (needs a working docker daemon).
     runs-on: [self-hosted, Linux, X64, potocolom]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: make verify-compose
       # Builds the api and worker-sim images and drives a real generation
       # through them; the script cleans up its containers and volumes.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
     # Self-hosted: docs/self-hosted-runner.md
     runs-on: [self-hosted, Linux, X64, potocolom]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       # The Makefile target is the single definition of what the job checks.
       # Bounded because it drives headless Chrome, and a hung browser would
       # hold the single self-hosted runner against every other job. The real

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: npm ci
       # The Makefile target is the single definition of what the job checks.
       - run: make verify-frontend

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -26,7 +26,7 @@ jobs:
     # Self-hosted: docs/self-hosted-runner.md
     runs-on: [self-hosted, Linux, X64, potocolom]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: python3.11 -m venv .ci-venv
       - run: .ci-venv/bin/pip install -e ./backend -e ./worker
       - run: .ci-venv/bin/python scripts/simulate.py

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -28,7 +28,7 @@ jobs:
     # Self-hosted: docs/self-hosted-runner.md
     runs-on: [self-hosted, Linux, X64, potocolom]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       # Fails if a too-old toolchain would be accepted instead of refused.
       - run: make verify-guards
       # The documented onboarding path, run as a contributor would run it.

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         working-directory: worker
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: python3.11 -m venv .venv
       - run: .venv/bin/pip install -e ".[dev]"
       # The Makefile target is the single definition of what the job checks.


### PR DESCRIPTION
Closes #205.

`actions/checkout` runs before any project code on the persistent self-hosted runner, and the deploy job's runner has a working Docker daemon. A retargeted tag or a compromised upstream executes with runner privileges before a single project check has run.

`docs/self-hosted-runner.md:125-129` accepts the runner risk for a solo org and recommends the outside-collaborator approval setting. That reasoning covers contributor code. It does not cover upstream action code, which PR approval does not gate at all.

Pinned to `3d3c42e5aac5ba805825da76410c181273ba90b1`, which is what `v7` resolves to today and is also tagged `v7.0.1` (committed 2026-07-17). The version stays as a trailing comment so the intended release remains readable.

Two notes against the issue as filed:

- It says six workflows; there are seven. `docs.yml` was added after the issue was written.
- `actions/checkout` is the *only* action referenced anywhere in the repository, so this pins the entire third-party action surface rather than just the main one.

Container base images in `deploy/docker/` and `deploy/compose/` remain on mutable tags, deliberately and as scoped in the issue: they do not execute ahead of project checks the way `checkout` does, and pinning digests costs more maintenance than it buys before production builds are cut. Model artifact pinning is tracked separately.

## Verification

All seven workflow files parse as YAML, and `make verify` is green end to end (backend 115, worker 86, frontend build and CSP check). The real check is CI on this PR: every workflow triggers here, because each one includes its own file in its path filter, so a bad SHA fails immediately and visibly.