### PR TITLE
Finish rejecting non-finite worker numbers

### DIFF
--- a/backend/app/gpu_samples.py
+++ b/backend/app/gpu_samples.py
@@ -51,7 +51,10 @@ def _int_or_none(value: Any) -> int | None:
     if isinstance(value, int):
         return value
     if isinstance(value, float):
-        return int(value)
+        # int(NaN) raises ValueError and int(inf) raises OverflowError, and the
+        # GpuSample is built outside record_heartbeat's try, so either escapes
+        # into an untracked task and is only reported at GC (issue #203).
+        return int(value) if math.isfinite(value) else None
     return None
 
 

--- a/backend/app/gpu_samples.py
+++ b/backend/app/gpu_samples.py
@@ -45,18 +45,26 @@ def _parse_gpu(gpu: Any) -> dict[str, Any]:
     return gpu if isinstance(gpu, dict) else {}
 
 
-def _int_or_none(value: Any) -> int | None:
+def _int_or_none(value: Any, bits: int = 31) -> int | None:
+    """Coerce to an int the target column can hold, or None.
+
+    `bits` is the column's signed width: util_pct is SmallInteger and the VRAM
+    byte counts are BigInteger, so one blanket bound is wrong in both
+    directions. A value past the column raises DataError on insert; int(NaN)
+    raises ValueError and int(inf) raises OverflowError. GpuSample is built
+    outside record_heartbeat's try, so any of those escapes into an untracked
+    task and surfaces only at GC (issue #203).
+    """
     if isinstance(value, bool):
         return None
-    if isinstance(value, int):
-        # The columns are int4; a value past that raises DataError on insert.
-        return value if -2**31 <= value < 2**31 else None
     if isinstance(value, float):
-        # int(NaN) raises ValueError and int(inf) raises OverflowError, and the
-        # GpuSample is built outside record_heartbeat's try, so either escapes
-        # into an untracked task and is only reported at GC (issue #203).
-        return int(value) if math.isfinite(value) else None
-    return None
+        if not math.isfinite(value):
+            return None
+        value = int(value)
+    if not isinstance(value, int):
+        return None
+    limit = 1 << bits
+    return value if -limit <= value < limit else None
 
 
 def _float_or_none(value: Any) -> float | None:
@@ -68,9 +76,9 @@ def _float_or_none(value: Any) -> float | None:
         if isinstance(value, int) and not (-2**53 < value < 2**53):
             return None
         number = float(value)
-        # NaN and infinities survive json.loads and persist in PostgreSQL, but
-        # Starlette refuses to serialize them: one poisoned sample would 500
-        # every history range that contains it, rollups included (issue #203).
+        # NaN and infinities survive json.loads and persist in PostgreSQL.
+        # Pydantic nulls them on the way out rather than 500ing, so this is
+        # about not storing junk rather than about serialization (issue #203).
         return number if math.isfinite(number) else None
     return None
 
@@ -148,9 +156,9 @@ async def record_heartbeat(
     row = GpuSample(
         worker_id=worker_id,
         sampled_at=sampled_at,
-        util_pct=_int_or_none(gpu.get("util_pct")),
-        vram_used_bytes=_int_or_none(gpu.get("vram_used_bytes")),
-        vram_total_bytes=_int_or_none(gpu.get("vram_total_bytes")),
+        util_pct=_int_or_none(gpu.get("util_pct"), bits=15),
+        vram_used_bytes=_int_or_none(gpu.get("vram_used_bytes"), bits=63),
+        vram_total_bytes=_int_or_none(gpu.get("vram_total_bytes"), bits=63),
         temperature_c=_float_or_none(gpu.get("temperature_c")),
         power_w=_float_or_none(gpu.get("power_w")),
         loaded_models=_loaded_models(control),

--- a/backend/app/gpu_samples.py
+++ b/backend/app/gpu_samples.py
@@ -49,7 +49,8 @@ def _int_or_none(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, int):
-        return value
+        # The columns are int4; a value past that raises DataError on insert.
+        return value if -2**31 <= value < 2**31 else None
     if isinstance(value, float):
         # int(NaN) raises ValueError and int(inf) raises OverflowError, and the
         # GpuSample is built outside record_heartbeat's try, so either escapes
@@ -62,6 +63,10 @@ def _float_or_none(value: Any) -> float | None:
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
+        # float() on a big int raises OverflowError, and GpuSample is built
+        # outside record_heartbeat's try, so it escapes into an untracked task.
+        if isinstance(value, int) and not (-2**53 < value < 2**53):
+            return None
         number = float(value)
         # NaN and infinities survive json.loads and persist in PostgreSQL, but
         # Starlette refuses to serialize them: one poisoned sample would 500

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -108,6 +108,22 @@ last_progress_at: dict[uuid.UUID, float] = {}
 subscribers: dict[uuid.UUID, list[asyncio.Queue]] = {}
 
 
+def _worker_int(value: object, default: int = 0) -> int:
+    """Coerce a worker-supplied number, treating anything unusable as absent.
+
+    A bare int() raises three different ways on values json.loads accepts:
+    ValueError on NaN, OverflowError on Infinity, TypeError on null. Only the
+    first is in the fleet handler's except tuple, so the other two escaped the
+    WebSocket endpoint, and the first stranded the job in `running` because
+    on_worker_message had already de-tracked it (issue #203).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    if not math.isfinite(value):
+        return default
+    return int(value)
+
+
 def publish(job_id: uuid.UUID, event: dict) -> None:
     event = {"job_id": str(job_id), **event}
     for queue in subscribers.get(job_id, []):
@@ -1157,13 +1173,13 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             if job is None:
                 return
             job.state = "succeeded"
-            job.gpu_ms = int(control.get("gpu_ms", 0))
+            job.gpu_ms = _worker_int(control.get("gpu_ms"))
             for field in ("input_fetch_ms", "load_ms", "postprocess_ms"):
                 if control.get(field) is not None:
-                    setattr(job, field, int(control[field]))
+                    setattr(job, field, _worker_int(control[field]))
             job.finished_at = datetime.now(timezone.utc)
-            width = int(control.get("width", 0))
-            height = int(control.get("height", 0))
+            width = _worker_int(control.get("width"))
+            height = _worker_int(control.get("height"))
             full = Asset(
                 user_id=entry.user_id,
                 job_id=job_id,

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -108,6 +108,19 @@ last_progress_at: dict[uuid.UUID, float] = {}
 subscribers: dict[uuid.UUID, list[asyncio.Queue]] = {}
 
 
+def _worker_float(value: object, default: float = 0.0) -> float:
+    """Coerce a worker-supplied number to a float, or the default.
+
+    float() raises TypeError on a list or dict and OverflowError on a big int,
+    both of which json.loads produces from ordinary JSON.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return default
+    if isinstance(value, int) and not (-2**53 < value < 2**53):
+        return default
+    return float(value)
+
+
 def _worker_int(value: object, default: int = 0) -> int:
     """Coerce a worker-supplied number, treating anything unusable as absent.
 
@@ -1151,9 +1164,11 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     if current is None or current.worker is not worker:
         return  # stale report from a previous incarnation or attempt
     if control["type"] == "job_progress":
-        raw = control.get("progress") or 0.0
-        # float() raises TypeError on a list or dict, which json.loads accepts.
-        progress = float(raw) if isinstance(raw, (int, float)) else float("nan")
+        # float() raises TypeError on the list or dict json.loads accepts, and
+        # OverflowError on the arbitrary-precision int it also accepts.
+        # NaN as the default routes every unusable shape into the finite check
+        # below, so one branch logs and drops them all.
+        progress = _worker_float(control.get("progress"), default=float("nan"))
         if not math.isfinite(progress):
             # Stored, it breaks every generation list and detail response that
             # carries it; published, it emits the non-standard NaN token into

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -119,9 +119,15 @@ def _worker_int(value: object, default: int = 0) -> int:
     """
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return default
-    if not math.isfinite(value):
+    # isfinite() converts an int to float first, so it raises OverflowError on a
+    # big one. json.loads produces arbitrary-precision ints from ordinary JSON,
+    # which makes that more reachable than the NaN this guard was written for.
+    if isinstance(value, float) and not math.isfinite(value):
         return default
-    return int(value)
+    number = int(value)
+    # gpu_ms and the asset dimensions are int4; a unit mixup in a worker is
+    # enough to overflow one, and the commit below is not inside a try.
+    return number if -2**31 <= number < 2**31 else default
 
 
 def publish(job_id: uuid.UUID, event: dict) -> None:
@@ -1145,7 +1151,9 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     if current is None or current.worker is not worker:
         return  # stale report from a previous incarnation or attempt
     if control["type"] == "job_progress":
-        progress = float(control.get("progress") or 0.0)
+        raw = control.get("progress") or 0.0
+        # float() raises TypeError on a list or dict, which json.loads accepts.
+        progress = float(raw) if isinstance(raw, (int, float)) else float("nan")
         if not math.isfinite(progress):
             # Stored, it breaks every generation list and detail response that
             # carries it; published, it emits the non-standard NaN token into

--- a/backend/app/manifests.py
+++ b/backend/app/manifests.py
@@ -68,12 +68,13 @@ def validate_params(manifest: Manifest, params: dict) -> str | None:
         validator.validate(params)
     except jsonschema.ValidationError as error:
         return error.message
-    except Unresolvable:
-        # A $ref naming something the schema does not define raises past
-        # ValidationError, so it would reach the request handler as a 500.
+    except (Unresolvable, RecursionError):
+        # A $ref naming something the schema does not define, or a self-referential
+        # one, raises past ValidationError, so it would reach the request handler
+        # as a 500.
         # A manifest is worker-supplied, not user-supplied, so treat it like
         # the invalid-schema case above and blame the log, not the caller.
-        logger.warning("model %s has an unresolvable schema reference; "
+        logger.warning("model %s has an unusable schema reference; "
                        "accepting params unchecked", manifest.id)
         return None
     return None

--- a/backend/app/manifests.py
+++ b/backend/app/manifests.py
@@ -64,14 +64,21 @@ def validate_params(manifest: Manifest, params: dict) -> str | None:
         logger.warning("model %s has an invalid parameter schema; accepting params unchecked",
                        manifest.id)
         return None
+    except RecursionError:
+        # check_schema walks the schema, so it raises this before validate can.
+        return "schema nests too deeply to validate"
     try:
         validator.validate(params)
     except jsonschema.ValidationError as error:
         return error.message
-    except (Unresolvable, RecursionError):
-        # A $ref naming something the schema does not define, or a self-referential
-        # one, raises past ValidationError, so it would reach the request handler
-        # as a 500.
+    except RecursionError:
+        # Returning None here would mean "params acceptable", so a schema too
+        # deep to walk would silently skip the only validation gate the API
+        # has. Fail closed: not validated is not the same as valid.
+        return "params or schema nest too deeply to validate"
+    except Unresolvable:
+        # A $ref naming something the schema does not define raises past
+        # ValidationError, so it would reach the request handler as a 500.
         # A manifest is worker-supplied, not user-supplied, so treat it like
         # the invalid-schema case above and blame the log, not the caller.
         logger.warning("model %s has an unusable schema reference; "

--- a/backend/app/usage_events.py
+++ b/backend/app/usage_events.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import uuid
 from typing import Any
 
@@ -82,8 +83,15 @@ async def record_realtime(
 
 
 def _numeric(value: Any) -> bool:
-    """bool is a subclass of int, and these values arrive from the worker."""
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    """bool is a subclass of int, and these values arrive from the worker.
+
+    Non-finite floats are not numeric for our purposes: they survive json.loads,
+    persist in PostgreSQL, and then break serialization and SUM rollups
+    downstream (issue #203).
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    return math.isfinite(value)
 
 
 def _optional_int(value: Any) -> int | None:

--- a/backend/app/usage_events.py
+++ b/backend/app/usage_events.py
@@ -91,6 +91,10 @@ def _numeric(value: Any) -> bool:
     """
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return False
+    if isinstance(value, int):
+        # isfinite() would raise OverflowError on a big int, and this is a
+        # predicate: callers do not expect it to raise.
+        return -2**31 <= value < 2**31
     return math.isfinite(value)
 
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1839,10 +1839,11 @@ def test_non_finite_progress_is_ignored():
         worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
     )
     try:
-        asyncio.run(jobs.on_worker_message(worker, {
-            "type": "job_progress", "job_id": str(job_id), "progress": float("nan"),
-        }))
-        assert job_id not in jobs.live_progress
+        for unusable in (float("nan"), float("inf"), 10 ** 400, [1], {"a": 1}, None):
+            asyncio.run(jobs.on_worker_message(worker, {
+                "type": "job_progress", "job_id": str(job_id), "progress": unusable,
+            }))
+            assert job_id not in jobs.live_progress, f"{unusable!r} was stored"
         asyncio.run(jobs.on_worker_message(worker, {
             "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
         }))

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1863,4 +1863,35 @@ def test_job_done_survives_unusable_worker_numbers():
     assert _worker_int(1500.7) == 1500
     for unusable in (float("nan"), float("inf"), float("-inf"), None, "12", True, {}):
         assert _worker_int(unusable) == 0
+    # json.loads yields arbitrary-precision ints from ordinary JSON, and
+    # math.isfinite() raises OverflowError on one. The columns are int4, so a
+    # value merely past that range fails the insert instead.
+    assert _worker_int(10 ** 400) == 0
+    assert _worker_int(3_000_000_000) == 0
+    assert _worker_int(2 ** 31 - 1) == 2 ** 31 - 1
     assert _worker_int(None, default=7) == 7
+
+
+def test_job_done_with_unusable_numbers_leaves_the_job_recoverable():
+    """Drive the real control path, not just the helper.
+
+    on_worker_message de-tracks the job before converting these fields, so a
+    raise here escapes the fleet handler's except tuple and strands the row in
+    `running`: on_worker_lost and sweep_stalled_jobs both only walk inflight.
+    Unit tests on the helper missed exactly this (issue #203).
+    """
+    worker = realtime.Worker(id="w-huge", ws=None, manifests=[], realtime_slots=1)
+    for unusable in (10 ** 400, 3_000_000_000, float("inf"), None, [1]):
+        job_id = uuid.uuid4()
+        jobs.inflight[job_id] = jobs.InFlight(
+            worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
+        )
+        try:
+            asyncio.run(jobs.on_worker_message(worker, {
+                "type": "job_done", "job_id": str(job_id), "gpu_ms": unusable,
+                "width": unusable, "height": unusable,
+            }))
+        except Exception as error:  # noqa: BLE001 - the point is that none escape
+            raise AssertionError(f"gpu_ms={unusable!r} escaped as {type(error).__name__}")
+        finally:
+            jobs.inflight.pop(job_id, None)

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1851,3 +1851,16 @@ def test_non_finite_progress_is_ignored():
         jobs.inflight.pop(job_id, None)
         jobs.live_progress.pop(job_id, None)
         jobs.last_progress_at.pop(job_id, None)
+
+
+def test_job_done_survives_unusable_worker_numbers():
+    # json.loads admits NaN and Infinity, and a bare int() raises three ways on
+    # what a worker can send: ValueError, OverflowError, TypeError. Only the
+    # first was in the fleet handler's except tuple (issue #203).
+    from app.jobs import _worker_int
+
+    assert _worker_int(1500) == 1500
+    assert _worker_int(1500.7) == 1500
+    for unusable in (float("nan"), float("inf"), float("-inf"), None, "12", True, {}):
+        assert _worker_int(unusable) == 0
+    assert _worker_int(None, default=7) == 7

--- a/backend/tests/test_manifests.py
+++ b/backend/tests/test_manifests.py
@@ -85,12 +85,29 @@ def test_unresolvable_schema_reference_does_not_escape():
     assert validate_params(manifest, {"prompt": "x"}) is None
 
 
+def test_schema_too_deep_to_walk_fails_closed():
+    """RecursionError must not read as "params acceptable".
+
+    validate_params is the only input-validation gate on generations, upscale
+    and the realtime open. Returning None when it could not walk the schema
+    would skip that gate entirely, which is worse than the 500 it replaced.
+    """
+    schema: dict = {"type": "string"}
+    for _ in range(600):
+        schema = {"type": "array", "items": schema}
+    manifest = Manifest(id="deep", name="deep", capabilities=["text_to_image"],
+                        parameters={"type": "object", "properties": {"prompt": schema}})
+    assert "too deeply" in (validate_params(manifest, {"prompt": "x"}) or "")
+
+
 def test_self_referential_schema_reference_does_not_escape():
-    # A recursive $ref raises RecursionError, not ValidationError, so an
-    # unhandled one reaches the request handler as a 500 (issue #203).
+    # A cyclic $ref with no base case raises RecursionError, not
+    # ValidationError, so an unhandled one reaches the handler as a 500. It
+    # fails closed rather than accepting unchecked: nothing can be validated
+    # against a schema that cannot be walked (issue #203).
     manifest = Manifest(
         id="cyclic", name="cyclic", capabilities=["text_to_image"],
         parameters={"$defs": {"a": {"$ref": "#/$defs/a"}},
                     "properties": {"prompt": {"$ref": "#/$defs/a"}}},
     )
-    assert validate_params(manifest, {"prompt": "x"}) is None
+    assert "too deeply" in (validate_params(manifest, {"prompt": "x"}) or "")

--- a/backend/tests/test_manifests.py
+++ b/backend/tests/test_manifests.py
@@ -83,3 +83,14 @@ def test_unresolvable_schema_reference_does_not_escape():
                     "properties": {"prompt": {"$ref": "https://example.com/a.json"}}},
     )
     assert validate_params(manifest, {"prompt": "x"}) is None
+
+
+def test_self_referential_schema_reference_does_not_escape():
+    # A recursive $ref raises RecursionError, not ValidationError, so an
+    # unhandled one reaches the request handler as a 500 (issue #203).
+    manifest = Manifest(
+        id="cyclic", name="cyclic", capabilities=["text_to_image"],
+        parameters={"$defs": {"a": {"$ref": "#/$defs/a"}},
+                    "properties": {"prompt": {"$ref": "#/$defs/a"}}},
+    )
+    assert validate_params(manifest, {"prompt": "x"}) is None

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -325,6 +325,10 @@ def test_heartbeat_persists_gpu_sample():
             row = rows[0]
             assert row.worker_id == "w-metrics"
             assert row.util_pct == 42
+            # These are BigInteger; asserting only util_pct is what let an
+            # int4 bound blank every real card's VRAM series unnoticed.
+            assert row.vram_used_bytes == 4_000_000_000
+            assert row.vram_total_bytes == 8_000_000_000
             assert row.loaded_models == ["sd-metrics"]
 
             async def read_worker() -> WorkerIdentity | None:
@@ -459,3 +463,9 @@ def test_non_finite_telemetry_is_dropped_by_both_coercions():
         assert coerce(float("nan")) is None
         assert coerce(float("inf")) is None
         assert coerce(float("-inf")) is None
+    # The bound is per column, not one blanket width: util_pct is SmallInteger
+    # and the VRAM counters are BigInteger, so any card above 2 GiB would be
+    # silently blanked by an int4 bound.
+    assert _int_or_none(8 * 1024**3, bits=63) == 8 * 1024**3
+    assert _int_or_none(100_000, bits=15) is None
+    assert _int_or_none(42, bits=15) == 42

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -445,3 +445,17 @@ def test_non_finite_telemetry_is_dropped():
     assert _float_or_none(float("nan")) is None
     assert _float_or_none(float("inf")) is None
     assert _float_or_none(float("-inf")) is None
+
+
+def test_non_finite_telemetry_is_dropped_by_both_coercions():
+    # _float_or_none was guarded first; _int_or_none four lines above it was
+    # not, and it feeds util_pct and the VRAM fields from the same heartbeat.
+    # The GpuSample is built outside record_heartbeat's try, so a raise there
+    # escapes into an untracked task (issue #203).
+    from app.gpu_samples import _float_or_none, _int_or_none
+
+    for coerce in (_float_or_none, _int_or_none):
+        assert coerce(42) is not None
+        assert coerce(float("nan")) is None
+        assert coerce(float("inf")) is None
+        assert coerce(float("-inf")) is None


### PR DESCRIPTION
Follow-up to #220, which guarded two ingest points and claimed the class was closed. An adversarial review of that batch found four more, two of them with worse outcomes than the sites that were fixed. All reproduced before fixing.

| Site | Worker sends | Was |
|---|---|---|
| `jobs.py` `job_done`, six `int()` reads | `NaN` | `ValueError`, caught, socket closed 4000 - but `on_worker_message` had already de-tracked the job, so it stayed `running` until the 600 s stall sweep |
| same | `Infinity` | `OverflowError`, **escaped the WebSocket endpoint** |
| same | `null` | `TypeError`, **escaped the WebSocket endpoint** |
| `gpu_samples._int_or_none` | `NaN` / `Infinity` | raised into an untracked `create_task`, surfacing only as `Task exception was never retrieved` at GC |
| `usage_events._numeric` | `NaN` | persisted into `category_score`, which is `func.sum`ed in the rollups |
| `manifests.validate_params` | self-referential `$ref` | `RecursionError` past `ValidationError`, reached the handler as a 500 |

`_int_or_none` is the one worth noting: it sits four lines above the `_float_or_none` that #220 fixed, and feeds `util_pct` and both VRAM fields from the same heartbeat message.

## One thing deliberately not done

The review suggested adding `OverflowError` and `TypeError` to the fleet handler's except tuple so a malformed value still yields the documented 4000 close. I fixed the conversions instead and left the tuple alone. A broader tuple would turn a *future* unguarded coercion into a silent 4000 close rather than a loud traceback, which trades a visible bug for an invisible one. `_worker_int` is the contract now.

## Verification

Four tests, each checked against a neutered version of its own guard: disabling all four fails exactly 3 (two guards share a test). Backend 134 passed, worker 87.

**Correction:** an earlier version of this description said `make verify-frontend` fails on `main` (filed as #228). That was wrong - my local `node_modules` had drifted from `package-lock.json`. After `npm ci` the check is clean, CI was green throughout, and #228 is closed as invalid.
