### PR TITLE
Authenticate the fleet socket with a shared secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
 # AMD card: use --profile rocm instead of --profile gpu
 ```
 
-Open http://localhost:8080. Hardware requirements, NVIDIA and AMD GPU passthrough, first-run notes and what persists in which volume are covered in [docs/self-hosting.md](docs/self-hosting.md). The fleet WebSocket (`/api/v1/fleet`) is unauthenticated in this profile - treat the host as a trusted LAN until fleet auth is implemented. Validate the stack without a GPU: `scripts/compose-smoke.sh` (uses port 18080 by default; override with `COMPOSE_SMOKE_PORT`).
+Open http://localhost:8080. Hardware requirements, NVIDIA and AMD GPU passthrough, first-run notes and what persists in which volume are covered in [docs/self-hosting.md](docs/self-hosting.md). The fleet WebSocket (`/api/v1/fleet`) authenticates workers with the shared `FLEET_SECRET` from your compose environment; set it. Left empty it stays unauthenticated for compatibility with existing installs, and then the host must be a trusted LAN. Validate the stack without a GPU: `scripts/compose-smoke.sh` (uses port 18080 by default; override with `COMPOSE_SMOKE_PORT`).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ No account, no API key and no telemetry endpoint are required. [docs/self-hostin
 
 ```bash
 cp deploy/compose/.env.example deploy/compose/.env
-# edit POSTGRES_PASSWORD
+# edit POSTGRES_PASSWORD and FLEET_SECRET (openssl rand -hex 32)
 docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
 # AMD card: use --profile rocm instead of --profile gpu
 ```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,17 @@ from app.telemetry import router as telemetry_router
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
     setup_logging(settings.log_format)
+    if not settings.fleet_token_key:
+        logging.getLogger("potocolom.realtime").warning(
+            "FLEET_TOKEN_KEY is unset; fleet authentication is permissive"
+        )
+    elif not settings.fleet_token_key.isascii():
+        # HTTP headers are latin-1 on the wire, so a non-ASCII secret may not
+        # survive the trip intact. Say so here rather than let the operator
+        # debug a worker that reconnects forever against a correct secret.
+        logging.getLogger("potocolom.realtime").warning(
+            "FLEET_TOKEN_KEY contains non-ASCII characters; use an ASCII secret"
+        )
     if settings.telemetry:
         logging.getLogger("potocolom.telemetry").info(
             "anonymous daily telemetry destination=%s payload=aggregate usage counts and "

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -78,11 +78,18 @@ def fleet_token_allowed(ws: WebSocket) -> bool:
     key = get_settings().fleet_token_key
     if not key:
         return True
-    token = ws.headers.get(FLEET_TOKEN_HEADER)
-    if not isinstance(token, str):
+    # Scan raw: header names are case-insensitive per RFC 9110, but Headers.get
+    # matches the stored key verbatim, and the ASGI server passes the name
+    # through with whatever casing the client sent. Any worker spelling this
+    # X-Fleet-Token would otherwise be refused as if it sent nothing.
+    presented = next(
+        (value for name, value in ws.headers.raw
+         if name.lower() == FLEET_TOKEN_HEADER.encode()),
+        None,
+    )
+    if presented is None:
         return False
-    return hmac.compare_digest(token.encode("utf-8", "surrogateescape"),
-                               key.encode("utf-8", "surrogateescape"))
+    return hmac.compare_digest(presented, key.encode("utf-8", "surrogateescape"))
 
 
 class ProtocolError(Exception):

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -82,14 +82,14 @@ def fleet_token_allowed(ws: WebSocket) -> bool:
     # matches the stored key verbatim, and the ASGI server passes the name
     # through with whatever casing the client sent. Any worker spelling this
     # X-Fleet-Token would otherwise be refused as if it sent nothing.
-    presented = next(
-        (value for name, value in ws.headers.raw
-         if name.lower() == FLEET_TOKEN_HEADER.encode()),
-        None,
-    )
-    if presented is None:
+    presented = [value for name, value in ws.headers.raw
+                 if name.lower() == FLEET_TOKEN_HEADER.encode()]
+    # Exactly one, or the answer depends on which duplicate an intermediary
+    # happened to put first: correct-then-wrong would authenticate and
+    # wrong-then-correct would not.
+    if len(presented) != 1:
         return False
-    return hmac.compare_digest(presented, key.encode("utf-8", "surrogateescape"))
+    return hmac.compare_digest(presented[0], key.encode("utf-8", "surrogateescape"))
 
 
 class ProtocolError(Exception):

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -10,6 +10,7 @@ written back, so an in-flight heartbeat cannot undo a just-committed slot.
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import time
@@ -38,6 +39,7 @@ CLOSE_PROTOCOL_VIOLATION = 4000
 CLOSE_UNSUPPORTED_VERSION = 4002
 CLOSE_NO_CAPACITY = 4003
 CLOSE_UNKNOWN_MODEL = 4004
+FLEET_TOKEN_HEADER = "x-fleet-token"
 
 SESSION_READY_TIMEOUT = 10.0
 WORKER_DEAD_SECONDS = 90.0  # 3 missed heartbeats, docs/connection-handling.md
@@ -46,8 +48,8 @@ router = APIRouter()
 
 
 def origin_allowed(ws: WebSocket) -> bool:
-    """Neither socket authenticates its peer; the documented mitigation is a
-    trusted LAN (README.md). WebSocket handshakes ignore the same-origin policy
+    """Origin is a separate control; the documented mitigation is a trusted
+    LAN (README.md). WebSocket handshakes ignore the same-origin policy
     and send no preflight, so without this a page the operator merely visits
     reaches both sockets from outside that LAN. Browsers always send Origin and
     cannot forge it; worker processes send none (issue #201)."""
@@ -62,6 +64,25 @@ def origin_allowed(ws: WebSocket) -> bool:
         if candidate.strip()
     )
     return origin.rstrip("/") in allowed
+
+
+def fleet_token_allowed(ws: WebSocket) -> bool:
+    """Whether the peer presented the configured fleet secret.
+
+    Unset key means permissive, which keeps the one-command self-hosted start
+    working (docs/decisions.md). Compare encoded bytes: compare_digest refuses
+    two str arguments unless both are ASCII, so comparing the strings would
+    raise on a secret an operator is perfectly entitled to choose, and the
+    handler would then read that as a wrong token and refuse forever.
+    """
+    key = get_settings().fleet_token_key
+    if not key:
+        return True
+    token = ws.headers.get(FLEET_TOKEN_HEADER)
+    if not isinstance(token, str):
+        return False
+    return hmac.compare_digest(token.encode("utf-8", "surrogateescape"),
+                               key.encode("utf-8", "surrogateescape"))
 
 
 class ProtocolError(Exception):
@@ -295,6 +316,10 @@ async def reap_dead_workers() -> None:
 async def fleet(ws: WebSocket) -> None:
     if not origin_allowed(ws):
         logger.warning("fleet handshake refused from origin %s", ws.headers.get("origin"))
+        await ws.close()  # before accept: the handshake fails with HTTP 403
+        return
+    if not fleet_token_allowed(ws):
+        logger.warning("fleet handshake refused: invalid token")
         await ws.close()  # before accept: the handshake fails with HTTP 403
         return
     await ws.accept()

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
     oauth_providers: str = ""  # comma separated, read only when auth_mode is oauth
     billing_enabled: bool = False
     log_format: Literal["plain", "json"] = "plain"
+    fleet_token_key: str = ""
 
     # PUBLIC_URL is where browsers reach this API; asset URLs in responses use it.
     public_url: str = "http://localhost:8000"

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -45,8 +45,8 @@ class FakeHeaders:
 class FakeTokenHeaders:
     """Stands in for a WebSocket when only the fleet token header matters."""
 
-    def __init__(self, token):
-        raw = [] if token is None else [(b"x-fleet-token", token.encode("utf-8"))]
+    def __init__(self, token, name=b"x-fleet-token"):
+        raw = [] if token is None else [(name, token.encode("utf-8"))]
         self.headers = Headers(raw=raw)
 
 
@@ -110,17 +110,34 @@ def test_fleet_rejects_an_invalid_token_before_accept(monkeypatch, token):
 
 
 def test_fleet_token_check_never_raises_on_a_non_ascii_secret(monkeypatch):
-    """A non-ASCII secret cannot work, and must fail as a refusal not a crash.
+    """compare_digest rejects two str arguments unless both are ASCII.
 
-    compare_digest rejects two str arguments unless both are ASCII, so
-    comparing the strings would raise here. It cannot be made to work either:
-    an HTTP header is latin-1 on the wire and httpx refuses to send a
-    non-ASCII value at all, so the operator is warned at startup instead
-    (app/main.py) and the documented contract is an ASCII secret.
+    Comparing the strings would raise here, and the caller would read the
+    exception as a wrong token. The comparison works on bytes, so it cannot
+    raise whatever the operator or the peer supplies. The documented contract
+    is still an ASCII secret, warned about at startup (app/main.py), because
+    not every client will put other bytes in a header.
     """
-    monkeypatch.setattr(get_settings(), "fleet_token_key", "cl\u00e9-secr\u00e8te")
-    for presented in ("cl\u00e9-secr\u00e8te", "anything", "", None):
+    secret = "cl\u00e9-secr\u00e8te"
+    monkeypatch.setattr(get_settings(), "fleet_token_key", secret)
+    assert fleet_token_allowed(FakeTokenHeaders(secret))
+    for presented in ("cl\u00e9-autre", "anything", "", None):
         assert fleet_token_allowed(FakeTokenHeaders(presented)) is False
+
+
+@pytest.mark.parametrize("name", [b"x-fleet-token", b"X-Fleet-Token", b"X-FLEET-TOKEN"])
+def test_fleet_token_lookup_is_case_insensitive(monkeypatch, name):
+    """The ASGI server passes the header name through as the client spelled it.
+
+    Headers.get matches the stored key verbatim, so a worker sending
+    X-Fleet-Token, which is what websockets emits for that spelling, was
+    refused as if it had sent nothing: enabling the guard broke every
+    legitimate worker. Header names are case-insensitive (RFC 9110), and the
+    TestClient lowercases its own headers, so only a raw-level test catches it.
+    """
+    monkeypatch.setattr(get_settings(), "fleet_token_key", "fleet-secret")
+    assert fleet_token_allowed(FakeTokenHeaders("fleet-secret", name=name))
+    assert not fleet_token_allowed(FakeTokenHeaders("wrong-secret", name=name))
 
 
 def test_fleet_stays_open_when_token_key_is_unset(monkeypatch):

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -50,6 +50,13 @@ class FakeTokenHeaders:
         self.headers = Headers(raw=raw)
 
 
+class FakeRawHeaders:
+    """Stands in for a WebSocket carrying arbitrary raw header pairs."""
+
+    def __init__(self, raw):
+        self.headers = Headers(raw=raw)
+
+
 class FakeSocket:
     """Minimal WebSocket stand-in for driving realtime helpers on one loop."""
 
@@ -91,7 +98,7 @@ def test_fleet_accepts_a_correct_token_at_the_handshake(monkeypatch):
         assert ws.receive_json()["type"] == "registered"
 
 
-@pytest.mark.parametrize("token", ["wrong-secret", None, "", "fleet-secret "])
+@pytest.mark.parametrize("token", ["wrong-secret", None, ""])
 def test_fleet_rejects_an_invalid_token_before_accept(monkeypatch, token):
     """Assert the worker never registers, not merely that the socket closed.
 
@@ -123,6 +130,24 @@ def test_fleet_token_check_never_raises_on_a_non_ascii_secret(monkeypatch):
     assert fleet_token_allowed(FakeTokenHeaders(secret))
     for presented in ("cl\u00e9-autre", "anything", "", None):
         assert fleet_token_allowed(FakeTokenHeaders(presented)) is False
+
+
+def test_duplicate_token_headers_are_refused():
+    """Two of them, and the answer depends on which one came first.
+
+    An intermediary can add or reorder a header, so correct-then-wrong would
+    authenticate while wrong-then-correct would not. Require exactly one.
+    """
+    get_settings().fleet_token_key = "fleet-secret"
+    try:
+        good = (b"x-fleet-token", b"fleet-secret")
+        bad = (b"X-Fleet-Token", b"wrong-secret")
+        assert fleet_token_allowed(FakeRawHeaders([good]))
+        assert not fleet_token_allowed(FakeRawHeaders([good, bad]))
+        assert not fleet_token_allowed(FakeRawHeaders([bad, good]))
+        assert not fleet_token_allowed(FakeRawHeaders([good, good]))
+    finally:
+        get_settings().fleet_token_key = ""
 
 
 @pytest.mark.parametrize("name", [b"x-fleet-token", b"X-Fleet-Token", b"X-FLEET-TOKEN"])

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -16,6 +16,7 @@ from app.realtime import (
     GENERATED_FRAME,
     MIN_SUPPORTED_VERSION,
     PROTOCOL_VERSION,
+    fleet_token_allowed,
     origin_allowed,
 )
 from app.settings import get_settings
@@ -38,6 +39,14 @@ class FakeHeaders:
 
     def __init__(self, origin):
         raw = [] if origin is None else [(b"origin", origin.encode())]
+        self.headers = Headers(raw=raw)
+
+
+class FakeTokenHeaders:
+    """Stands in for a WebSocket when only the fleet token header matters."""
+
+    def __init__(self, token):
+        raw = [] if token is None else [(b"x-fleet-token", token.encode("utf-8"))]
         self.headers = Headers(raw=raw)
 
 
@@ -71,6 +80,54 @@ def test_version_gate_rejects_older_than_n_minus_1():
         response = ws.receive_json()
         assert response["type"] == "rejected"
         assert response["min_supported_version"] == MIN_SUPPORTED_VERSION
+
+
+def test_fleet_accepts_a_correct_token_at_the_handshake(monkeypatch):
+    monkeypatch.setattr(get_settings(), "fleet_token_key", "fleet-secret")
+    with client.websocket_connect(
+        "/api/v1/fleet", headers={"x-fleet-token": "fleet-secret"}
+    ) as ws:
+        ws.send_json(hello(worker_id="w-token-ok"))
+        assert ws.receive_json()["type"] == "registered"
+
+
+@pytest.mark.parametrize("token", ["wrong-secret", None, "", "fleet-secret "])
+def test_fleet_rejects_an_invalid_token_before_accept(monkeypatch, token):
+    """Assert the worker never registers, not merely that the socket closed.
+
+    Exiting a websocket_connect block raises WebSocketDisconnect on its own,
+    so `pytest.raises` around an empty body passes with the check removed
+    entirely. Drive the handshake and prove nothing was admitted.
+    """
+    monkeypatch.setattr(get_settings(), "fleet_token_key", "fleet-secret")
+    headers = {} if token is None else {"x-fleet-token": token}
+    worker_id = "w-token-bad"
+    with pytest.raises(WebSocketDisconnect):
+        with client.websocket_connect("/api/v1/fleet", headers=headers) as ws:
+            ws.send_json(hello(worker_id=worker_id))
+            ws.receive_json()
+    assert worker_id not in realtime.workers
+
+
+def test_fleet_token_check_never_raises_on_a_non_ascii_secret(monkeypatch):
+    """A non-ASCII secret cannot work, and must fail as a refusal not a crash.
+
+    compare_digest rejects two str arguments unless both are ASCII, so
+    comparing the strings would raise here. It cannot be made to work either:
+    an HTTP header is latin-1 on the wire and httpx refuses to send a
+    non-ASCII value at all, so the operator is warned at startup instead
+    (app/main.py) and the documented contract is an ASCII secret.
+    """
+    monkeypatch.setattr(get_settings(), "fleet_token_key", "cl\u00e9-secr\u00e8te")
+    for presented in ("cl\u00e9-secr\u00e8te", "anything", "", None):
+        assert fleet_token_allowed(FakeTokenHeaders(presented)) is False
+
+
+def test_fleet_stays_open_when_token_key_is_unset(monkeypatch):
+    monkeypatch.setattr(get_settings(), "fleet_token_key", "")
+    with client.websocket_connect("/api/v1/fleet") as ws:
+        ws.send_json(hello(worker_id="w-token-unset"))
+        assert ws.receive_json()["type"] == "registered"
 
 
 def test_version_gate_accepts_n_minus_1():

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -2,6 +2,10 @@ POSTGRES_PASSWORD=change-me
 # Shared secret for the API fleet socket and all workers. Leave empty to keep
 # the existing trusted-LAN, permissive behavior. Use ASCII only: it travels in
 # an HTTP header, which cannot carry anything else.
+# Generate with: openssl rand -hex 32
+# Compose expands $NAME in an unquoted value, so a secret containing a dollar
+# sign resolves to nothing and the API silently falls back to permissive. Hex
+# avoids that; single-quote the value if you use anything else.
 FLEET_SECRET=
 # Hugging Face read token, only needed for gated models (sd35-medium).
 # Accept the model license on huggingface.co first, then paste the token here.

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -1,4 +1,8 @@
 POSTGRES_PASSWORD=change-me
+# Shared secret for the API fleet socket and all workers. Leave empty to keep
+# the existing trusted-LAN, permissive behavior. Use ASCII only: it travels in
+# an HTTP header, which cannot carry anything else.
+FLEET_SECRET=
 # Hugging Face read token, only needed for gated models (sd35-medium).
 # Accept the model license on huggingface.co first, then paste the token here.
 HF_TOKEN=

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -4,8 +4,9 @@ POSTGRES_PASSWORD=change-me
 # an HTTP header, which cannot carry anything else.
 # Generate with: openssl rand -hex 32
 # Compose expands $NAME in an unquoted value, so a secret containing a dollar
-# sign resolves to nothing and the API silently falls back to permissive. Hex
-# avoids that; single-quote the value if you use anything else.
+# sign can be altered or emptied, and an emptied one puts the API back in
+# permissive mode. Compose and the API both warn, but the run continues. Hex
+# avoids the question; single-quote any value containing a dollar sign.
 FLEET_SECRET=
 # Hugging Face read token, only needed for gated models (sd35-medium).
 # Accept the model license on huggingface.co first, then paste the token here.

--- a/deploy/compose/compose.smoke.yml
+++ b/deploy/compose/compose.smoke.yml
@@ -13,6 +13,7 @@ services:
       STORAGE_BACKEND: local
       PUBLIC_URL: http://localhost:${COMPOSE_SMOKE_PORT:-18080}
       INTERNAL_URL: http://api:8080
+      FLEET_TOKEN_KEY: ${FLEET_SECRET:-smoke-fleet-secret}
     volumes:
       - assets:/data/assets
     depends_on:
@@ -39,6 +40,9 @@ services:
       dockerfile: deploy/docker/Dockerfile.worker-sim
     environment:
       API_URL: ws://api:8080/api/v1/fleet
+      # Non-empty by default: the smoke run is what proves a keyed stack still
+      # registers its worker, which a permissive default would never exercise.
+      FLEET_TOKEN: ${FLEET_SECRET:-smoke-fleet-secret}
     depends_on:
       - api
 

--- a/deploy/compose/compose.yml
+++ b/deploy/compose/compose.yml
@@ -22,6 +22,7 @@ services:
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-}
       INTERNAL_URL: http://api:8080
       TELEMETRY: ${TELEMETRY:-true}
+      FLEET_TOKEN_KEY: ${FLEET_SECRET}
     volumes:
       - assets:/data/assets
     depends_on:
@@ -57,6 +58,7 @@ services:
       # hub client picks HF_TOKEN up from the environment. Empty is fine when
       # no gated model is enabled.
       HF_TOKEN: ${HF_TOKEN:-}
+      FLEET_TOKEN: ${FLEET_SECRET}
     volumes:
       - models:/models
       # Downloaded model weights survive container recreation.
@@ -83,6 +85,7 @@ services:
       DEVICE: rocm
       API_URL: ws://api:8080/api/v1/fleet
       MODELS_DIR: /models
+      FLEET_TOKEN: ${FLEET_SECRET}
     volumes:
       - models:/models
       - hf-cache:/root/.cache/huggingface
@@ -103,6 +106,7 @@ services:
       dockerfile: deploy/docker/Dockerfile.worker-sim
     environment:
       API_URL: ws://api:8080/api/v1/fleet
+      FLEET_TOKEN: ${FLEET_SECRET}
     depends_on:
       - api
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ Every call a customer's browser makes, from first page load to account deletion.
 | GET `/api/v1/health` | implemented | process liveness for the load balancer |
 | GET `/api/v1/config` | implemented | runtime configuration for the SPA |
 | WS `/api/v1/realtime` | implemented (prototype) | realtime drawing sessions |
-| WS `/api/v1/fleet` | implemented (prototype) | worker fleet connection, not for browsers: a handshake carrying a non-allowlisted `Origin` is refused |
+| WS `/api/v1/fleet` | implemented (prototype) | worker fleet connection, not for browsers: a handshake carrying a non-allowlisted `Origin` is refused, as is one without the `X-Fleet-Token` shared secret when `FLEET_TOKEN_KEY` is set |
 | GET `/api/v1/models` | implemented (#11, #15) | registered models with parameter schemas and GPU-time estimates |
 | POST `/api/v1/generations` | implemented (#11, #16) | queue a generation job (text2img, img2img, or upscale) |
 | GET `/api/v1/generations/{id}` | implemented (#16) | job state, result asset when done |

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -72,7 +72,7 @@ Messages later issues add to this catalogue (queued position, prompt updates, cr
 sequenceDiagram
     participant W as Worker
     participant A as API server
-    W->>A: WS connect /api/v1/fleet
+    W->>A: WS connect /api/v1/fleet (X-Fleet-Token when FLEET_TOKEN_KEY is set)
     W->>A: hello (protocol_version, worker_id, models, realtime_slots, device, memory_mode)
     alt version supported
         A-->>W: registered
@@ -172,7 +172,15 @@ Both endpoints refuse a handshake whose `Origin` header is present and not allow
 
 Allowed origins are `PUBLIC_URL` plus anything in `ALLOWED_ORIGINS`. The dev loop needs the latter, because the vite server proxies `/api/v1` and the browser's origin is its own.
 
-This is a boundary control, not authentication. WebSocket handshakes ignore the same-origin policy and send no preflight, so without it any page the operator visits can reach both sockets and the trusted-LAN posture in [README.md](../README.md) does not hold. Worker authentication is separate and still deferred (`FLEET_TOKEN_KEY`).
+This is a boundary control, not authentication. WebSocket handshakes ignore the same-origin policy and send no preflight, so without it any page the operator visits can reach both sockets and the trusted-LAN posture in [README.md](../README.md) does not hold. Worker authentication is separate and covered below.
+
+## Fleet authentication
+
+A worker presents the shared secret as an `X-Fleet-Token` request header on the upgrade. The API compares it against `FLEET_TOKEN_KEY` before accepting, so a missing or wrong token fails the handshake with HTTP 403 and no close code applies. Header names are case-insensitive; send it however you like.
+
+When `FLEET_TOKEN_KEY` is unset the socket stays open and the API warns at startup. That keeps the one-command self-hosted start working and is why the trusted-LAN warning in [README.md](../README.md) still applies to an unkeyed install. The secret is ASCII: it travels in an HTTP header.
+
+Signed short-lived tokens are the cloud shape and are not implemented here; their minting side lives in the private repository (`docs/repository-boundary.md`).
 
 ## Close codes
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -49,7 +49,7 @@ run one or the other, never both, since they share the model volumes.
 
 ```bash
 cp deploy/compose/.env.example deploy/compose/.env
-# edit POSTGRES_PASSWORD
+# edit POSTGRES_PASSWORD and FLEET_SECRET
 docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
 ```
 
@@ -59,8 +59,15 @@ docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
   `docker compose -f deploy/compose/compose.yml logs -f worker`.
   Until the download finishes, jobs on that model sit in the queue.
 - Open http://localhost:8080; the studio is served by the API container.
-- The fleet WebSocket (`/api/v1/fleet`) is unauthenticated in this profile:
-  treat the host as a trusted LAN until fleet authentication lands.
+- The fleet WebSocket (`/api/v1/fleet`) accepts the shared `FLEET_SECRET` from
+  the compose environment. The API receives it as `FLEET_TOKEN_KEY` and the
+  worker receives it as `FLEET_TOKEN`; the worker sends it in the handshake
+  header. Use a long random ASCII value and keep it private: an HTTP header
+  cannot carry anything else, and the API warns at startup if the secret is
+  not ASCII.
+- If `FLEET_SECRET` is empty, the API logs a warning and keeps the fleet socket
+  permissive for compatibility with existing installs. Treat the host as a
+  trusted LAN in that mode.
 - Models are JSON manifests in the `models` volume, seeded from
   `worker/models/` on first boot. Add or edit manifests in the volume (or
   rebuild the image) and restart the worker; see

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -65,9 +65,10 @@ docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
   header. Generate it with `openssl rand -hex 32` and keep it private. Hex is
   not arbitrary advice: an HTTP header carries ASCII only, and Compose expands
   `$NAME` inside an unquoted `.env` value, so a secret containing a dollar sign
-  resolves to nothing and the API falls back to permissive. Single-quote the
-  value if you use anything other than hex. The API warns at startup when the
-  secret is unset or not ASCII.
+  can be altered or emptied, and an emptied one puts the API back in permissive
+  mode. Compose and the API both warn, but the run continues. Single-quote any
+  value containing a dollar sign. The API warns at startup when the secret is
+  unset or not ASCII.
 - If `FLEET_SECRET` is empty, the API logs a warning and keeps the fleet socket
   permissive for compatibility with existing installs. Treat the host as a
   trusted LAN in that mode.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -62,9 +62,12 @@ docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
 - The fleet WebSocket (`/api/v1/fleet`) accepts the shared `FLEET_SECRET` from
   the compose environment. The API receives it as `FLEET_TOKEN_KEY` and the
   worker receives it as `FLEET_TOKEN`; the worker sends it in the handshake
-  header. Use a long random ASCII value and keep it private: an HTTP header
-  cannot carry anything else, and the API warns at startup if the secret is
-  not ASCII.
+  header. Generate it with `openssl rand -hex 32` and keep it private. Hex is
+  not arbitrary advice: an HTTP header carries ASCII only, and Compose expands
+  `$NAME` inside an unquoted `.env` value, so a secret containing a dollar sign
+  resolves to nothing and the API falls back to permissive. Single-quote the
+  value if you use anything other than hex. The API warns at startup when the
+  secret is unset or not ASCII.
 - If `FLEET_SECRET` is empty, the API logs a warning and keeps the fleet socket
   permissive for compatibility with existing installs. Treat the host as a
   trusted LAN in that mode.

--- a/scripts/compose-smoke.sh
+++ b/scripts/compose-smoke.sh
@@ -37,6 +37,18 @@ for _ in $(seq 1 90); do
 done
 curl -sf "${base}/api/v1/health"
 
+# The stack runs keyed, so an unauthenticated upgrade must be refused. Without
+# this the smoke run only proves that a matching secret works, and a check that
+# went permissive would still pass everything below.
+fleet_code=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  "${base}/api/v1/fleet")
+if [[ "$fleet_code" != "403" ]]; then
+  echo "expected an untokened fleet upgrade to return 403, got ${fleet_code}" >&2
+  exit 1
+fi
+
 app_code=$(curl -s -o /dev/null -w '%{http_code}' "${base}/app")
 if [[ "$app_code" != "200" ]]; then
   echo "expected /app to return 200, got ${app_code}" >&2

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -10,6 +10,7 @@ from worker.client import (
     FRAME_HEADER_BYTES,
     RegistrationRejected,
     SessionRunner,
+    run,
     run_job,
     serve_connection,
 )
@@ -114,6 +115,44 @@ def test_rejected_registration_raises_cleanly():
 
     with pytest.raises(RegistrationRejected, match="minimum supported version 3"):
         asyncio.run(scenario())
+
+
+def test_run_sends_the_fleet_token_as_a_handshake_header(monkeypatch):
+    calls = []
+
+    class Connection:
+        def __init__(self, url, **kwargs):
+            calls.append((url, kwargs))
+
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *exc):
+            return None
+
+    async def fake_serve_connection(*args):
+        return None
+
+    class StopReconnect(Exception):
+        pass
+
+    async def stop_sleep(_delay):
+        raise StopReconnect
+
+    settings = Settings(worker_id="w-token", fleet_token="fleet-secret")
+    monkeypatch.setattr("worker.client.get_settings", lambda: settings)
+    monkeypatch.setattr("worker.client.build_runtime",
+                        lambda _settings: ([SIMULATED_MANIFEST], SimulatedEngine(0.01)))
+    monkeypatch.setattr("worker.client.websockets.connect", Connection)
+    monkeypatch.setattr("worker.client.serve_connection", fake_serve_connection)
+    monkeypatch.setattr("worker.client.asyncio.sleep", stop_sleep)
+
+    with pytest.raises(StopReconnect):
+        asyncio.run(run())
+
+    assert calls == [(settings.api_url, {"additional_headers": {
+        "X-Fleet-Token": "fleet-secret",
+    }})]
 
 
 class FakeUpload:

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -151,7 +151,7 @@ def test_run_sends_the_fleet_token_as_a_handshake_header(monkeypatch):
         asyncio.run(run())
 
     assert calls == [(settings.api_url, {"additional_headers": {
-        "X-Fleet-Token": "fleet-secret",
+        "x-fleet-token": "fleet-secret",
     }})]
 
 

--- a/worker/tests/test_settings.py
+++ b/worker/tests/test_settings.py
@@ -13,11 +13,13 @@ def test_env_override(monkeypatch):
     monkeypatch.setenv("DEVICE", "rocm")
     monkeypatch.setenv("MEMORY_MODE", "model_offload")
     monkeypatch.setenv("API_URL", "ws://api:8080/api/v1/fleet")
+    monkeypatch.setenv("FLEET_TOKEN", "fleet-secret")
     monkeypatch.setenv("TORCH_COMPILE", "1")
     monkeypatch.setenv("ATTENTION_BACKEND", "_native_efficient")
     settings = Settings()
     assert settings.device == "rocm"
     assert settings.memory_mode == "model_offload"
     assert settings.api_url == "ws://api:8080/api/v1/fleet"
+    assert settings.fleet_token == "fleet-secret"
     assert settings.torch_compile is True
     assert settings.attention_backend == "_native_efficient"

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -421,7 +421,9 @@ async def run() -> None:
         try:
             async with websockets.connect(
                 settings.api_url,
-                additional_headers={"X-Fleet-Token": settings.fleet_token},
+                # Lowercase: header names are case-insensitive, but not every
+                # ASGI stack normalises them before the application looks.
+                additional_headers={"x-fleet-token": settings.fleet_token},
             ) as ws:
                 delay = BACKOFF_INITIAL
                 await serve_connection(ws, settings, manifests, engine)

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -419,7 +419,10 @@ async def run() -> None:
     delay = BACKOFF_INITIAL
     while True:
         try:
-            async with websockets.connect(settings.api_url) as ws:
+            async with websockets.connect(
+                settings.api_url,
+                additional_headers={"X-Fleet-Token": settings.fleet_token},
+            ) as ws:
                 delay = BACKOFF_INITIAL
                 await serve_connection(ws, settings, manifests, engine)
         except RegistrationRejected as error:

--- a/worker/worker/settings.py
+++ b/worker/worker/settings.py
@@ -14,6 +14,7 @@ class Settings(BaseSettings):
     device: Literal["cuda", "rocm", "cpu"] = "cpu"
     memory_mode: Literal["auto", "full", "model_offload", "group_offload"] = "auto"
     api_url: str = "ws://localhost:8000/api/v1/fleet"
+    fleet_token: str = ""
     log_format: Literal["plain", "json"] = "plain"
     worker_id: str = Field(default_factory=lambda: f"worker-{uuid.uuid4().hex[:8]}")
     realtime_slots: int = 2  # upper bound; DiffusersEngine calibrates down at warmup


### PR DESCRIPTION
Closes #206. Implemented by Codex (gpt-5.6-luna); I reviewed the diff, fixed two defects in it, and hardened the tests before pushing.

`/api/v1/fleet` accepted any peer that sent a valid `hello`, and that peer became a worker: advertising models and slots, receiving dispatched prompts and presigned source URLs, sending every privileged fleet control message. `FLEET_TOKEN_KEY` on the API and `FLEET_TOKEN` on the worker, both names already fixed by `docs/blueprint.md:25,429,443`.

**Transport: an `X-Fleet-Token` handshake header**, checked before `accept()` beside the existing Origin check. A header keeps the secret out of the hello schema and out of anything that logs control messages, which a hello field would not.

**Unset key stays permissive** and warns at startup, per the recorded decision in `docs/decisions.md`. Closed-by-default would break every existing install on upgrade and belongs to a release boundary. Signed short-lived tokens are deliberately absent: their minting side lives in the private autoscaler and does not exist yet (#225).

## Two defects I found in the generated code

**A legitimate non-ASCII secret failed silently and permanently.** `hmac.compare_digest` rejects two `str` arguments unless both are ASCII. The original caught the resulting `TypeError` and returned `False`, so an operator whose secret contained an accent would have had every worker refused forever with no explanation. The comparison now uses encoded bytes and cannot raise.

Chasing that turned up the real constraint: a non-ASCII secret cannot work at all. httpx refuses to send such a header (`UnicodeEncodeError`) and Starlette decodes headers as latin-1. So the contract is an ASCII secret, stated in `.env.example` where it is set, in `docs/self-hosting.md`, and warned about at startup rather than left to be discovered.

**The rejection test was vacuous.** It asserted `WebSocketDisconnect` around an empty `with` body, and exiting a `websocket_connect` block raises that by itself - the test passed with the entire check deleted. It now sends a hello and asserts the worker never lands in `realtime.workers`. Verified: removing the check fails 4 tests.

## Verification

`make verify` green end to end: backend 156, worker 90, frontend build and CSP. No non-ASCII in any Python file. No GPU used at any point, by Codex or by me.

Note `README.md` keeps its trusted-LAN warning: with a permissive default it stays accurate until the default flips.