### PR TITLE
Hold the GPU lock until the inference thread actually finishes

### DIFF
--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -1135,3 +1135,43 @@ def test_generation_oom_demotes_once_and_retries_once():
     engine._pipeline.assert_called_once_with(
         manifest, "t2i", allow_demotion=False,
     )
+
+
+def test_gpu_lock_is_held_until_the_thread_finishes():
+    """Cancelling mid-inference must not free the GPU for the next entrant.
+
+    asyncio cancellation cannot stop a thread, so awaiting to_thread directly
+    would unwind the `async with self._gpu` and release the lock while the
+    thread is still on the device (issue #202).
+    """
+    import threading
+    import time
+
+    running, finished = threading.Event(), threading.Event()
+
+    def native_work():
+        running.set()
+        time.sleep(0.3)
+        finished.set()
+
+    async def scenario():
+        gpu = asyncio.Lock()
+        engine = SimpleNamespace(_run_to_completion=DiffusersEngine._run_to_completion)
+
+        async def held():
+            async with gpu:
+                await engine._run_to_completion(engine, native_work)
+
+        task = asyncio.create_task(held())
+        await asyncio.get_running_loop().run_in_executor(None, running.wait)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        # The lock may be free by now, but only because the thread is done.
+        return gpu.locked(), finished.is_set()
+
+    locked, thread_finished = asyncio.run(scenario())
+    assert thread_finished, "lock was released while the thread was still running"
+    assert not locked

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -572,11 +572,29 @@ class DiffusersEngine:
         pipeline.set_progress_bar_config(disable=True)
         return pipeline
 
+    async def _run_to_completion(self, fn: Any, *args: Any, **kwargs: Any) -> Any:
+        """`to_thread` that cannot be abandoned while its thread still runs.
+
+        Cancellation cannot stop a thread. Awaiting `to_thread` directly means a
+        cancelled await unwinds the enclosing `async with self._gpu` and frees
+        the lock while the thread is still on the device, so the next entrant
+        runs concurrently on a GPU the rest of the system treats as serialized
+        (issue #202). Shielding alone does not help: the outer await still
+        raises and still unwinds, so the thread has to be awaited before the
+        cancellation propagates.
+        """
+        task = asyncio.ensure_future(asyncio.to_thread(fn, *args, **kwargs))
+        try:
+            return await asyncio.shield(task)
+        except asyncio.CancelledError:
+            await asyncio.wait([task])
+            raise
+
     async def calibrate_realtime(self, manifest: Manifest, configured: int) -> int:
         async with self._gpu:
             try:
-                return await asyncio.to_thread(self._calibrate_realtime,
-                                               manifest, configured)
+                return await self._run_to_completion(self._calibrate_realtime,
+                                                     manifest, configured)
             except Exception:
                 # Could not measure; advertise nothing rather than a guess,
                 # and never let a boot-time inference error kill the worker.
@@ -717,7 +735,7 @@ class DiffusersEngine:
 
     async def load_model(self, manifest: Manifest) -> int:
         async with self._gpu:
-            return await asyncio.to_thread(self._load_model, manifest)
+            return await self._run_to_completion(self._load_model, manifest)
 
     def _load_model(self, manifest: Manifest) -> int:
         self._evict_all()
@@ -733,11 +751,11 @@ class DiffusersEngine:
 
     async def unload_model(self, model_id: str) -> None:
         async with self._gpu:
-            await asyncio.to_thread(self._evict_model, model_id)
+            await self._run_to_completion(self._evict_model, model_id)
 
     async def unload_all(self) -> None:
         async with self._gpu:
-            await asyncio.to_thread(self._evict_all)
+            await self._run_to_completion(self._evict_all)
 
     def _from_pretrained(self, cls: Any, manifest: Manifest) -> Any:
         source = manifest.source or manifest.id
@@ -963,8 +981,8 @@ class DiffusersEngine:
         loop = asyncio.get_running_loop()
         async with self._gpu:
             try:
-                return await asyncio.to_thread(runner, manifest, dict(params),
-                                               progress, loop, input_image)
+                return await self._run_to_completion(runner, manifest, dict(params),
+                                                     progress, loop, input_image)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
             except (ValueError, TypeError):
@@ -978,8 +996,8 @@ class DiffusersEngine:
             # mid-denoise; free the others and run once more.
             self._evict_except(manifest.id)
             try:
-                return await asyncio.to_thread(runner, manifest, dict(params),
-                                               progress, loop, input_image)
+                return await self._run_to_completion(runner, manifest, dict(params),
+                                                     progress, loop, input_image)
             except self.torch.OutOfMemoryError as error:
                 retry_error = error.with_traceback(None)
             if not self._demote_rung(manifest, phase="generation retry"):
@@ -988,11 +1006,11 @@ class DiffusersEngine:
                 mode = f"upscale-{int(params.get('factor', 0))}"
             else:
                 mode = "i2i" if input_image is not None else "t2i"
-            await asyncio.to_thread(
+            await self._run_to_completion(
                 self._pipeline, manifest, mode, allow_demotion=False,
             )
-            return await asyncio.to_thread(runner, manifest, dict(params),
-                                           progress, loop, input_image)
+            return await self._run_to_completion(runner, manifest, dict(params),
+                                                 progress, loop, input_image)
 
     def _generate(self, manifest: Manifest, params: dict, progress: ProgressFn,
                   loop: asyncio.AbstractEventLoop,
@@ -1135,7 +1153,7 @@ class DiffusersEngine:
             # GPU text encoders for long prompts, and diffusion uses the GPU.
             frame_result: tuple[Image.Image, int] | None = None
             try:
-                frame_result = await asyncio.to_thread(
+                frame_result = await self._run_to_completion(
                     self._frame, manifest, frame_params, canvas, strength)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
@@ -1147,7 +1165,7 @@ class DiffusersEngine:
             if frame_result is None:
                 # The eviction mutates GPU residency, so it remains serialized.
                 self._evict_except(manifest.id)
-                frame_result = await asyncio.to_thread(
+                frame_result = await self._run_to_completion(
                     self._frame, manifest, frame_params, canvas, strength)
             image, gpu_ms = frame_result
         async with self._codec:


### PR DESCRIPTION
Closes #202.

## The bug

`self._gpu` was held only around an `await asyncio.to_thread(...)`. Cancelling that await unwinds the `async with` and frees the lock, but asyncio cannot stop a thread, so the next entrant reaches a GPU the first thread is still using.

Two ordinary events trigger it. A browser closing a realtime session: `SessionRunner.close` cancels the task without awaiting it. A fleet disconnect: `serve_connection` cancels every job task and gathers them. The API requeues disconnected work, so a reconnect can dispatch a second attempt onto that GPU.

`docs/internals/02-worker-inference.md:90` and `03-batching-realtime.md:72` assert one image at a time under a single GPU lock, and the measured slot count in `decisions.md:457` is calibrated against exactly that. The invariant did not hold under cancellation.

## The fix, and why the obvious one does not work

I offered two shapes on the issue: await completion in a `finally`, or shield the await. Testing them showed **shielding alone does not fix it** - the outer await still raises `CancelledError` and still unwinds the `async with`, so the lock is still freed early:

```
broken (today)   LEAKS  thread_finished=False lock_still_held=False
shield only      LEAKS  thread_finished=False lock_still_held=False
shield + wait    safe   thread_finished=True  lock_still_held=False
```

So there is really one correct shape. `_run_to_completion` shields the task and then awaits it before letting the cancellation propagate.

## Scope grew from 2 sites to 10

#207 moved Pillow work onto its own `self._codec` lock but left this pattern everywhere it appears under the GPU lock: generation (initial, OOM retry, rung-demotion rebuild, final retry), realtime frames (initial and retry), calibration, `load_model`, `unload_model`, `unload_all`.

The eviction sites matter as much as the inference ones. Releasing the lock partway through an eviction lets a new entrant reach weights that are being freed.

The two `self._codec` calls are deliberately left alone: same shape, but the ceiling is bounded Pillow work rather than device state.

## Verification

One test, checked against a neutered version of its own fix: replacing the helper body with a plain `to_thread` makes it fail. It asserts the thread has finished by the time the lock is free, which is the property that was violated.

`make verify` green: backend 115, worker 87, frontend build and CSP check.