### PR TITLE
Coerce the remaining worker and user numbers

### DIFF
--- a/backend/app/benchmark_sessions.py
+++ b/backend/app/benchmark_sessions.py
@@ -20,22 +20,27 @@ from app.tables import BenchmarkMeasurement, BenchmarkSession, User
 router = APIRouter()
 
 
+# Every int below lands in an int4 column, so a value past that is a 422 from
+# the model rather than a DataError from the insert.
+Int4 = Field(default=None, ge=-(2**31), lt=2**31)
+
+
 class MeasurementInput(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
-    prompt_id: int
+    prompt_id: int = Field(ge=-(2**31), lt=2**31)
     title: str
     category: str
     model_id: str
     variant: str
     cell_key: str
     params: dict = Field(default_factory=dict)
-    model_load_ms: int | None = None
+    model_load_ms: int | None = Int4
     state: Literal["succeeded", "failed"]
-    gpu_ms: int | None = None
+    gpu_ms: int | None = Int4
     wall_s: float | None = None
-    width: int | None = None
-    height: int | None = None
+    width: int | None = Int4
+    height: int | None = Int4
     job_id: str | None = None
     file: str | None = None
     error: str | None = None
@@ -44,12 +49,12 @@ class MeasurementInput(BaseModel):
 class BenchmarkInput(BaseModel):
     created_at: datetime
     target_vram_gb: float | None = None
-    prompt_count: int
+    prompt_count: int = Field(ge=0, lt=2**31)
     models: list[str]
-    variants_per_prompt: int
-    total_jobs: int
-    succeeded: int
-    failed: int
+    variants_per_prompt: int = Field(ge=0, lt=2**31)
+    total_jobs: int = Field(ge=0, lt=2**31)
+    succeeded: int = Field(ge=0, lt=2**31)
+    failed: int = Field(ge=0, lt=2**31)
     results: list[MeasurementInput]
 
 

--- a/backend/app/benchmark_sessions.py
+++ b/backend/app/benchmark_sessions.py
@@ -43,7 +43,9 @@ class MeasurementInput(BaseModel):
         # This dict goes to a JSONB column unvalidated otherwise, and jsonb
         # rejects the NaN and Infinity json.loads accepts.
         if not json_finite(value):
-            raise ValueError("params contain a value JSON storage cannot hold")
+            raise ValueError(
+                "params are too deeply nested or contain a value JSON storage cannot hold"
+            )
         return value
     model_load_ms: int | None = Int4
     state: Literal["succeeded", "failed"]

--- a/backend/app/benchmark_sessions.py
+++ b/backend/app/benchmark_sessions.py
@@ -8,13 +8,14 @@ from datetime import datetime
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db
 from app.auth import current_user, require_role
 from app.settings import get_settings
+from app.manifests import json_finite
 from app.tables import BenchmarkMeasurement, BenchmarkSession, User
 
 router = APIRouter()
@@ -35,6 +36,15 @@ class MeasurementInput(BaseModel):
     variant: str
     cell_key: str
     params: dict = Field(default_factory=dict)
+
+    @field_validator("params")
+    @classmethod
+    def _params_are_storable(cls, value: dict) -> dict:
+        # This dict goes to a JSONB column unvalidated otherwise, and jsonb
+        # rejects the NaN and Infinity json.loads accepts.
+        if not json_finite(value):
+            raise ValueError("params contain a value JSON storage cannot hold")
+        return value
     model_load_ms: int | None = Int4
     state: Literal["succeeded", "failed"]
     gpu_ms: int | None = Int4

--- a/backend/app/estimates.py
+++ b/backend/app/estimates.py
@@ -48,7 +48,7 @@ def _load_timings() -> dict[str, dict[str, Any]]:
             for key, value in factors_raw.items():
                 try:
                     factor, ms = int(key), int(value)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, OverflowError):
                     continue
                 if factor > 0 and ms > 0:
                     factors[factor] = ms
@@ -97,7 +97,7 @@ def _estimate_from_baseline(
             return max(1, factors[min(factors)])
         try:
             factor = int(params["factor"])
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             return None
         known = factors.get(factor)
         return max(1, known) if known is not None else None
@@ -109,7 +109,7 @@ def _estimate_from_baseline(
         steps = int(params["steps"])
         width = int(params["width"])
         height = int(params["height"])
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
 
     if steps <= 0 or width <= 0 or height <= 0:

--- a/backend/app/estimates.py
+++ b/backend/app/estimates.py
@@ -105,19 +105,20 @@ def _estimate_from_baseline(
     if not all(key in params for key in ("steps", "width", "height")):
         return None
 
+    # The arithmetic overflows before int() does: an arbitrary-precision int
+    # divides to a float that cannot hold it, and a merely huge one reaches
+    # round() as infinity. Both come straight from a worker manifest.
     try:
         steps = int(params["steps"])
         width = int(params["width"])
         height = int(params["height"])
+        if steps <= 0 or width <= 0 or height <= 0:
+            return None
+        step_scale = steps / baseline["steps"]
+        pixel_scale = (width * height) / (baseline["width"] * baseline["height"])
+        return max(1, round(baseline["gpu_ms"] * step_scale * pixel_scale))
     except (TypeError, ValueError, OverflowError):
         return None
-
-    if steps <= 0 or width <= 0 or height <= 0:
-        return None
-
-    step_scale = steps / baseline["steps"]
-    pixel_scale = (width * height) / (baseline["width"] * baseline["height"])
-    return max(1, round(baseline["gpu_ms"] * step_scale * pixel_scale))
 
 
 def _params_with_timing_defaults(

--- a/backend/app/gpu_samples.py
+++ b/backend/app/gpu_samples.py
@@ -38,7 +38,11 @@ def _utcnow() -> datetime:
 def _vram_used_pct(used: int | None, total: int | None) -> int | None:
     if used is None or total is None or total <= 0:
         return None
-    return round(used * 100 / total)
+    # The rollup columns are SmallInteger. A worker reporting used >> total
+    # would overflow one and fail maintain_once, which is a single
+    # transaction: rollups, pruning and worker cleanup would all stop until
+    # the sample aged out 48 hours later.
+    return min(round(used * 100 / total), 2**15 - 1)
 
 
 def _parse_gpu(gpu: Any) -> dict[str, Any]:

--- a/backend/app/gpu_samples.py
+++ b/backend/app/gpu_samples.py
@@ -38,11 +38,12 @@ def _utcnow() -> datetime:
 def _vram_used_pct(used: int | None, total: int | None) -> int | None:
     if used is None or total is None or total <= 0:
         return None
-    # The rollup columns are SmallInteger. A worker reporting used >> total
-    # would overflow one and fail maintain_once, which is a single
-    # transaction: rollups, pruning and worker cleanup would all stop until
-    # the sample aged out 48 hours later.
-    return min(round(used * 100 / total), 2**15 - 1)
+    # The rollup columns are SmallInteger, and maintain_once is one
+    # transaction: an overflow there stops rollups, pruning and worker cleanup
+    # until the sample ages out. Drop an impossible ratio rather than clamp it,
+    # matching _int_or_none and keeping the retained rollup means honest; a
+    # clamped 32767 would skew a 30-day bucket that a null is filtered out of.
+    return _int_or_none(round(used * 100 / total), bits=15)
 
 
 def _parse_gpu(gpu: Any) -> dict[str, Any]:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1157,7 +1157,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
 
 
 async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
-    job_id = uuid.UUID(control["job_id"])
+    job_id = realtime.peer_uuid(control["job_id"])
     # Only the worker recorded for the attempt may speak for the job: after a
     # stall requeue the old worker may still be connected and reporting.
     current = inflight.get(job_id)

--- a/backend/app/manifests.py
+++ b/backend/app/manifests.py
@@ -6,6 +6,7 @@ persists them and GET /api/v1/models exposes them to the frontend.
 
 import json
 import logging
+import math
 from functools import lru_cache
 
 import jsonschema
@@ -57,8 +58,26 @@ def _params_validator(schema_json: str) -> Draft202012Validator:
     return Draft202012Validator(schema)
 
 
+def json_finite(value: object) -> bool:
+    """jsonb has no NaN or Infinity, and json.loads produces both by default.
+
+    Anything reaching a JSONB column has to be checked at the edge: rejecting
+    them in the engine's serializer only turns the DataError into a ValueError,
+    and both are a 500.
+    """
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, dict):
+        return all(json_finite(item) for item in value.values())
+    if isinstance(value, list):
+        return all(json_finite(item) for item in value)
+    return True
+
+
 def validate_params(manifest: Manifest, params: dict) -> str | None:
     """Return a validation error message, or None when params are acceptable."""
+    if not json_finite(params):
+        return "params contain a value JSON storage cannot hold"
     try:
         # dumps walks the schema too, so it raises before check_schema can.
         schema_json = json.dumps(manifest.parameters, sort_keys=True)
@@ -100,4 +119,10 @@ def parse_manifests(raw: object) -> list[Manifest]:
         raise ValueError(f"invalid manifest: {error}") from error
     for manifest in manifests:
         validate_capability_exclusivity(manifest)
+        # parameters is persisted to a JSONB column, which has no NaN or
+        # Infinity; without this the upsert kills the socket on every reconnect.
+        if not json_finite(manifest.parameters):
+            raise ValueError(
+                f"manifest {manifest.id}: parameters contain a value JSON storage cannot hold"
+            )
     return manifests

--- a/backend/app/manifests.py
+++ b/backend/app/manifests.py
@@ -27,7 +27,9 @@ class Manifest(BaseModel):
     name: str
     capabilities: list[str]
     parameters: dict = Field(default_factory=dict)  # JSON Schema for the model's call parameters
-    min_vram_gb: int = 0
+    # int4 in the models table; a worker-supplied value past it fails the
+    # upsert, and that runs before the fleet handler's cleanup can see it.
+    min_vram_gb: int = Field(default=0, ge=0, lt=2**31)
     prompt_token_limit: int = 0  # text encoder window; 0 means the studio stays quiet
     default: bool = False  # preselected by clients when nothing is pinned
     license_id: str = ""
@@ -57,8 +59,9 @@ def _params_validator(schema_json: str) -> Draft202012Validator:
 
 def validate_params(manifest: Manifest, params: dict) -> str | None:
     """Return a validation error message, or None when params are acceptable."""
-    schema_json = json.dumps(manifest.parameters, sort_keys=True)
     try:
+        # dumps walks the schema too, so it raises before check_schema can.
+        schema_json = json.dumps(manifest.parameters, sort_keys=True)
         validator = _params_validator(schema_json)
     except jsonschema.SchemaError:
         logger.warning("model %s has an invalid parameter schema; accepting params unchecked",

--- a/backend/app/manifests.py
+++ b/backend/app/manifests.py
@@ -58,26 +58,36 @@ def _params_validator(schema_json: str) -> Draft202012Validator:
     return Draft202012Validator(schema)
 
 
-def json_finite(value: object) -> bool:
-    """jsonb has no NaN or Infinity, and json.loads produces both by default.
+# Deeper than any real parameter set or schema, and far below the depth at
+# which walking the structure would exhaust the stack. json.loads accepts ~993
+# levels and this predicate costs three frames per level, so without a cap it
+# would raise where json.loads succeeded: a guard failing inside the guard.
+JSON_MAX_DEPTH = 64
 
-    Anything reaching a JSONB column has to be checked at the edge: rejecting
-    them in the engine's serializer only turns the DataError into a ValueError,
-    and both are a 500.
+
+def json_finite(value: object, depth: int = 0) -> bool:
+    """Whether a decoded JSON value is storable in a JSONB column.
+
+    jsonb has no NaN or Infinity and json.loads produces both by default, so
+    this has to be checked at the edge: rejecting them in the engine's
+    serializer only turns the DataError into a ValueError, and both are a 500.
+    Over-deep structures are rejected here for the same reason.
     """
+    if depth > JSON_MAX_DEPTH:
+        return False
     if isinstance(value, float):
         return math.isfinite(value)
     if isinstance(value, dict):
-        return all(json_finite(item) for item in value.values())
+        return all(json_finite(item, depth + 1) for item in value.values())
     if isinstance(value, list):
-        return all(json_finite(item) for item in value)
+        return all(json_finite(item, depth + 1) for item in value)
     return True
 
 
 def validate_params(manifest: Manifest, params: dict) -> str | None:
     """Return a validation error message, or None when params are acceptable."""
     if not json_finite(params):
-        return "params contain a value JSON storage cannot hold"
+        return "params are too deeply nested or contain a value JSON storage cannot hold"
     try:
         # dumps walks the schema too, so it raises before check_schema can.
         schema_json = json.dumps(manifest.parameters, sort_keys=True)
@@ -123,6 +133,7 @@ def parse_manifests(raw: object) -> list[Manifest]:
         # Infinity; without this the upsert kills the socket on every reconnect.
         if not json_finite(manifest.parameters):
             raise ValueError(
-                f"manifest {manifest.id}: parameters contain a value JSON storage cannot hold"
+                f"manifest {manifest.id}: parameters are too deeply nested or contain "
+                "a value JSON storage cannot hold"
             )
     return manifests

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -14,12 +14,14 @@ router = APIRouter()
 
 def _parse_ts(value: str, name: str) -> datetime:
     text = value.strip()
-    if text.isdigit():
-        ms = int(text)
-        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
     try:
+        if text.isdigit():
+            # isdigit() is true for superscripts and other numeric characters
+            # int() rejects, and an epoch far enough out overflows the year or
+            # the float division; all three are a bad timestamp, not a 500.
+            return datetime.fromtimestamp(int(text) / 1000, tz=timezone.utc)
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError as error:
+    except (ValueError, OverflowError, OSError) as error:
         raise HTTPException(status_code=422, detail=f"invalid {name} timestamp") from error
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)

--- a/backend/app/metrics.py
+++ b/backend/app/metrics.py
@@ -21,11 +21,13 @@ def _parse_ts(value: str, name: str) -> datetime:
             # the float division; all three are a bad timestamp, not a 500.
             return datetime.fromtimestamp(int(text) / 1000, tz=timezone.utc)
         parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        # astimezone overflows at the edges of the representable range, e.g.
+        # 0001-01-01T00:00:00+14:00, so it belongs inside the try too.
+        return parsed.astimezone(timezone.utc)
     except (ValueError, OverflowError, OSError) as error:
         raise HTTPException(status_code=422, detail=f"invalid {name} timestamp") from error
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 @router.get("/api/v1/metrics/gpu/history")

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -95,10 +95,11 @@ async def refuse(ws: WebSocket, code: int, message: str) -> None:
 def parse_control(text: str) -> dict:
     try:
         control = json.loads(text)
-    except ValueError as error:
+    except (ValueError, RecursionError) as error:
         # JSONDecodeError subclasses ValueError, but CPython refuses an int
-        # conversion past 4300 digits with the bare parent, and three of the
-        # four callers only catch ProtocolError.
+        # conversion past 4300 digits with the bare parent, and the parser
+        # itself gives up past about 993 levels of nesting with a
+        # RecursionError. Three of the four callers only catch ProtocolError.
         raise ProtocolError("malformed JSON") from error
     if not isinstance(control, dict) or "type" not in control:
         raise ProtocolError("control message without a type")
@@ -321,9 +322,16 @@ async def fleet(ws: WebSocket) -> None:
         # registers, with nothing explaining why.
         logger.warning("fleet hello refused: %s", error)
         # Reason on the wire: the worker logs the close it receives, and
-        # without it an operator with a bad manifest sees only a
-        # reconnect loop with no cause on either side.
-        await ws.close(code=CLOSE_PROTOCOL_VIOLATION, reason=str(error)[:120])
+        # without it an operator with a bad manifest sees only a reconnect
+        # loop with no cause on either side. Truncate in BYTES, not code
+        # points: a close frame carries at most 125, of which 2 are the code,
+        # and manifest ids reach this message unfiltered. Over that, websockets
+        # raises its own ProtocolError, which is a different class from ours
+        # and so escapes this handler, aborting with 1006 and no reason at all.
+        # The ignore on encode also drops the lone surrogates json.loads
+        # accepts but UTF-8 cannot represent.
+        detail = str(error).encode("utf-8", "ignore")[:123].decode("utf-8", "ignore")
+        await ws.close(code=CLOSE_PROTOCOL_VIOLATION, reason=detail)
         return
     if version < MIN_SUPPORTED_VERSION:
         logger.warning("worker %s rejected: protocol version %s below %s",

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -95,7 +95,10 @@ async def refuse(ws: WebSocket, code: int, message: str) -> None:
 def parse_control(text: str) -> dict:
     try:
         control = json.loads(text)
-    except json.JSONDecodeError as error:
+    except ValueError as error:
+        # JSONDecodeError subclasses ValueError, but CPython refuses an int
+        # conversion past 4300 digits with the bare parent, and three of the
+        # four callers only catch ProtocolError.
         raise ProtocolError("malformed JSON") from error
     if not isinstance(control, dict) or "type" not in control:
         raise ProtocolError("control message without a type")
@@ -317,7 +320,10 @@ async def fleet(ws: WebSocket) -> None:
         # operator with a bad manifest sees a worker that starts and never
         # registers, with nothing explaining why.
         logger.warning("fleet hello refused: %s", error)
-        await ws.close(code=CLOSE_PROTOCOL_VIOLATION)
+        # Reason on the wire: the worker logs the close it receives, and
+        # without it an operator with a bad manifest sees only a
+        # reconnect loop with no cause on either side.
+        await ws.close(code=CLOSE_PROTOCOL_VIOLATION, reason=str(error)[:120])
         return
     if version < MIN_SUPPORTED_VERSION:
         logger.warning("worker %s rejected: protocol version %s below %s",

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -102,6 +102,18 @@ def parse_control(text: str) -> dict:
     return control
 
 
+def peer_uuid(value: object) -> uuid.UUID:
+    """Parse an id a peer sent.
+
+    uuid.UUID raises AttributeError on an int and TypeError on null, neither of
+    which belongs in the handler's except tuple: widening it would relabel an
+    internal bug as a protocol violation and close 4000 with no traceback.
+    """
+    if not isinstance(value, str):
+        raise ProtocolError("id must be a string")
+    return uuid.UUID(value)
+
+
 def frame_session_id(data: bytes) -> uuid.UUID:
     if len(data) < FRAME_HEADER_BYTES:
         raise ProtocolError("binary frame shorter than the header")
@@ -300,7 +312,11 @@ async def fleet(ws: WebSocket) -> None:
                 and (worker.device is None or isinstance(worker.device, str))
                 and (worker.memory_mode is None or isinstance(worker.memory_mode, str))):
             raise ProtocolError("hello fields have wrong types")
-    except (ProtocolError, KeyError):
+    except (ProtocolError, KeyError) as error:
+        # Logged: a rejected hello is otherwise silent on both sides, so an
+        # operator with a bad manifest sees a worker that starts and never
+        # registers, with nothing explaining why.
+        logger.warning("fleet hello refused: %s", error)
         await ws.close(code=CLOSE_PROTOCOL_VIOLATION)
         return
     if version < MIN_SUPPORTED_VERSION:
@@ -335,14 +351,14 @@ async def fleet(ws: WebSocket) -> None:
                     control = parse_control(message["text"])
                     worker.last_seen = time.monotonic()
                     if control["type"] == "session_ready":
-                        session = sessions.get(uuid.UUID(control["session_id"]))
+                        session = sessions.get(peer_uuid(control["session_id"]))
                         if session is not None:
                             session.ready.set()
                     elif control["type"] in ("job_progress", "job_done", "job_failed"):
                         from app import jobs  # late import; jobs reads this module's state
                         await jobs.on_worker_message(worker, control)
                     elif control["type"] == "session_closed":
-                        session_id = uuid.UUID(control["session_id"])
+                        session_id = peer_uuid(control["session_id"])
                         owner = closing_sessions.pop(session_id, None)
                         if owner is not None:
                             from app import usage_events
@@ -366,9 +382,7 @@ async def fleet(ws: WebSocket) -> None:
                     # Heartbeats refresh last_seen only; slot accounting has
                     # one writer (assign/release), so self-reported counts
                     # are deliberately not written back.
-            # uuid.UUID raises AttributeError on an int and TypeError on null,
-            # not just ValueError; all three are the peer sending nonsense.
-            except (ProtocolError, KeyError, ValueError, TypeError, AttributeError):
+            except (ProtocolError, KeyError, ValueError):
                 logger.warning("worker %s violated the protocol, closing", worker.id)
                 await ws.close(code=CLOSE_PROTOCOL_VIOLATION)
                 break

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -316,8 +316,11 @@ async def fleet(ws: WebSocket) -> None:
     await ws.send_json({"type": "registered"})
     from app import gpu_samples, registry  # late import; registry reads this module's state
     gpu_samples.schedule_worker_identity(worker.id, worker.device, worker.memory_mode)
-    await registry.persist_manifests(worker.manifests)
     try:
+        # Inside the try: this awaits a database write, and a failure before
+        # the try left the worker in `workers` with no cleanup path, so it kept
+        # being advertised until the 90 second reaper noticed.
+        await registry.persist_manifests(worker.manifests)
         while True:
             message = await ws.receive()
             if message["type"] == "websocket.disconnect":
@@ -363,7 +366,9 @@ async def fleet(ws: WebSocket) -> None:
                     # Heartbeats refresh last_seen only; slot accounting has
                     # one writer (assign/release), so self-reported counts
                     # are deliberately not written back.
-            except (ProtocolError, KeyError, ValueError):
+            # uuid.UUID raises AttributeError on an int and TypeError on null,
+            # not just ValueError; all three are the peer sending nonsense.
+            except (ProtocolError, KeyError, ValueError, TypeError, AttributeError):
                 logger.warning("worker %s violated the protocol, closing", worker.id)
                 await ws.close(code=CLOSE_PROTOCOL_VIOLATION)
                 break

--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -56,10 +56,15 @@ async def list_models() -> list[dict]:
         if "upscale" in manifest.capabilities:
             # Measured per-factor numbers for the studio's factor picker; the
             # default-params estimate cannot express factors with unequal cost.
-            factor_spec = manifest.parameters.get("properties", {}).get("factor", {})
+            # A manifest is worker-supplied, so neither properties nor the
+            # factor enum is guaranteed to be the shape it should be; a bare
+            # `for` over a non-list 500s this endpoint for every caller.
+            properties = manifest.parameters.get("properties")
+            factor_spec = properties.get("factor", {}) if isinstance(properties, dict) else {}
+            enum = factor_spec.get("enum") if isinstance(factor_spec, dict) else None
             by_factor = {
                 str(factor): estimate_gpu_ms(manifest.id, {"factor": factor})
-                for factor in factor_spec.get("enum", [])
+                for factor in (enum if isinstance(enum, list) else [])
             }
             payload["estimated_gpu_ms_by_factor"] = {
                 factor: ms for factor, ms in by_factor.items() if ms is not None

--- a/backend/app/usage_events.py
+++ b/backend/app/usage_events.py
@@ -95,7 +95,8 @@ def _numeric(value: Any) -> bool:
         # isfinite() would raise OverflowError on a big int, and this is a
         # predicate: callers do not expect it to raise.
         return -2**31 <= value < 2**31
-    return math.isfinite(value)
+    # The float branch feeds int4 columns too, so finite is not enough.
+    return math.isfinite(value) and -2**31 <= value < 2**31
 
 
 def _optional_int(value: Any) -> int | None:

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1896,3 +1896,27 @@ def test_job_done_with_unusable_numbers_leaves_the_job_recoverable():
             raise AssertionError(f"gpu_ms={unusable!r} escaped as {type(error).__name__}")
         finally:
             jobs.inflight.pop(job_id, None)
+
+
+def test_generation_params_must_be_json_storable():
+    # jobs.params is JSONB, which has no NaN or Infinity; the shipped schemas
+    # do not set additionalProperties: false, so an unconstrained property
+    # carried one straight to the insert (issue #232).
+    from app.manifests import json_finite
+
+    assert json_finite({"prompt": "x", "steps": 4})
+    assert not json_finite({"prompt": "x", "extra": float("inf")})
+    assert not json_finite({"nested": [{"deep": float("nan")}]})
+
+
+def test_peer_uuid_rejects_a_non_string_id():
+    # uuid.UUID raises AttributeError on an int and TypeError on null. Widening
+    # the fleet handler's except tuple to catch those would relabel an internal
+    # bug as a protocol violation, so the parse is guarded instead (issue #232).
+    assert realtime.peer_uuid(str(uuid.uuid4()))
+    for bad in (5, None, [1], {"a": 1}):
+        try:
+            realtime.peer_uuid(bad)
+        except realtime.ProtocolError:
+            continue
+        raise AssertionError(f"{bad!r} was accepted as an id")

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -469,3 +469,18 @@ def test_non_finite_telemetry_is_dropped_by_both_coercions():
     assert _int_or_none(8 * 1024**3, bits=63) == 8 * 1024**3
     assert _int_or_none(100_000, bits=15) is None
     assert _int_or_none(42, bits=15) == 42
+
+
+def test_gpu_history_rejects_unusable_timestamps():
+    # "²".isdigit() is True but int() rejects it; a far-future epoch overflows
+    # the year, and a 25-digit one overflows the float division. All three were
+    # 500s from an ordinary authenticated GET (issue #232).
+    with TestClient(app) as client:
+        good = "1700000000000"
+        for value in ("99999999999999999", "9" * 25, "\u00b2", "not-a-date"):
+            response = client.get("/api/v1/metrics/gpu/history",
+                                  params={"from": value, "to": good})
+            assert response.status_code == 422, f"{value!r} gave {response.status_code}"
+        ok = client.get("/api/v1/metrics/gpu/history",
+                        params={"from": good, "to": "1700000600000"})
+        assert ok.status_code == 200

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -478,13 +478,20 @@ def test_gpu_history_rejects_unusable_timestamps():
     # 500s from an ordinary authenticated GET (issue #232).
     with TestClient(app) as client:
         good = "1700000000000"
-        for value in ("99999999999999999", "9" * 25, "\u00b2", "not-a-date"):
+        # The last two are the ISO branch: astimezone overflows at the edges
+        # of the representable range, one line below the digit branch.
+        for value in ("99999999999999999", "9" * 25, "\u00b2", "not-a-date",
+                      "0001-01-01T00:00:00+14:00", "9999-12-31T23:59:59-14:00"):
             response = client.get("/api/v1/metrics/gpu/history",
                                   params={"from": value, "to": good})
             assert response.status_code == 422, f"{value!r} gave {response.status_code}"
         ok = client.get("/api/v1/metrics/gpu/history",
                         params={"from": good, "to": "1700000600000"})
         assert ok.status_code == 200
+        iso = client.get("/api/v1/metrics/gpu/history",
+                         params={"from": "2020-01-01T00:00:00Z",
+                                 "to": "2020-01-02T00:00:00Z"})
+        assert iso.status_code == 200
 
 
 def test_vram_percentage_cannot_overflow_the_rollup_column():

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -494,7 +494,11 @@ def test_vram_percentage_cannot_overflow_the_rollup_column():
     from app.gpu_samples import _vram_used_pct
 
     assert _vram_used_pct(4, 8) == 50
-    assert _vram_used_pct(2**62, 1) == 2**15 - 1
+    # An impossible ratio is dropped, not clamped, in both directions. A
+    # clamped 32767 would skew the rollup mean for the 30 days a bucket is
+    # retained, where a null is filtered out of it.
+    assert _vram_used_pct(2**62, 1) is None
+    assert _vram_used_pct(-(2**62), 1) is None
     assert _vram_used_pct(None, 8) is None
     assert _vram_used_pct(4, 0) is None
 

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -472,7 +472,8 @@ def test_non_finite_telemetry_is_dropped_by_both_coercions():
 
 
 def test_gpu_history_rejects_unusable_timestamps():
-    # "²".isdigit() is True but int() rejects it; a far-future epoch overflows
+    # A superscript two passes isdigit() but int() rejects it; a far-future
+    # epoch overflows
     # the year, and a 25-digit one overflows the float division. All three were
     # 500s from an ordinary authenticated GET (issue #232).
     with TestClient(app) as client:
@@ -484,3 +485,63 @@ def test_gpu_history_rejects_unusable_timestamps():
         ok = client.get("/api/v1/metrics/gpu/history",
                         params={"from": good, "to": "1700000600000"})
         assert ok.status_code == 200
+
+
+def test_vram_percentage_cannot_overflow_the_rollup_column():
+    # The rollup columns are SmallInteger, and maintain_once is one
+    # transaction: an overflow there stops rollups, pruning and worker cleanup
+    # until the sample ages out 48 hours later (issue #232).
+    from app.gpu_samples import _vram_used_pct
+
+    assert _vram_used_pct(4, 8) == 50
+    assert _vram_used_pct(2**62, 1) == 2**15 - 1
+    assert _vram_used_pct(None, 8) is None
+    assert _vram_used_pct(4, 0) is None
+
+
+def test_usage_event_floats_are_bounded_like_the_ints():
+    # _numeric bounded its int branch but not its float branch, so 1e30
+    # reached an int4 column and the whole usage event was dropped.
+    from app.usage_events import _optional_float, _optional_int
+
+    assert _optional_int(1500.0) == 1500
+    assert _optional_int(1e30) is None
+    assert _optional_float(1e30) is None
+    assert _optional_float(float("nan")) is None
+
+
+def test_benchmark_input_bounds_its_int4_columns():
+    # Tested at the model rather than the route because the route is gated
+    # behind BENCHMARK_API; the model is the validation boundary either way.
+    # Every int below lands in an int4 column (issue #232).
+    import pydantic
+
+    from app.benchmark_sessions import BenchmarkInput, MeasurementInput
+
+    base = {"created_at": "2026-01-01T00:00:00Z", "models": ["m"], "results": [],
+            "prompt_count": 1, "variants_per_prompt": 1, "total_jobs": 1,
+            "succeeded": 1, "failed": 0}
+    assert BenchmarkInput.model_validate(base).prompt_count == 1
+    for field in ("prompt_count", "variants_per_prompt", "total_jobs", "succeeded", "failed"):
+        try:
+            BenchmarkInput.model_validate({**base, field: 3_000_000_000})
+        except pydantic.ValidationError:
+            continue
+        raise AssertionError(f"{field} accepted a value past int4")
+
+    measurement = {"prompt_id": 1, "title": "t", "category": "c", "model_id": "m",
+                   "variant": "v", "cell_key": "k", "state": "succeeded"}
+    assert MeasurementInput.model_validate(measurement).prompt_id == 1
+    for field in ("prompt_id", "model_load_ms", "gpu_ms", "width", "height"):
+        try:
+            MeasurementInput.model_validate({**measurement, field: 3_000_000_000})
+        except pydantic.ValidationError:
+            continue
+        raise AssertionError(f"{field} accepted a value past int4")
+    # The params dict reaches JSONB unvalidated otherwise.
+    try:
+        MeasurementInput.model_validate({**measurement, "params": {"x": float("inf")}})
+    except pydantic.ValidationError:
+        pass
+    else:
+        raise AssertionError("a non-finite benchmark param was accepted")

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -343,3 +343,45 @@ def test_foreign_origin_cannot_register_a_worker():
             ws.send_json(hello(worker_id="w-evil"))
             ws.receive_json()
     assert "w-evil" not in realtime.workers
+
+
+def test_fleet_closes_4000_on_a_non_string_job_id():
+    """Drive the socket, not peer_uuid.
+
+    uuid.UUID raises AttributeError on an int and TypeError on null, neither of
+    which is in the fleet handler's except tuple, so before peer_uuid these
+    escaped the endpoint. Testing the helper alone leaves jobs.py unguarded by
+    the suite, which is the failure mode that let this class survive four
+    review rounds (issue #232).
+    """
+    for bad in (5, None, [1], {"a": 1}):
+        with client.websocket_connect("/api/v1/fleet") as ws:
+            ws.send_json(hello(worker_id=f"w-badid-{type(bad).__name__}"))
+            assert ws.receive_json()["type"] == "registered"
+            ws.send_json({"type": "job_done", "job_id": bad, "gpu_ms": 1})
+            with pytest.raises(WebSocketDisconnect) as closed:
+                ws.receive_json()
+            assert closed.value.code == realtime.CLOSE_PROTOCOL_VIOLATION, bad
+
+
+def test_fleet_survives_an_over_deep_manifest_and_an_oversized_number():
+    # json_finite costs three frames per level against json.loads' ~993, so an
+    # uncapped walk raised where the parser succeeded. A number past CPython's
+    # 4300-digit int limit raises a bare ValueError, not JSONDecodeError.
+    deep: object = 1
+    for _ in range(400):
+        deep = {"a": deep}
+    with client.websocket_connect("/api/v1/fleet") as ws:
+        ws.send_json({"type": "hello", "protocol_version": PROTOCOL_VERSION,
+                      "worker_id": "w-deep", "realtime_slots": 0,
+                      "models": [{"id": "m", "name": "m", "capabilities": ["text_to_image"],
+                                  "parameters": deep}]})
+        with pytest.raises(WebSocketDisconnect) as closed:
+            ws.receive_json()
+        assert closed.value.code == realtime.CLOSE_PROTOCOL_VIOLATION
+
+    with client.websocket_connect("/api/v1/fleet") as ws:
+        ws.send_text('{"type": "hello", "protocol_version": ' + "9" * 5000 + "}")
+        with pytest.raises(WebSocketDisconnect) as closed:
+            ws.receive_json()
+        assert closed.value.code == realtime.CLOSE_PROTOCOL_VIOLATION

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -385,3 +385,26 @@ def test_fleet_survives_an_over_deep_manifest_and_an_oversized_number():
         with pytest.raises(WebSocketDisconnect) as closed:
             ws.receive_json()
         assert closed.value.code == realtime.CLOSE_PROTOCOL_VIOLATION
+
+
+def test_hello_refusal_reason_fits_a_close_frame():
+    """A close frame carries 125 bytes total, 2 of them the code.
+
+    manifest.id reaches the refusal message unfiltered, so truncating the
+    reason by code points overflowed the frame for any multi-byte id.
+    websockets then raises its own ProtocolError, a different class from ours,
+    which escapes the handler and aborts with 1006 and no reason: strictly
+    worse than the bare close the reason was added to improve (issue #232).
+    """
+    for bad_id in ("m" * 200, "\u6f22" * 200, "\U0001f600" * 200, "m\ud800m"):
+        with client.websocket_connect("/api/v1/fleet") as ws:
+            ws.send_json({"type": "hello", "protocol_version": PROTOCOL_VERSION,
+                          "worker_id": "w-reason", "realtime_slots": 0,
+                          "models": [{"id": bad_id, "name": "n",
+                                      "capabilities": ["upscale", "text_to_image"],
+                                      "parameters": {}}]})
+            with pytest.raises(WebSocketDisconnect) as closed:
+                ws.receive_json()
+            assert closed.value.code == realtime.CLOSE_PROTOCOL_VIOLATION
+            encoded = (closed.value.reason or "").encode("utf-8")
+            assert len(encoded) <= 123, f"{bad_id[:8]}: {len(encoded)} bytes"

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -61,3 +61,63 @@ def test_models_endpoint_survives_a_malformed_upscale_manifest():
         assert TestClient(app).get("/api/v1/models").status_code == 200
     finally:
         realtime.workers.pop(worker.id, None)
+
+
+def test_models_endpoint_survives_manifest_numbers_that_overflow_the_estimate():
+    # The overflow is in the scaling arithmetic, not the int() calls: an
+    # arbitrary-precision int divides to a float that cannot hold it, and a
+    # merely huge one reaches round() as infinity (issue #232).
+    from app import realtime
+    from app.main import app
+    from fastapi.testclient import TestClient
+
+    for steps in (10 ** 400, 10 ** 308):
+        worker = realtime.Worker(
+            id="w-est", ws=None, realtime_slots=0,
+            manifests=[Manifest(id="sdxl-base", name="sdxl-base",
+                                capabilities=["text_to_image"],
+                                parameters={"properties": {
+                                    "steps": {"default": steps},
+                                    "width": {"default": 1024},
+                                    "height": {"default": 1024}}})],
+        )
+        realtime.workers[worker.id] = worker
+        try:
+            assert TestClient(app).get("/api/v1/models").status_code == 200, steps
+        finally:
+            realtime.workers.pop(worker.id, None)
+
+
+def test_manifest_parameters_must_be_json_storable():
+    # parameters is persisted to JSONB, which has no NaN or Infinity, while
+    # json.loads produces both. Without this the upsert killed the fleet
+    # socket on every reconnect (issue #232).
+    from app.manifests import parse_manifests
+
+    good = [{"id": "m", "name": "m", "capabilities": ["text_to_image"],
+             "parameters": {"properties": {"steps": {"default": 4}}}}]
+    assert parse_manifests(good)[0].id == "m"
+
+    bad = [{"id": "m", "name": "m", "capabilities": ["text_to_image"],
+            "parameters": {"properties": {"steps": {"default": float("inf")}}}}]
+    try:
+        parse_manifests(bad)
+    except ValueError as error:
+        assert "JSON storage" in str(error)
+    else:
+        raise AssertionError("a non-finite manifest parameter was accepted")
+
+
+def test_min_vram_gb_is_bounded_at_the_manifest():
+    # models.min_vram_gb is int4; an unbounded value failed the upsert, which
+    # ran before the fleet handler's cleanup could see the worker.
+    from app.manifests import parse_manifests
+
+    entry = {"id": "m", "name": "m", "capabilities": ["text_to_image"],
+             "min_vram_gb": 3_000_000_000}
+    try:
+        parse_manifests([entry])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("an out-of-range min_vram_gb was accepted")

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -39,3 +39,25 @@ def test_available_prefers_studio_visible_over_stale_benchmark_only():
     finally:
         realtime.workers.clear()
         realtime.workers.update(saved)
+
+
+def test_models_endpoint_survives_a_malformed_upscale_manifest():
+    # A manifest is worker-supplied, so neither `properties` nor the factor
+    # `enum` is guaranteed to be the shape it should be. A bare `for` over a
+    # non-list 500s this endpoint for every caller (issue #232).
+    from app import realtime
+    from app.main import app
+    from fastapi.testclient import TestClient
+
+    worker = realtime.Worker(
+        id="w-bad", ws=None, realtime_slots=0,
+        manifests=[Manifest(id="up-bad", name="up-bad", capabilities=["upscale"],
+                            parameters={"properties": {"factor": {"enum": 4}}}),
+                   Manifest(id="up-worse", name="up-worse", capabilities=["upscale"],
+                            parameters={"properties": "not-a-dict"})],
+    )
+    realtime.workers[worker.id] = worker
+    try:
+        assert TestClient(app).get("/api/v1/models").status_code == 200
+    finally:
+        realtime.workers.pop(worker.id, None)

--- a/worker/tests/test_manifests.py
+++ b/worker/tests/test_manifests.py
@@ -147,7 +147,6 @@ def test_unknown_manifest_field_is_loud(tmp_path):
         load_manifests(str(tmp_path))
 
 
-
 def test_min_vram_gb_is_bounded_where_the_operator_sees_it(tmp_path):
     # The API refuses a value past int4 at registration, which the operator
     # experiences as a worker that starts and reconnect-loops with no cause on
@@ -158,11 +157,11 @@ def test_min_vram_gb_is_bounded_where_the_operator_sees_it(tmp_path):
         "source": "x/y", "min_vram_gb": 3_000_000_000,
     }))
     with pytest.raises(ValidationError):
-        load_manifests(tmp_path)
+        load_manifests(str(tmp_path))
 
     (tmp_path / "bad.json").unlink()
     (tmp_path / "good.json").write_text(json.dumps({
         "id": "good", "name": "good", "capabilities": ["text_to_image"],
         "source": "x/y", "min_vram_gb": 12,
     }))
-    assert load_manifests(tmp_path)[0].min_vram_gb == 12
+    assert load_manifests(str(tmp_path))[0].min_vram_gb == 12

--- a/worker/tests/test_manifests.py
+++ b/worker/tests/test_manifests.py
@@ -145,3 +145,24 @@ def test_unknown_manifest_field_is_loud(tmp_path):
     (tmp_path / "bad.json").write_text(json.dumps({**SD_TURBO, "vram": 8}))
     with pytest.raises(ValidationError):
         load_manifests(str(tmp_path))
+
+
+
+def test_min_vram_gb_is_bounded_where_the_operator_sees_it(tmp_path):
+    # The API refuses a value past int4 at registration, which the operator
+    # experiences as a worker that starts and reconnect-loops with no cause on
+    # either side. Catching it at load keeps the failure next to the file that
+    # caused it (issue #232).
+    (tmp_path / "bad.json").write_text(json.dumps({
+        "id": "bad", "name": "bad", "capabilities": ["text_to_image"],
+        "source": "x/y", "min_vram_gb": 3_000_000_000,
+    }))
+    with pytest.raises(ValidationError):
+        load_manifests(tmp_path)
+
+    (tmp_path / "bad.json").unlink()
+    (tmp_path / "good.json").write_text(json.dumps({
+        "id": "good", "name": "good", "capabilities": ["text_to_image"],
+        "source": "x/y", "min_vram_gb": 12,
+    }))
+    assert load_manifests(tmp_path)[0].min_vram_gb == 12

--- a/worker/worker/manifests.py
+++ b/worker/worker/manifests.py
@@ -18,7 +18,9 @@ class Manifest(BaseModel):
     name: str
     capabilities: list[str]  # text_to_image, image_to_image, realtime, upscale
     parameters: dict = Field(default_factory=dict)  # JSON Schema for the model's call parameters
-    min_vram_gb: int = 0
+    # Matches the API's bound, so a bad value fails here where the operator
+    # can see it rather than silently at registration.
+    min_vram_gb: int = Field(default=0, ge=0, lt=2**31)
     # Native text encoder window in tokens. The worker chunks declared CLIP
     # prompts past this window, while the studio still warns that later chunks
     # influence the image weakly. Left at 0 rather than 77 on purpose: a


### PR DESCRIPTION
Closes #232, which I filed before merging #227 precisely so this claim could be made once and be true.

**Two were reachable over HTTP with no worker involved, both 500s:**

| Request | Was |
|---|---|
| `GET /api/v1/metrics/gpu/history?from=99999999999999999` | `ValueError: year 3170843 is out of range` |
| same, 25 digits | `OverflowError: integer division result too large for a float` |
| same, `from=²` | `ValueError` - `"²".isdigit()` is `True`, `int()` disagrees |
| `POST /api/v1/benchmark/sessions` with `prompt_count: 3000000000` | `DataError`, int4 column |

`_parse_ts` ran its digit branch outside the `try` that already turns a bad timestamp into a 422.

**Three needed a worker.** `estimates.py` caught `TypeError` and `ValueError` but not the `OverflowError` that `int(float("inf"))` raises; `registry.py` iterated the factor `enum` and indexed `properties` without checking either is the shape it should be. Both 500 `GET /api/v1/models` for every caller. `min_vram_gb` is now bounded on the manifest model, where the other constraints live.

Moving `persist_manifests` inside the fleet handler's `try` matters beyond the `DataError`: it ran after `workers[worker.id] = worker` but before the `try` that removes it, so any failure left the worker registered and advertised until the 90-second reaper noticed.

`uuid.UUID` raises `AttributeError` on an int and `TypeError` on null, not only `ValueError`, so two of the three escaped the fleet loop.

Also the `json.dumps` site the issue notes, now inside the try.

## Tests

Endpoint-level, deliberately. A real authenticated `GET` for the timestamps, and a registered worker carrying a malformed upscale manifest for the models route. Three rounds of this bug class survived review because the tests exercised the helper rather than the path, so these do not.

Verified by neutering: reverting either fix fails its own test. `make verify` green at backend 138, worker 88, frontend build and CSP.