### PR TITLE
Wire ALLOWED_ORIGINS into the paths that need it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ WORKER ?= rocm
 
 api: ## API server on :8000; assets under ./data (make deps first)
 	cd backend && STORAGE_LOCAL_PATH=$(CURDIR)/data \
+		ALLOWED_ORIGINS=http://localhost:5173 \
 		BENCHMARK_API=1 TELEMETRY=false .venv/bin/uvicorn app.main:app --port 8000
 
 worker-rocm: ## inference worker on the AMD GPU (make setup-rocm once)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Read the list below before reporting. Several open surfaces here are recorded de
 
 Known and deliberate, so not vulnerabilities:
 
-- **The fleet WebSocket (`/api/v1/fleet`) is unauthenticated.** Documented in [README.md](README.md) and mitigated by deployment posture: treat the host as a trusted LAN. Tracked in #206.
+- **The fleet WebSocket (`/api/v1/fleet`) is unauthenticated.** Documented in [README.md](README.md) and mitigated by deployment posture: treat the host as a trusted LAN. Both WebSocket endpoints reject a browser `Origin` that is not allowlisted, so a page you merely visit cannot reach them; a process on that LAN still can, which is what worker authentication is for. Tracked in #206.
 - **`AUTH_MODE=none` is the shipped default** and resolves every request to one local user. Only that mode exists; `local` and `oauth` are seams, not implementations. Tracked in #5 and #9.
 - **There is no rate limiting.** Deferred by recorded decision, see [docs/decisions.md](docs/decisions.md).
 - **Pull requests execute contributor code on a self-hosted runner.** Accepted for a solo org and documented in [docs/self-hosted-runner.md](docs/self-hosted-runner.md).
@@ -26,7 +26,7 @@ Known and deliberate, so not vulnerabilities:
 In scope, and worth reporting:
 
 - Anything that crosses a boundary the documentation claims holds. If a document says a check is enforced and it is not, that is a finding regardless of how small it looks.
-- Anything reachable by a client that is not on the trusted LAN, including a web page the operator merely visits.
+- Anything reachable by a client that is not on the trusted LAN. A web page the operator merely visits counts: report any way one reaches an endpoint despite the `Origin` check.
 - Anything that lets one user reach another user's jobs, assets or sessions.
 - Anything that lets a worker corrupt or forge state the API treats as authoritative.
 - Anything in the shipped container images, compose stack or release artifacts.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "alembic>=1.13,<2",
     "boto3>=1.34,<2",
     "jsonschema>=4.21,<5",
+    "referencing>=0.35,<1",  # manifests.py catches Unresolvable directly
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -4,13 +4,20 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
+from starlette.datastructures import Headers
 from sqlalchemy import select
 from starlette.websockets import WebSocketDisconnect
 
 from app import db, realtime
 from app.main import app
 from app.manifests import Manifest
-from app.realtime import CANVAS_FRAME, origin_allowed, GENERATED_FRAME, MIN_SUPPORTED_VERSION, PROTOCOL_VERSION
+from app.realtime import (
+    CANVAS_FRAME,
+    GENERATED_FRAME,
+    MIN_SUPPORTED_VERSION,
+    PROTOCOL_VERSION,
+    origin_allowed,
+)
 from app.settings import get_settings
 from app.tables import UsageEvent
 
@@ -22,10 +29,15 @@ def manifest(model_id="sd-sim") -> dict:
 
 
 class FakeHeaders:
-    """Stands in for a WebSocket when only the Origin header matters."""
+    """Stands in for a WebSocket when only the Origin header matters.
+
+    Uses the real Headers type: case-insensitive lookup is its behaviour and a
+    plain dict would not prove origin_allowed relies on it correctly.
+    """
 
     def __init__(self, origin):
-        self.headers = {} if origin is None else {"origin": origin}
+        raw = [] if origin is None else [(b"origin", origin.encode())]
+        self.headers = Headers(raw=raw)
 
 
 class FakeSocket:
@@ -302,7 +314,6 @@ def test_reaper_closes_silent_workers():
     finally:
         realtime.workers.pop("w-stale", None)
         realtime.workers.pop("w-fresh", None)
-
 
 
 def test_origin_allowed_only_for_no_origin_and_configured_origins():

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -4,8 +4,8 @@ import uuid
 
 import pytest
 from fastapi.testclient import TestClient
-from starlette.datastructures import Headers
 from sqlalchemy import select
+from starlette.datastructures import Headers
 from starlette.websockets import WebSocketDisconnect
 
 from app import db, realtime
@@ -31,8 +31,9 @@ def manifest(model_id="sd-sim") -> dict:
 class FakeHeaders:
     """Stands in for a WebSocket when only the Origin header matters.
 
-    Uses the real Headers type: case-insensitive lookup is its behaviour and a
-    plain dict would not prove origin_allowed relies on it correctly.
+    Uses the real Headers type so the fixture matches what the endpoint passes.
+    Note this is less strict than a dict, not more: Headers.get is
+    case-insensitive, so it would tolerate a lookup a dict would catch.
     """
 
     def __init__(self, origin):

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -3,3 +3,11 @@ POSTGRES_PASSWORD=change-me
 # Accept the model license on huggingface.co first, then paste the token here.
 HF_TOKEN=
 TELEMETRY=true
+
+# Where browsers reach this install. Change it if you serve the studio on a LAN
+# address: it is the allowlist for the WebSocket endpoints and the base for
+# image URLs, so leaving it as localhost breaks both from another machine.
+PUBLIC_URL=http://localhost:8080
+# Extra browser origins allowed to open the WebSocket endpoints, comma separated.
+# Only needed when the studio is served from a different origin than the API.
+ALLOWED_ORIGINS=

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -18,7 +18,8 @@ services:
       AUTH_MODE: none
       DATABASE_URL: postgresql://potocolom:${POSTGRES_PASSWORD}@postgres/potocolom
       STORAGE_BACKEND: local
-      PUBLIC_URL: http://localhost:8080
+      PUBLIC_URL: ${PUBLIC_URL:-http://localhost:8080}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-}
       INTERNAL_URL: http://api:8080
       TELEMETRY: ${TELEMETRY:-true}
     volumes:

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ Every call a customer's browser makes, from first page load to account deletion.
 | GET `/api/v1/health` | implemented | process liveness for the load balancer |
 | GET `/api/v1/config` | implemented | runtime configuration for the SPA |
 | WS `/api/v1/realtime` | implemented (prototype) | realtime drawing sessions |
-| WS `/api/v1/fleet` | implemented (prototype) | worker fleet connection, not for browsers |
+| WS `/api/v1/fleet` | implemented (prototype) | worker fleet connection, not for browsers: a handshake carrying a non-allowlisted `Origin` is refused |
 | GET `/api/v1/models` | implemented (#11, #15) | registered models with parameter schemas and GPU-time estimates |
 | POST `/api/v1/generations` | implemented (#11, #16) | queue a generation job (text2img, img2img, or upscale) |
 | GET `/api/v1/generations/{id}` | implemented (#16) | job state, result asset when done |

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -11,7 +11,10 @@ const apiProxy = {
 };
 
 export default defineConfig({
-	server: { proxy: apiProxy },
+	// strictPort: the API allowlists this exact origin for the WebSocket
+	// endpoints (ALLOWED_ORIGINS in the Makefile), so a silent fallback to
+	// 5174 when 5173 is taken would produce an opaque 403 instead.
+	server: { port: 5173, strictPort: true, proxy: apiProxy },
 	preview: { proxy: apiProxy },
 	plugins: [
 		waitlistProxy(),

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -113,6 +113,7 @@ cmd_start() {
 	echo "Starting API on :$API_PORT..."
 	start_one api "$DEV_DIR/api.pid" \
 		"cd \"$REPO/backend\" && STORAGE_LOCAL_PATH=\"$REPO/data\" \
+		ALLOWED_ORIGINS=\"http://localhost:$WEB_PORT\" \
 		exec .venv/bin/uvicorn app.main:app --host 127.0.0.1 --port $API_PORT"
 
 	echo "Starting frontend on :$WEB_PORT..."


### PR DESCRIPTION
Cleanup from the adversarial review of the #201/#203 batch. Every item here is a loose end from work already merged.

**`ALLOWED_ORIGINS` was never wired into the dev loop it was added for.** `vite.config.ts` proxies with `changeOrigin: true`, which rewrites `Host`, not `Origin`, so the browser origin arriving at the API is `http://localhost:5173` while `public_url` defaults to `:8000`. This does not break today only because `frontend/src` contains zero WebSocket references. The moment #19's realtime client lands, `make api` + `make web` would have produced a bare 403 with no obvious cause. One env var on `make api`.

**compose hardcoded `PUBLIC_URL`.** An operator serving the studio at a LAN address, which is exactly the profile the README describes, gets a silent 403 on both sockets. That deployment was already half broken (`LocalStorage.url` bakes `PUBLIC_URL` into image URLs), but the Origin check turned it into a second, less legible symptom. Both variables are overridable now, with `.env.example` explaining why it matters.

**`referencing` is imported directly** by `manifests.py` for `Unresolvable` but was only a transitive dependency of `jsonschema`. Every other direct dependency here is deliberately bounded.

**Test hygiene**, same review: the import line #219 added was 111 characters against the configured `line-length = 100` (it passes only because ruff's `select` omits E501) and broke alphabetical order; `FakeHeaders` used a plain dict, so the unit tests never exercised the case-insensitive `starlette.datastructures.Headers` that `origin_allowed` actually reads.

**`SECURITY.md` and `api.md`** still described the fleet socket as mitigated by deployment posture alone. True before #201; incomplete after it. Neither mentioned the control that now makes the trusted-LAN claim hold.

## Verification

Backend 131, worker 87, ruff clean, mermaid 35. No line over 100 characters in the touched test files. 

**Correction:** an earlier version of this description said `make verify-frontend` fails on `main` (filed as #228). That was wrong - my local `node_modules` had drifted from `package-lock.json`. After `npm ci` the check is clean, CI was green throughout, and #228 is closed as invalid.
