### PR TITLE
Close the second-cancellation hole in the GPU lock guard

### DIFF
--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -102,8 +102,9 @@ The wait is a full generation in the worst queued case, one frame for a realtime
 on a cold start a model download plus calibration, which can be minutes for multi-gigabyte
 weights. Under compose the stop grace period will SIGKILL before a cold-start download
 finishes. That is safe when nothing has been dispatched; a model load inside a
-dispatched job can be killed with work outstanding, and the API's stall sweep
-recovers it.
+dispatched job can be killed with work outstanding. The socket dies with the
+process, so `on_worker_lost` requeues it; the stall sweep covers the different
+case of a worker that stays connected and goes quiet.
 
 The alternative is worse: releasing the lock while the thread is still on the device lets the
 next entrant run concurrently on a GPU the scheduler treats as serialized, which is what the

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -91,6 +91,22 @@ Authenticate and authorize a browser realtime connection before queueing, reserv
 
 > Shipped status (2026-07-30): **not yet implemented.** The current endpoint accepts the WebSocket before `open`, binds only the implicit local user, and has no ticket, connection index, invalidation path, or unauthorized/forbidden close semantics. The governing decision is "Realtime authorization: bind once, invalidate explicitly"; issue #19, "Real-Time Generation Protocol", owns direct-socket behavior and "Gateway realtime tickets and revocation" owns the gateway path.
 
+## GPU work is not interruptible
+
+In-flight GPU work bounds how fast a worker can shut down or reconnect. The worker holds one
+GPU lock around work that runs in a thread, and cancelling an `await` cannot stop a thread, so
+the lock is only released once that thread finishes. A disconnect, a `close_session`, or a
+Ctrl-C therefore waits for the current operation rather than abandoning it.
+
+The wait is a full generation in the worst queued case, one frame for a realtime session, and
+on a cold start a model download plus calibration, which can be minutes for multi-gigabyte
+weights. Under compose the stop grace period will SIGKILL before a cold-start download
+finishes; that is safe, because nothing has been dispatched yet.
+
+The alternative is worse: releasing the lock while the thread is still on the device lets the
+next entrant run concurrently on a GPU the scheduler treats as serialized, which is what the
+slot calibration in [decisions.md](decisions.md) is measured against.
+
 ## Timeouts and intervals
 
 | What | Value | Why |

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -101,7 +101,9 @@ Ctrl-C therefore waits for the current operation rather than abandoning it.
 The wait is a full generation in the worst queued case, one frame for a realtime session, and
 on a cold start a model download plus calibration, which can be minutes for multi-gigabyte
 weights. Under compose the stop grace period will SIGKILL before a cold-start download
-finishes; that is safe, because nothing has been dispatched yet.
+finishes. That is safe when nothing has been dispatched; a model load inside a
+dispatched job can be killed with work outstanding, and the API's stall sweep
+recovers it.
 
 The alternative is worse: releasing the lock while the thread is still on the device lets the
 next entrant run concurrently on a GPU the scheduler treats as serialized, which is what the

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -1175,3 +1175,44 @@ def test_gpu_lock_is_held_until_the_thread_finishes():
     locked, thread_finished = asyncio.run(scenario())
     assert thread_finished, "lock was released while the thread was still running"
     assert not locked
+
+
+def test_gpu_lock_survives_a_second_cancellation():
+    """A cancel arriving while we wait for the thread must not free the lock.
+
+    asyncio.wait is itself an await point, so a second cancellation there would
+    skip the raise, unwind the `async with self._gpu`, and leak the lock exactly
+    as the original defect did. Shutdown gathers can deliver one.
+    """
+    import threading
+    import time
+
+    running, finished = threading.Event(), threading.Event()
+
+    def native_work():
+        running.set()
+        time.sleep(0.4)
+        finished.set()
+
+    async def scenario():
+        gpu = asyncio.Lock()
+        engine = SimpleNamespace(_run_to_completion=DiffusersEngine._run_to_completion)
+
+        async def held():
+            async with gpu:
+                await engine._run_to_completion(engine, native_work)
+
+        task = asyncio.create_task(held())
+        await asyncio.get_running_loop().run_in_executor(None, running.wait)
+        task.cancel()
+        await asyncio.sleep(0.05)
+        task.cancel()  # e.g. a second Ctrl-C during a shutdown gather
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return gpu.locked(), finished.is_set()
+
+    locked, thread_finished = asyncio.run(scenario())
+    assert thread_finished, "second cancellation released the lock mid-thread"
+    assert not locked

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -9,6 +9,7 @@ inference thread directly.
 """
 
 import asyncio
+import contextlib
 import io
 import math
 import os
@@ -18,7 +19,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar
 
 from PIL import Image
 
@@ -37,6 +38,7 @@ from worker.memory_ladder import (
 logger = logging.getLogger("potocolom.worker")
 
 ProgressFn = Callable[[float], None]
+T = TypeVar("T")
 
 REALTIME_SIZE = 512  # the realtime bar is 512 px (docs/decisions.md)
 # After a non-OOM generation error, drop the resident model at most this often
@@ -572,7 +574,7 @@ class DiffusersEngine:
         pipeline.set_progress_bar_config(disable=True)
         return pipeline
 
-    async def _run_to_completion(self, fn: Any, *args: Any, **kwargs: Any) -> Any:
+    async def _run_to_completion(self, fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
         """`to_thread` that cannot be abandoned while its thread still runs.
 
         Cancellation cannot stop a thread. Awaiting `to_thread` directly means a
@@ -587,7 +589,17 @@ class DiffusersEngine:
         try:
             return await asyncio.shield(task)
         except asyncio.CancelledError:
-            await asyncio.wait([task])
+            # asyncio.wait is itself an await point: a second cancellation
+            # arriving here would skip the raise, unwind the lock, and leak it
+            # exactly as before. Shutdown gathers can deliver one.
+            while not task.done():
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.wait([task])
+            if not task.cancelled():
+                # Retrieve it, or a thread that failed while we were cancelled
+                # is reported as a bare "Task exception was never retrieved"
+                # at GC, with no surrounding context.
+                task.exception()
             raise
 
     async def calibrate_realtime(self, manifest: Manifest, configured: int) -> int:

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -595,11 +595,12 @@ class DiffusersEngine:
             while not task.done():
                 with contextlib.suppress(asyncio.CancelledError):
                     await asyncio.wait([task])
-            if not task.cancelled():
-                # Retrieve it, or a thread that failed while we were cancelled
-                # is reported as a bare "Task exception was never retrieved"
-                # at GC, with no surrounding context.
-                task.exception()
+            if not task.cancelled() and (failure := task.exception()) is not None:
+                # Retrieving it without logging replaces a bare "Task exception
+                # was never retrieved" at GC with total silence. Report it here,
+                # where the model and phase are still known.
+                logger.warning("GPU work failed while cancelled: %s", failure,
+                               exc_info=failure)
             raise
 
     async def calibrate_realtime(self, manifest: Manifest, configured: int) -> int:


### PR DESCRIPTION
Follow-up to #222, which fixed the GPU lock leak and then left the same defect one level down. Found by an adversarial review; reproduced before fixing.

`asyncio.wait` is itself an await point:

```python
except asyncio.CancelledError:
    await asyncio.wait([task])   # a cancel arriving HERE skips the raise below
    raise
```

A second cancellation raises straight out of the `except` branch, so the `raise` never runs, the enclosing `async with self._gpu` unwinds, and the lock is released with the thread still on the device. That is the original defect verbatim.

```
lock_held=False  thread_finished=False
LEAKS
```

Reachable on shutdown: `serve_connection`'s `finally` cancels every job and runner task and then awaits a `gather`. If that gather is itself cancelled - SIGINT during shutdown, a second Ctrl-C, an outer timeout - every child gets its second cancel while parked in `asyncio.wait`.

Fixed by looping until the task is genuinely done, suppressing cancellation around each wait. Also retrieves the task exception, so a thread that failed while we were being cancelled is not reported as a bare `Task exception was never retrieved` at GC with no context.

## Typing regression

The helper was annotated `-> Any`, which erased the return type at all ten call sites - in the same file whose previous change (#218) existed to keep mypy clean. `frame_result: tuple[Image.Image, int] | None` was being assigned an `Any`. A `TypeVar` restores it; mypy is clean.

## Documented

Neither PR stated the consequence: in-flight GPU work is not interruptible, so it bounds worker shutdown and reconnect, and on a cold start that includes a multi-gigabyte model download. Now a section in `docs/connection-handling.md`, including why the alternative is worse.

## Verification

New test cancels twice 50 ms apart and asserts the thread finished before the lock was free; it fails against the shipped shape. Worker 88 passed, backend 131, mermaid 35. 

**Correction:** an earlier version of this description said `make verify-frontend` fails on `main` (filed as #228). That was wrong - my local `node_modules` had drifted from `package-lock.json`. After `npm ci` the check is clean, CI was green throughout, and #228 is closed as invalid.
