### PR TITLE
Treat the fleet peer as untrusted in sessions, completion and uploads

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1297,7 +1297,8 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             try:
                 await get_storage().delete(orphan)
             except Exception:
-                logger.debug("no orphaned blob %s to remove for job %s", orphan, job_id)
+                logger.warning("could not remove orphaned blob %s for job %s", orphan,
+                               job_id, exc_info=True)
         url = await get_storage().url(entry.storage_key)
         publish(job_id, {"state": "succeeded", "url": url})
         logger.info("job %s succeeded, gpu_ms=%s", job_id, control.get("gpu_ms"))

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1215,6 +1215,12 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         except Exception:
             logger.exception("could not inspect output for job %s", job_id)
             return
+        # Before either branch. image_info awaits a thread, so a stall requeue
+        # can have replaced this attempt while its output was being inspected,
+        # and a late verdict must not fail the row or delete the objects that
+        # now belong to the attempt after it.
+        if inflight.get(job_id) is not current:
+            return
         if (image is None or image.size <= 0
                 or image.content_type != "image/png"):
             entry = inflight.pop(job_id, None)
@@ -1224,19 +1230,19 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             last_progress_at.pop(job_id, None)
             release_job_slot(worker)
             await mark_failed(job_id, "worker output was missing or invalid")
-            # Nothing else collects a rejected upload: no asset row names it
-            # and the success path only cleans up earlier attempts.
-            for rejected in (entry.storage_key, entry.thumb_storage_key):
+            # Nothing else collects these: no asset row names them, and the
+            # success path that cleans up earlier attempts never runs. Clean
+            # this attempt and every one before it.
+            rejected_keys = [entry.storage_key, entry.thumb_storage_key]
+            for earlier in range(1, entry.attempt):
+                rejected_keys.extend(storage_keys_for_attempt(entry.user_id, job_id, earlier))
+            for rejected in rejected_keys:
                 try:
                     await get_storage().delete(rejected)
                 except Exception:
                     logger.debug("no rejected blob %s to remove for job %s", rejected, job_id)
             return
         image_dimensions = (image.width, image.height)
-        # image_info awaits a thread, so re-check ownership: a stall requeue
-        # can have replaced this attempt while we were inspecting its output.
-        if inflight.get(job_id) is not current:
-            return
 
     entry = inflight.pop(job_id, None)
     live_progress.pop(job_id, None)

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1230,17 +1230,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             last_progress_at.pop(job_id, None)
             release_job_slot(worker)
             await mark_failed(job_id, "worker output was missing or invalid")
-            # Nothing else collects these: no asset row names them, and the
-            # success path that cleans up earlier attempts never runs. Clean
-            # this attempt and every one before it.
-            rejected_keys = [entry.storage_key, entry.thumb_storage_key]
-            for earlier in range(1, entry.attempt):
-                rejected_keys.extend(storage_keys_for_attempt(entry.user_id, job_id, earlier))
-            for rejected in rejected_keys:
-                try:
-                    await get_storage().delete(rejected)
-                except Exception:
-                    logger.debug("no rejected blob %s to remove for job %s", rejected, job_id)
+            await purge_attempt_blobs(entry.user_id, job_id, entry.attempt)
             return
         image_dimensions = (image.width, image.height)
 
@@ -1316,6 +1306,29 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     else:
         reason = str(control.get("reason", "worker reported failure"))
         await mark_failed(job_id, reason)
+        # A reported failure can still have uploaded: nothing downstream names
+        # those objects, so this is their only collector.
+        await purge_attempt_blobs(entry.user_id, job_id, entry.attempt)
+
+
+async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: int) -> None:
+    """Remove the objects of this attempt and every earlier one.
+
+    Terminal paths are the only collector these have: no asset row names them,
+    and the success path never runs. A worker can upload a master and a
+    thumbnail and then report a failure, and on S3 nothing bounds what it
+    uploaded.
+
+    On a versioned S3 bucket this removes the key, not the bytes: the delete
+    writes a marker and the object survives as a noncurrent version. Issue
+    #252 covers purging by version; until then the reclaim is local-only.
+    """
+    for earlier in range(1, attempt + 1):
+        for key in storage_keys_for_attempt(user_id, job_id, earlier):
+            try:
+                await get_storage().delete(key)
+            except Exception:
+                logger.debug("no blob %s to remove for job %s", key, job_id)
 
 
 async def mark_failed(job_id: uuid.UUID, reason: str) -> None:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1319,16 +1319,19 @@ async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: in
     thumbnail and then report a failure, and on S3 nothing bounds what it
     uploaded.
 
-    On a versioned S3 bucket this removes the key, not the bytes: the delete
-    writes a marker and the object survives as a noncurrent version. Issue
-    #252 covers purging by version; until then the reclaim is local-only.
+    S3Storage.delete purges every version of the key, not just the current
+    one, so this reclaims the storage rather than hiding it.
     """
     for earlier in range(1, attempt + 1):
         for key in storage_keys_for_attempt(user_id, job_id, earlier):
             try:
                 await get_storage().delete(key)
             except Exception:
-                logger.debug("no blob %s to remove for job %s", key, job_id)
+                # Warning, not debug: a missing object does not normally make
+                # a delete raise, so this is a real cleanup failure such as a
+                # denied permission, and nothing retries it.
+                logger.warning("could not remove blob %s for job %s", key, job_id,
+                               exc_info=True)
 
 
 async def mark_failed(job_id: uuid.UUID, reason: str) -> None:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -89,6 +89,7 @@ class InFlight:
     storage_key: str
     thumb_storage_key: str
     user_id: uuid.UUID
+    attempt: int = 1
 
 
 inflight: dict[uuid.UUID, InFlight] = {}
@@ -96,7 +97,16 @@ lost_jobs: list[uuid.UUID] = []  # drained by the dispatch loop
 
 
 def storage_key_in_flight(key: str) -> bool:
-    return any(key in (entry.storage_key, entry.thumb_storage_key) for entry in inflight.values())
+    for job_id, entry in inflight.items():
+        expected = storage_keys_for_attempt(entry.user_id, job_id, entry.attempt)
+        if key in expected:
+            return True
+    return False
+
+
+def storage_keys_for_attempt(user_id: uuid.UUID, job_id: uuid.UUID, attempt: int) -> tuple[str, str]:
+    prefix = f"{user_id}/{job_id}-attempt-{attempt}"
+    return f"{prefix}.png", f"{prefix}-thumb.webp"
 
 # Latest reported denoising fraction per running job. Transient by design:
 # the job row is the source of truth for state, progress is display only.
@@ -1107,15 +1117,18 @@ async def dispatch(job_id: uuid.UUID) -> bool:
         worker = pick_job_worker(job.model_id)
         if worker is None:
             return False
-        storage_key = f"{job.user_id}/{job.id}.png"
-        thumb_storage_key = f"{job.user_id}/{job.id}-thumb.webp"
+        storage_key, thumb_storage_key = storage_keys_for_attempt(
+            job.user_id, job.id, job.attempt
+        )
         target = await get_storage().upload_target(storage_key)
         thumb_target = await get_storage().upload_target(thumb_storage_key)
         # Bookkeeping before the send: if the worker dies from here on, its
         # disconnect handler finds the inflight entry and requeues the job.
         worker.jobs_in_flight += 1
-        inflight[job.id] = InFlight(worker=worker, storage_key=storage_key,
-                                    thumb_storage_key=thumb_storage_key, user_id=job.user_id)
+        inflight[job.id] = InFlight(
+            worker=worker, storage_key=storage_key, thumb_storage_key=thumb_storage_key,
+            user_id=job.user_id, attempt=job.attempt,
+        )
         last_progress_at[job_id] = time.monotonic()
         job.state = "running"
         job.dispatched_at = datetime.now(timezone.utc)
@@ -1180,6 +1193,40 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         last_progress_at[job_id] = time.monotonic()
         publish(job_id, {"state": "running", "progress": progress})
         return
+    image_dimensions = (0, 0)
+    if control["type"] == "job_done":
+        gpu_ms = _worker_int(control.get("gpu_ms"))
+        phase_ms = {
+            field: _worker_int(control[field])
+            for field in ("input_fetch_ms", "load_ms", "postprocess_ms")
+            if control.get(field) is not None
+        }
+        # Convert claimed dimensions before touching inflight as well. The
+        # object is authoritative below, but malformed peer fields must not
+        # strand the running row if conversion ever rejects one.
+        _worker_int(control.get("width"))
+        _worker_int(control.get("height"))
+        if db.session_factory is None:
+            logger.warning("job %s finished on the worker but the database is unavailable",
+                           job_id)
+            return
+        try:
+            image = await get_storage().image_info(current.storage_key)
+        except Exception:
+            logger.exception("could not inspect output for job %s", job_id)
+            return
+        if (image is None or image.size <= 0
+                or image.content_type != "image/png"):
+            entry = inflight.pop(job_id, None)
+            if entry is None:
+                return
+            live_progress.pop(job_id, None)
+            last_progress_at.pop(job_id, None)
+            release_job_slot(worker)
+            await mark_failed(job_id, "worker output was missing or invalid")
+            return
+        image_dimensions = (image.width, image.height)
+
     entry = inflight.pop(job_id, None)
     live_progress.pop(job_id, None)
     last_progress_at.pop(job_id, None)
@@ -1196,13 +1243,11 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             if job is None:
                 return
             job.state = "succeeded"
-            job.gpu_ms = _worker_int(control.get("gpu_ms"))
-            for field in ("input_fetch_ms", "load_ms", "postprocess_ms"):
-                if control.get(field) is not None:
-                    setattr(job, field, _worker_int(control[field]))
+            job.gpu_ms = gpu_ms
+            for field, value in phase_ms.items():
+                setattr(job, field, value)
             job.finished_at = datetime.now(timezone.utc)
-            width = _worker_int(control.get("width"))
-            height = _worker_int(control.get("height"))
+            width, height = image_dimensions
             full = Asset(
                 user_id=entry.user_id,
                 job_id=job_id,
@@ -1232,13 +1277,20 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
                     height=thumb_height,
                 ))
             await session.commit()
+        orphans = []
         if control.get("has_thumbnail") is not True:
-            # A previous attempt may have uploaded a thumbnail this attempt
-            # did not report; drop the orphan blob rather than leak it.
+            # This attempt may have uploaded a thumbnail it did not report.
+            orphans.append(entry.thumb_storage_key)
+        # Attempts no longer share one key, so a retry leaves the earlier
+        # attempt's blobs behind instead of overwriting them. Nothing else
+        # collects them: the asset row only ever names the winning key.
+        for earlier in range(1, entry.attempt):
+            orphans.extend(storage_keys_for_attempt(entry.user_id, job_id, earlier))
+        for orphan in orphans:
             try:
-                await get_storage().delete(entry.thumb_storage_key)
+                await get_storage().delete(orphan)
             except Exception:
-                logger.debug("no orphaned thumbnail to remove for job %s", job_id)
+                logger.debug("no orphaned blob %s to remove for job %s", orphan, job_id)
         url = await get_storage().url(entry.storage_key)
         publish(job_id, {"state": "succeeded", "url": url})
         logger.info("job %s succeeded, gpu_ms=%s", job_id, control.get("gpu_ms"))

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1224,8 +1224,19 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             last_progress_at.pop(job_id, None)
             release_job_slot(worker)
             await mark_failed(job_id, "worker output was missing or invalid")
+            # Nothing else collects a rejected upload: no asset row names it
+            # and the success path only cleans up earlier attempts.
+            for rejected in (entry.storage_key, entry.thumb_storage_key):
+                try:
+                    await get_storage().delete(rejected)
+                except Exception:
+                    logger.debug("no rejected blob %s to remove for job %s", rejected, job_id)
             return
         image_dimensions = (image.width, image.height)
+        # image_info awaits a thread, so re-check ownership: a stall requeue
+        # can have replaced this attempt while we were inspecting its output.
+        if inflight.get(job_id) is not current:
+            return
 
     entry = inflight.pop(job_id, None)
     live_progress.pop(job_id, None)

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -392,9 +392,13 @@ async def fleet(ws: WebSocket) -> None:
                     data = message["bytes"]
                     session = sessions.get(frame_session_id(data))
                     # The worker is a network peer too: only the assigned
-                    # worker may relay generated frames for this session.
-                    if (session is not None and session.worker is worker
-                            and data[0] == GENERATED_FRAME):
+                    # worker may relay frames for this session. A frame for a
+                    # session this worker does not own is dropped, because
+                    # reassignment races produce those legitimately; the
+                    # assigned worker sending the wrong kind is not a race.
+                    if session is not None and session.worker is worker:
+                        if data[0] != GENERATED_FRAME:
+                            raise ProtocolError("worker frame is not a generated frame")
                         await safe_send(session.browser.send_bytes(data))
                 elif message.get("text") is not None:
                     control = parse_control(message["text"])
@@ -408,8 +412,13 @@ async def fleet(ws: WebSocket) -> None:
                         await jobs.on_worker_message(worker, control)
                     elif control["type"] == "session_closed":
                         session_id = peer_uuid(control["session_id"])
-                        owner = closing_sessions.pop(session_id, None)
-                        if owner is not None:
+                        # Peek before popping: a worker that held this session
+                        # earlier still knows its id, and popping on its word
+                        # would drop the current owner's entry and bill this
+                        # user for a session it did not run.
+                        owner = closing_sessions.get(session_id)
+                        if owner is not None and owner[2] is worker:
+                            del closing_sessions[session_id]
                             from app import usage_events
                             usage_events.schedule_realtime(owner[0], owner[1], control)
                     elif control["type"] in ("gpu_status", "model_loaded",

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -391,14 +391,17 @@ async def fleet(ws: WebSocket) -> None:
                 if message.get("bytes") is not None:
                     data = message["bytes"]
                     session = sessions.get(frame_session_id(data))
-                    if session is not None:  # browser may have just closed
+                    # The worker is a network peer too: only the assigned
+                    # worker may relay generated frames for this session.
+                    if (session is not None and session.worker is worker
+                            and data[0] == GENERATED_FRAME):
                         await safe_send(session.browser.send_bytes(data))
                 elif message.get("text") is not None:
                     control = parse_control(message["text"])
                     worker.last_seen = time.monotonic()
                     if control["type"] == "session_ready":
                         session = sessions.get(peer_uuid(control["session_id"]))
-                        if session is not None:
+                        if session is not None and session.worker is worker:
                             session.ready.set()
                     elif control["type"] in ("job_progress", "job_done", "job_failed"):
                         from app import jobs  # late import; jobs reads this module's state

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -82,6 +82,7 @@ def _png_dimensions(data: bytes) -> tuple[int, int]:
     """
     if len(data) < 45 or data[:8] != b"\x89PNG\r\n\x1a\n":
         raise ValueError("stored object is not a PNG")
+    view = memoryview(data)
     position = 8
     width = height = 0
     chunks = 0
@@ -90,19 +91,25 @@ def _png_dimensions(data: bytes) -> tuple[int, int]:
         chunks += 1
         if chunks > MAX_PNG_CHUNKS:
             raise ValueError("stored PNG has too many chunks")
-        length = struct.unpack(">I", data[position:position + 4])[0]
+        length = struct.unpack_from(">I", view, position)[0]
         end = position + 12 + length
         if end > len(data):
             raise ValueError("stored object has a truncated PNG chunk")
-        kind = data[position + 4:position + 8]
-        body = data[position + 8:position + 8 + length]
-        if zlib.crc32(kind + body) & 0xffffffff != struct.unpack(">I", data[end - 4:end])[0]:
+        kind = bytes(view[position + 4:position + 8])
+        # Seed the CRC with the kind and feed the body as a view. Slicing the
+        # body and concatenating it copied the chunk twice, so a 60 MB IDAT
+        # cost about 180 MB live for a 64 MB input, and a few concurrent
+        # completions would then exhaust the API task.
+        checksum = zlib.crc32(view[position + 8:position + 8 + length],
+                              zlib.crc32(kind)) & 0xffffffff
+        if checksum != struct.unpack_from(">I", view, end - 4)[0]:
             raise ValueError("stored object has a corrupt PNG chunk")
         if chunks == 1:
             if kind != b"IHDR" or length != 13:
                 raise ValueError("stored object does not start with a PNG header")
-            width, height = struct.unpack(">II", body[:8])
-            depth, colour, compression, filtering, interlace = body[8:13]
+            header = bytes(view[position + 8:position + 21])
+            width, height = struct.unpack_from(">II", header, 0)
+            depth, colour, compression, filtering, interlace = header[8:13]
             if colour not in _PNG_DEPTHS or depth not in _PNG_DEPTHS[colour]:
                 raise ValueError("stored PNG has an illegal colour type or bit depth")
             if compression != 0 or filtering != 0 or interlace not in (0, 1):

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -56,52 +56,42 @@ class ImageInfo:
     content_type: str
 
 
+# Generated output is one image. Both bounds are fixed here rather than derived
+# from the object, because the object is what a worker chose to upload: a
+# ceiling computed from a declared width and height is a ceiling the peer sets.
+MAX_IMAGE_EDGE = 16384
+
+
 def _png_dimensions(data: bytes) -> tuple[int, int]:
-    if len(data) < 33 or data[:8] != b"\x89PNG\r\n\x1a\n":
+    """Dimensions of a stored PNG, or ValueError if it is not a usable one.
+
+    Structure only: signature, a well-formed IHDR, and an IEND at the end. It
+    does not decompress. An earlier version did, to prove the image decoded,
+    and that was twice a denial of service: unbounded it turned 400 KB into
+    831 MB, and bounded by the declared dimensions it granted an 80 GB ceiling
+    to a 65 KB object claiming to be 100000x100000. Deciding how much memory to
+    spend from a number the peer supplied cannot be made safe, and a real
+    decoder belongs off the event loop, so this checks what it can cheaply
+    check and the caller treats the result as a claim about shape, not proof
+    the pixels are good.
+    """
+    if len(data) < 45 or data[:8] != b"\x89PNG\r\n\x1a\n":
         raise ValueError("stored object is not a PNG")
-    position = 8
-    width = height = None
-    idat = bytearray()
-    saw_iend = False
-    while position + 12 <= len(data):
-        length = struct.unpack(">I", data[position:position + 4])[0]
-        end = position + 12 + length
-        if end > len(data):
-            raise ValueError("stored object has a truncated PNG chunk")
-        kind = data[position + 4:position + 8]
-        body = data[position + 8:position + 8 + length]
-        checksum = struct.unpack(">I", data[position + 8 + length:end])[0]
-        if zlib.crc32(kind + body) & 0xffffffff != checksum:
-            raise ValueError("stored object has a corrupt PNG chunk")
-        if kind == b"IHDR":
-            if position != 8 or length != 13:
-                raise ValueError("stored object has no PNG dimensions")
-            width, height = struct.unpack(">II", body[:8])
-        elif kind == b"IDAT":
-            idat.extend(body)
-        elif kind == b"IEND":
-            saw_iend = length == 0
-            break
-        position = end
-    if width is None or height is None or width == 0 or height == 0:
-        raise ValueError("stored PNG has empty dimensions")
-    if width >= 2**31 or height >= 2**31:
-        raise ValueError("stored PNG dimensions exceed the database limit")
-    if not saw_iend or not idat:
+    length = struct.unpack(">I", data[8:12])[0]
+    if data[12:16] != b"IHDR" or length != 13:
+        raise ValueError("stored object has no PNG header")
+    body = data[16:29]
+    if zlib.crc32(b"IHDR" + body) & 0xffffffff != struct.unpack(">I", data[29:33])[0]:
+        raise ValueError("stored object has a corrupt PNG header")
+    # The trailer is fixed width, so completeness costs nothing to check and a
+    # truncated upload is the likeliest real failure here.
+    if data[-8:-4] != b"IEND" or struct.unpack(">I", data[-12:-8])[0] != 0:
         raise ValueError("stored object is not a complete PNG")
-    # Decompress against a ceiling derived from the header, not to completion.
-    # A few hundred KB of IDAT expands to hundreds of MB, and this runs on the
-    # API event loop for output a worker chose, so an unbounded decompress here
-    # is a denial of service with a small upload behind it. A row cannot exceed
-    # one filter byte plus four channels of 16 bits per pixel.
-    limit = height * (1 + width * 8) + 1
-    stream = zlib.decompressobj()
-    try:
-        produced = len(stream.decompress(bytes(idat), limit))
-    except zlib.error as error:
-        raise ValueError("stored PNG data is not decodable") from error
-    if produced >= limit:
-        raise ValueError("stored PNG expands past its declared dimensions")
+    width, height = struct.unpack(">II", body[:8])
+    if width == 0 or height == 0:
+        raise ValueError("stored PNG has empty dimensions")
+    if width > MAX_IMAGE_EDGE or height > MAX_IMAGE_EDGE:
+        raise ValueError("stored PNG dimensions are implausible")
     return width, height
 
 
@@ -139,19 +129,25 @@ class LocalStorage:
         )
 
     async def image_info(self, key: str) -> ImageInfo | None:
-        path = self.path(key)
-        try:
-            if path.stat().st_size > MAX_VERIFY_BYTES:
+        def inspect() -> ImageInfo | None:
+            path = self.path(key)
+            try:
+                if path.stat().st_size > MAX_VERIFY_BYTES:
+                    return None
+                data = path.read_bytes()
+            except FileNotFoundError:
                 return None
-            data = path.read_bytes()
-        except FileNotFoundError:
-            return None
-        try:
-            width, height = _png_dimensions(data)
-        except ValueError:
-            return None
-        return ImageInfo(width=width, height=height, size=len(data),
-                         content_type=PNG_CONTENT_TYPE)
+            try:
+                width, height = _png_dimensions(data)
+            except ValueError:
+                return None
+            return ImageInfo(width=width, height=height, size=len(data),
+                             content_type=PNG_CONTENT_TYPE)
+
+        # Off the loop: the read is up to MAX_VERIFY_BYTES of peer-supplied
+        # bytes and every millisecond of it would otherwise stall every other
+        # request and socket on this process.
+        return await asyncio.to_thread(inspect)
 
     async def url(self, key: str, download_name: str | None = None) -> str:
         url = f"{self.public_url}/api/v1/files/{key}"
@@ -211,7 +207,7 @@ class S3Storage:
                 body.close()
 
         try:
-            response, data = read_object()
+            response, data = await asyncio.to_thread(read_object)
         except ClientError as error:
             code = error.response.get("Error", {}).get("Code")
             if code in ("404", "NoSuchKey", "NotFound"):

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -56,38 +56,70 @@ class ImageInfo:
     content_type: str
 
 
-# Generated output is one image. Both bounds are fixed here rather than derived
-# from the object, because the object is what a worker chose to upload: a
-# ceiling computed from a declared width and height is a ceiling the peer sets.
-MAX_IMAGE_EDGE = 16384
+# Both bounds are fixed here rather than derived from the object, because the
+# object is what a worker chose to upload: a ceiling computed from a declared
+# width and height is a ceiling the peer sets. 4096 is the real maximum, a
+# factor-4 upscale of the largest shipped generation size.
+MAX_IMAGE_EDGE = 4096
+# Enough for any real encoder, and it bounds the walk below.
+MAX_PNG_CHUNKS = 4096
+
+# Bit depths each PNG colour type allows (PNG spec, table 11.1).
+_PNG_DEPTHS = {0: {1, 2, 4, 8, 16}, 2: {8, 16}, 3: {1, 2, 4, 8}, 4: {8, 16}, 6: {8, 16}}
 
 
 def _png_dimensions(data: bytes) -> tuple[int, int]:
     """Dimensions of a stored PNG, or ValueError if it is not a usable one.
 
-    Structure only: signature, a well-formed IHDR, and an IEND at the end. It
-    does not decompress. An earlier version did, to prove the image decoded,
-    and that was twice a denial of service: unbounded it turned 400 KB into
-    831 MB, and bounded by the declared dimensions it granted an 80 GB ceiling
-    to a 65 KB object claiming to be 100000x100000. Deciding how much memory to
-    spend from a number the peer supplied cannot be made safe, and a real
-    decoder belongs off the event loop, so this checks what it can cheaply
-    check and the caller treats the result as a claim about shape, not proof
-    the pixels are good.
+    Walks the chunk structure and checks every CRC, but never decompresses.
+    An earlier version did, to prove the image decoded, and that was twice a
+    denial of service: unbounded it turned 400 KB into 831 MB, and bounded by
+    the declared dimensions it granted an 80 GB ceiling to a 65 KB object
+    claiming 100000x100000. Deciding how much memory to spend from a number the
+    peer supplied cannot be made safe, and a real decoder belongs off this path
+    entirely, so the guarantee here is that the bytes are a structurally
+    complete PNG of a plausible size, not that the pixels decode.
     """
     if len(data) < 45 or data[:8] != b"\x89PNG\r\n\x1a\n":
         raise ValueError("stored object is not a PNG")
-    length = struct.unpack(">I", data[8:12])[0]
-    if data[12:16] != b"IHDR" or length != 13:
-        raise ValueError("stored object has no PNG header")
-    body = data[16:29]
-    if zlib.crc32(b"IHDR" + body) & 0xffffffff != struct.unpack(">I", data[29:33])[0]:
-        raise ValueError("stored object has a corrupt PNG header")
-    # The trailer is fixed width, so completeness costs nothing to check and a
-    # truncated upload is the likeliest real failure here.
-    if data[-8:-4] != b"IEND" or struct.unpack(">I", data[-12:-8])[0] != 0:
+    position = 8
+    width = height = 0
+    chunks = 0
+    saw_idat = False
+    while position + 12 <= len(data):
+        chunks += 1
+        if chunks > MAX_PNG_CHUNKS:
+            raise ValueError("stored PNG has too many chunks")
+        length = struct.unpack(">I", data[position:position + 4])[0]
+        end = position + 12 + length
+        if end > len(data):
+            raise ValueError("stored object has a truncated PNG chunk")
+        kind = data[position + 4:position + 8]
+        body = data[position + 8:position + 8 + length]
+        if zlib.crc32(kind + body) & 0xffffffff != struct.unpack(">I", data[end - 4:end])[0]:
+            raise ValueError("stored object has a corrupt PNG chunk")
+        if chunks == 1:
+            if kind != b"IHDR" or length != 13:
+                raise ValueError("stored object does not start with a PNG header")
+            width, height = struct.unpack(">II", body[:8])
+            depth, colour, compression, filtering, interlace = body[8:13]
+            if colour not in _PNG_DEPTHS or depth not in _PNG_DEPTHS[colour]:
+                raise ValueError("stored PNG has an illegal colour type or bit depth")
+            if compression != 0 or filtering != 0 or interlace not in (0, 1):
+                raise ValueError("stored PNG declares an unknown encoding")
+        elif kind == b"IHDR":
+            raise ValueError("stored PNG repeats its header")
+        elif kind == b"IDAT":
+            saw_idat = True
+        elif kind == b"IEND":
+            if length != 0 or end != len(data):
+                raise ValueError("stored PNG does not end at its IEND")
+            break
+        position = end
+    else:
         raise ValueError("stored object is not a complete PNG")
-    width, height = struct.unpack(">II", body[:8])
+    if not saw_idat:
+        raise ValueError("stored PNG carries no image data")
     if width == 0 or height == 0:
         raise ValueError("stored PNG has empty dimensions")
     if width > MAX_IMAGE_EDGE or height > MAX_IMAGE_EDGE:

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -313,10 +313,19 @@ class S3Storage:
                     if entry.get("Key") == key
                 ]
                 for start in range(0, len(doomed), 1000):  # DeleteObjects caps at 1000
-                    self.client.delete_objects(
+                    response = self.client.delete_objects(
                         Bucket=self.bucket,
                         Delete={"Objects": doomed[start:start + 1000], "Quiet": True},
                     )
+                    # Quiet suppresses the successes, not the failures, and the
+                    # call answers 200 either way. Discarding this reports a
+                    # reclaim that did not happen.
+                    errors = response.get("Errors") or []
+                    if errors:
+                        raise RuntimeError(
+                            f"could not delete {len(errors)} version(s) of {key}: "
+                            f"{errors[0].get('Code')}"
+                        )
 
         await asyncio.to_thread(purge)
 

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -291,7 +291,34 @@ class S3Storage:
         return await self.url(key)
 
     async def delete(self, key: str) -> None:
-        await asyncio.to_thread(self.client.delete_object, Bucket=self.bucket, Key=key)
+        """Remove the object and, on a versioned bucket, its history.
+
+        delete_object without a VersionId writes a delete marker and keeps the
+        bytes as a noncurrent version, so on the cloud bucket, which has
+        versioning on, a plain delete hides the key and keeps billing for it.
+        The terminal paths in jobs.py delete to reclaim storage from a peer
+        that can upload whatever it likes, so hiding is not enough.
+
+        Listing by exact prefix and filtering is deliberate: list_object_versions
+        takes a prefix, not a key, and a bucket with u/j-attempt-1.png also has
+        u/j-attempt-10.png under that prefix.
+        """
+        def purge() -> None:
+            paginator = self.client.get_paginator("list_object_versions")
+            for page in paginator.paginate(Bucket=self.bucket, Prefix=key):
+                doomed = [
+                    {"Key": entry["Key"], "VersionId": entry["VersionId"]}
+                    for group in ("Versions", "DeleteMarkers")
+                    for entry in page.get(group, [])
+                    if entry.get("Key") == key
+                ]
+                for start in range(0, len(doomed), 1000):  # DeleteObjects caps at 1000
+                    self.client.delete_objects(
+                        Bucket=self.bucket,
+                        Delete={"Objects": doomed[start:start + 1000], "Quiet": True},
+                    )
+
+        await asyncio.to_thread(purge)
 
 
 @lru_cache

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -232,9 +232,21 @@ class S3Storage:
             response = self.client.get_object(Bucket=self.bucket, Key=key)
             body = response["Body"]
             try:
-                # amt bounds what a worker can make the API buffer: the
-                # presigned PUT constrains bucket, key and content type only.
-                return response, body.read(MAX_VERIFY_BYTES + 1)
+                # read(amt) returns at most amt, not exactly amt, so a short
+                # read would truncate a valid PNG into a rejection and let an
+                # oversized object slip past the length check below. Loop to
+                # EOF or one byte past the bound, which is what makes the
+                # bound mean anything: the presigned PUT constrains bucket,
+                # key and content type only, never size.
+                chunks = []
+                remaining = MAX_VERIFY_BYTES + 1
+                while remaining > 0:
+                    chunk = body.read(remaining)
+                    if not chunk:
+                        break
+                    chunks.append(chunk)
+                    remaining -= len(chunk)
+                return response, b"".join(chunks)
             finally:
                 body.close()
 

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -7,6 +7,8 @@ URL in the cloud, an internal API route (app/files.py) when local.
 
 import asyncio
 import re
+import struct
+import zlib
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -40,8 +42,73 @@ class UploadTarget:
     headers: dict[str, str] = field(default_factory=dict)
 
 
+# Outputs are one generated image; anything larger is not worth reading into
+# the API process to inspect. The local upload route already caps at 20 MB,
+# but a presigned S3 PUT carries no size condition.
+MAX_VERIFY_BYTES = 64 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class ImageInfo:
+    width: int
+    height: int
+    size: int
+    content_type: str
+
+
+def _png_dimensions(data: bytes) -> tuple[int, int]:
+    if len(data) < 33 or data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("stored object is not a PNG")
+    position = 8
+    width = height = None
+    idat = bytearray()
+    saw_iend = False
+    while position + 12 <= len(data):
+        length = struct.unpack(">I", data[position:position + 4])[0]
+        end = position + 12 + length
+        if end > len(data):
+            raise ValueError("stored object has a truncated PNG chunk")
+        kind = data[position + 4:position + 8]
+        body = data[position + 8:position + 8 + length]
+        checksum = struct.unpack(">I", data[position + 8 + length:end])[0]
+        if zlib.crc32(kind + body) & 0xffffffff != checksum:
+            raise ValueError("stored object has a corrupt PNG chunk")
+        if kind == b"IHDR":
+            if position != 8 or length != 13:
+                raise ValueError("stored object has no PNG dimensions")
+            width, height = struct.unpack(">II", body[:8])
+        elif kind == b"IDAT":
+            idat.extend(body)
+        elif kind == b"IEND":
+            saw_iend = length == 0
+            break
+        position = end
+    if width is None or height is None or width == 0 or height == 0:
+        raise ValueError("stored PNG has empty dimensions")
+    if width >= 2**31 or height >= 2**31:
+        raise ValueError("stored PNG dimensions exceed the database limit")
+    if not saw_iend or not idat:
+        raise ValueError("stored object is not a complete PNG")
+    # Decompress against a ceiling derived from the header, not to completion.
+    # A few hundred KB of IDAT expands to hundreds of MB, and this runs on the
+    # API event loop for output a worker chose, so an unbounded decompress here
+    # is a denial of service with a small upload behind it. A row cannot exceed
+    # one filter byte plus four channels of 16 bits per pixel.
+    limit = height * (1 + width * 8) + 1
+    stream = zlib.decompressobj()
+    try:
+        produced = len(stream.decompress(bytes(idat), limit))
+    except zlib.error as error:
+        raise ValueError("stored PNG data is not decodable") from error
+    if produced >= limit:
+        raise ValueError("stored PNG expands past its declared dimensions")
+    return width, height
+
+
 class Storage(Protocol):
     async def upload_target(self, key: str) -> UploadTarget: ...
+
+    async def image_info(self, key: str) -> ImageInfo | None: ...
 
     async def url(self, key: str, download_name: str | None = None) -> str: ...
 
@@ -70,6 +137,21 @@ class LocalStorage:
             url=f"{self.worker_url}/api/v1/files/{key}",
             headers={"Content-Type": content_type},
         )
+
+    async def image_info(self, key: str) -> ImageInfo | None:
+        path = self.path(key)
+        try:
+            if path.stat().st_size > MAX_VERIFY_BYTES:
+                return None
+            data = path.read_bytes()
+        except FileNotFoundError:
+            return None
+        try:
+            width, height = _png_dimensions(data)
+        except ValueError:
+            return None
+        return ImageInfo(width=width, height=height, size=len(data),
+                         content_type=PNG_CONTENT_TYPE)
 
     async def url(self, key: str, download_name: str | None = None) -> str:
         url = f"{self.public_url}/api/v1/files/{key}"
@@ -114,6 +196,39 @@ class S3Storage:
             ExpiresIn=SIGNED_URL_TTL,
         )
         return UploadTarget(url=url, headers={"Content-Type": content_type})
+
+    async def image_info(self, key: str) -> ImageInfo | None:
+        from botocore.exceptions import ClientError
+
+        def read_object() -> tuple[dict, bytes]:
+            response = self.client.get_object(Bucket=self.bucket, Key=key)
+            body = response["Body"]
+            try:
+                # amt bounds what a worker can make the API buffer: the
+                # presigned PUT constrains bucket, key and content type only.
+                return response, body.read(MAX_VERIFY_BYTES + 1)
+            finally:
+                body.close()
+
+        try:
+            response, data = read_object()
+        except ClientError as error:
+            code = error.response.get("Error", {}).get("Code")
+            if code in ("404", "NoSuchKey", "NotFound"):
+                return None
+            raise
+        if len(data) > MAX_VERIFY_BYTES:
+            return None
+        try:
+            width, height = _png_dimensions(data)
+        except ValueError:
+            return None
+        return ImageInfo(
+            width=width,
+            height=height,
+            size=response.get("ContentLength", len(data)),
+            content_type=response.get("ContentType", PNG_CONTENT_TYPE),
+        )
 
     async def url(self, key: str, download_name: str | None = None) -> str:
         params = {"Bucket": self.bucket, "Key": key}

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -590,6 +590,34 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
         get_settings.cache_clear()
 
 
+@pytest.mark.db
+def test_a_rejected_upload_is_not_left_in_storage():
+    """Verification rejecting the output must not leave the object behind.
+
+    No asset row ever names it, and the success path only collects earlier
+    attempts, so nothing else would. A worker can push an arbitrarily large
+    invalid object through the presigned PUT, which carries no size condition.
+    """
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-rejected-upload")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "rejected"}},
+            ).json()["job_id"]
+            dispatch = worker.receive_json()
+            upload_path = urlsplit(dispatch["upload"]["url"]).path
+            key = upload_path.rsplit("/api/v1/files/", 1)[-1]
+            assert client.put(upload_path, content=b"not a png at all").status_code == 200
+            storage = jobs.get_storage()
+            assert storage.path(key).exists()
+
+            worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                              "width": 512, "height": 512})
+            poll_until(client, job_id, "failed")
+            assert not storage.path(key).exists(), "rejected upload was left behind"
+
+
 async def _write_blob(storage, key, data):
     storage.path(key).parent.mkdir(parents=True, exist_ok=True)
     storage.path(key).write_bytes(data)

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -2,8 +2,10 @@
 real fleet WebSocket. Real inference is the worker's side (worker/tests)."""
 
 import asyncio
+import struct
 import time
 import uuid
+import zlib
 from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlsplit
 
@@ -42,6 +44,17 @@ MANIFEST_WITH_RT = {
 }
 
 HOSTILE_PROMPT = 'A "lighthouse"\n; ../../ caf\u00e9'
+
+
+def png_bytes(width=512, height=512):
+    def chunk(kind, data):
+        return (struct.pack(">I", len(data)) + kind + data
+                + struct.pack(">I", zlib.crc32(kind + data) & 0xffffffff))
+
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    rows = b"".join(b"\0" + b"\0" * (width * 3) for _ in range(height))
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", header)
+            + chunk(b"IDAT", zlib.compress(rows)) + chunk(b"IEND", b""))
 
 
 def test_generation_download_name_falls_back_to_model():
@@ -297,13 +310,15 @@ def test_generation_end_to_end():
             assert dispatch["type"] == "dispatch_job"
             assert dispatch["job_id"] == job_id
             assert dispatch["params"] == {"prompt": HOSTILE_PROMPT}
-            assert dispatch["upload"]["url"].endswith(f"/{job_id}.png")
+            assert dispatch["upload"]["url"].endswith(f"/{job_id}-attempt-1.png")
             assert dispatch["upload"]["headers"] == {"Content-Type": "image/png"}
-            assert dispatch["thumb_upload"]["url"].endswith(f"/{job_id}-thumb.webp")
+            assert dispatch["thumb_upload"]["url"].endswith(
+                f"/{job_id}-attempt-1-thumb.webp"
+            )
             assert dispatch["thumb_upload"]["headers"] == {"Content-Type": "image/webp"}
 
             upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=b"png-bytes").status_code == 200
+            assert client.put(upload_path, content=png_bytes(320, 240)).status_code == 200
             thumb_path = urlsplit(dispatch["thumb_upload"]["url"]).path
             assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
 
@@ -315,20 +330,21 @@ def test_generation_end_to_end():
             job = poll_until(client, job_id, "succeeded")
             assert job["gpu_ms"] == 1234
             asset = job["assets"][0]
-            assert asset["width"] == 512
+            assert asset["width"] == 320
+            assert asset["height"] == 240
             assert asset["mime"] == "image/png"
-            assert asset["url"].endswith(f"/{job_id}.png")
+            assert asset["url"].endswith(f"/{job_id}-attempt-1.png")
             created_stamp = datetime.fromisoformat(job["created_at"]).strftime("%Y%m%d-%H%M%S")
             expected_name = f"potocolom-{created_stamp}-a-lighthouse-cafe.png"
             download_url = urlsplit(asset["download_url"])
             assert parse_qs(download_url.query) == {"download": [expected_name]}
             download_response = client.get(f"{download_url.path}?{download_url.query}")
-            assert download_response.content == b"png-bytes"
+            assert download_response.content == png_bytes(320, 240)
             assert download_response.headers["content-disposition"] == (
                 f'attachment; filename="{expected_name}"'
             )
             assert asset["thumbnail_url"] is not None
-            assert client.get(urlsplit(asset["url"]).path).content == b"png-bytes"
+            assert client.get(urlsplit(asset["url"]).path).content == png_bytes(320, 240)
             assert client.get(urlsplit(asset["thumbnail_url"]).path).content == b"thumb-bytes"
 
             history = client.get("/api/v1/generations").json()
@@ -505,6 +521,112 @@ def test_stalled_job_requeues_once(monkeypatch):
 
 
 @pytest.mark.db
+def test_retried_attempt_uses_a_new_upload_key_and_rejects_the_old_key(monkeypatch):
+    monkeypatch.setenv("JOB_STALL_SECONDS", "0.05")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-attempt-keys")
+                job_id = client.post(
+                    "/api/v1/generations",
+                    json={"model_id": "sd-test", "params": {"prompt": "keys"}},
+                ).json()["job_id"]
+                first = worker.receive_json()
+                first_path = urlsplit(first["upload"]["url"]).path
+
+                poll_until_attempt(client, job_id, 2, timeout=3.0)
+                second = worker.receive_json()
+                second_path = urlsplit(second["upload"]["url"]).path
+                assert first_path != second_path
+                assert client.put(first_path, content=b"stale").status_code == 403
+                assert client.put(second_path, content=png_bytes()).status_code == 200
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
+
+
+@pytest.mark.db
+def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
+    """Per-attempt keys stop a stale worker overwriting the winner, and start
+    leaking: the earlier attempt's blobs are no longer overwritten and nothing
+    else collects them, because the asset row only ever names the winning key.
+    """
+    monkeypatch.setenv("JOB_STALL_SECONDS", "0.05")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-attempt-orphans")
+                job_id = client.post(
+                    "/api/v1/generations",
+                    json={"model_id": "sd-test", "params": {"prompt": "orphans"}},
+                ).json()["job_id"]
+                first = worker.receive_json()
+                first_path = urlsplit(first["upload"]["url"]).path
+                first_thumb = urlsplit(first["thumb_upload"]["url"]).path
+
+                poll_until_attempt(client, job_id, 2, timeout=3.0)
+                second = worker.receive_json()
+                # The first attempt uploaded before it stalled.
+                storage = jobs.get_storage()
+                first_key = first_path.rsplit("/api/v1/files/", 1)[-1]
+                first_thumb_key = first_thumb.rsplit("/api/v1/files/", 1)[-1]
+                asyncio.run(_write_blob(storage, first_key, png_bytes()))
+                asyncio.run(_write_blob(storage, first_thumb_key, png_bytes()))
+
+                assert client.put(urlsplit(second["upload"]["url"]).path,
+                                  content=png_bytes()).status_code == 200
+                worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                                  "width": 512, "height": 512})
+                poll_until(client, job_id, "succeeded")
+
+                assert asyncio.run(storage.image_info(first_key)) is None
+                assert asyncio.run(storage.image_info(first_thumb_key)) is None
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
+
+
+async def _write_blob(storage, key, data):
+    storage.path(key).parent.mkdir(parents=True, exist_ok=True)
+    storage.path(key).write_bytes(data)
+
+
+@pytest.mark.db
+def test_malformed_completion_is_recoverable_through_the_fleet_socket(monkeypatch):
+    original_worker_int = jobs._worker_int
+
+    def raise_for_mapping(value, default=0):
+        if isinstance(value, dict):
+            raise ValueError("malformed worker number")
+        return original_worker_int(value, default)
+
+    monkeypatch.setattr(jobs, "_worker_int", raise_for_mapping)
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-malformed-done")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "malformed"}},
+            ).json()["job_id"]
+            worker.receive_json()
+            worker.send_json({
+                "type": "job_done",
+                "job_id": job_id,
+                "gpu_ms": {"not": "a number"},
+                "width": 512,
+                "height": 512,
+            })
+
+            job = poll_until_attempt(client, job_id, 2, timeout=3.0)
+            assert job["state"] == "queued"
+            assert uuid.UUID(job_id) not in jobs.inflight
+
+
+@pytest.mark.db
 def test_recover_requeues_running_and_dispatches_queued():
     async def prepare() -> tuple[uuid.UUID, uuid.UUID]:
         if not await db.connect():
@@ -527,7 +649,7 @@ def test_recover_requeues_running_and_dispatches_queued():
             first_id = first["job_id"]
 
             upload_path = urlsplit(first["upload"]["url"]).path
-            assert client.put(upload_path, content=b"png-bytes").status_code == 200
+            assert client.put(upload_path, content=png_bytes()).status_code == 200
             thumb_path = urlsplit(first["thumb_upload"]["url"]).path
             assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
             worker.send_json({"type": "job_done", "job_id": first_id,
@@ -555,7 +677,7 @@ def test_img2img_dispatch_includes_input_url():
 
             dispatch = worker.receive_json()
             upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=b"source-png").status_code == 200
+            assert client.put(upload_path, content=png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
                               "gpu_ms": 100, "width": 512, "height": 512})
             source_job = poll_until(client, source_job_id, "succeeded")
@@ -573,10 +695,10 @@ def test_img2img_dispatch_includes_input_url():
             assert i2i_dispatch["job_id"] == edit_job_id
             assert "input" in i2i_dispatch
             input_path = urlsplit(i2i_dispatch["input"]["url"]).path
-            assert client.get(input_path).content == b"source-png"
+            assert client.get(input_path).content == png_bytes()
 
             assert client.put(urlsplit(i2i_dispatch["upload"]["url"]).path,
-                              content=b"edited-png").status_code == 200
+                              content=png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": edit_job_id,
                               "gpu_ms": 200, "width": 512, "height": 512})
             edit_job = poll_until(client, edit_job_id, "succeeded")
@@ -596,7 +718,7 @@ def test_img2img_rejects_model_without_capability():
             job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
             upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=b"source").status_code == 200
+            assert client.put(upload_path, content=png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 1, "width": 512, "height": 512})
             source_job = poll_until(client, job_id, "succeeded")
@@ -633,7 +755,7 @@ def test_upscale_dispatch_includes_input_url():
             source_job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
             assert client.put(urlsplit(dispatch["upload"]["url"]).path,
-                              content=b"source-png").status_code == 200
+                              content=png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
                               "gpu_ms": 50, "width": 512, "height": 512})
             source_asset_id = poll_until(client, source_job_id, "succeeded")["assets"][0]["id"]
@@ -660,10 +782,12 @@ def test_upscale_dispatch_includes_input_url():
             assert up_dispatch["job_id"] == upscale_job_id
             assert up_dispatch["params"] == {"factor": 2}
             assert "input" in up_dispatch
-            assert client.get(urlsplit(up_dispatch["input"]["url"]).path).content == b"source-png"
+            assert client.get(urlsplit(up_dispatch["input"]["url"]).path).content == png_bytes()
 
+            # Upload the real upscaled image: the asset row takes its
+            # dimensions from the object now, not from the worker's claim.
             assert client.put(urlsplit(up_dispatch["upload"]["url"]).path,
-                              content=b"upscaled-png").status_code == 200
+                              content=png_bytes(1024, 1024)).status_code == 200
             worker.send_json({"type": "job_done", "job_id": upscale_job_id,
                               "gpu_ms": 400, "width": 1024, "height": 1024})
             done = poll_until(client, upscale_job_id, "succeeded")
@@ -763,7 +887,7 @@ def test_job_phase_timings_persisted():
             job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
             upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=b"png-bytes").status_code == 200
+            assert client.put(upload_path, content=png_bytes()).status_code == 200
 
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 900, "input_fetch_ms": 50,
@@ -833,7 +957,7 @@ def _wait_for_dispatch(worker, expected: set[str], timeout=5.0) -> dict:
 
 def _finish_job(client, worker, dispatch: dict) -> None:
     upload_path = urlsplit(dispatch["upload"]["url"]).path
-    assert client.put(upload_path, content=b"png-bytes").status_code == 200
+    assert client.put(upload_path, content=png_bytes()).status_code == 200
     worker.send_json({"type": "job_done", "job_id": dispatch["job_id"],
                       "gpu_ms": 1, "width": 512, "height": 512})
     poll_until(client, dispatch["job_id"], "succeeded")

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -592,6 +592,37 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
 
 
 @pytest.mark.db
+def test_a_reported_failure_does_not_leave_its_upload_behind():
+    """job_failed never calls image_info, so nothing bounds or collects it.
+
+    A worker can upload a master and a thumbnail and then report a failure. No
+    asset row names those objects and the success path never runs, so the
+    terminal failure path is their only collector.
+    """
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-failed-upload")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "failed"}},
+            ).json()["job_id"]
+            dispatch = worker.receive_json()
+            upload_path = urlsplit(dispatch["upload"]["url"]).path
+            key = upload_path.rsplit("/api/v1/files/", 1)[-1]
+            assert client.put(upload_path, content=png_bytes()).status_code == 200
+            storage = jobs.get_storage()
+            assert storage.path(key).exists()
+
+            worker.send_json({"type": "job_failed", "job_id": job_id,
+                              "reason": "worker said no"})
+            poll_until(client, job_id, "failed")
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline and storage.path(key).exists():
+                time.sleep(0.05)
+            assert not storage.path(key).exists(), "a reported failure kept its upload"
+
+
+@pytest.mark.db
 def test_a_late_verdict_does_not_fail_the_attempt_that_replaced_it(monkeypatch):
     """image_info awaits a thread, so the attempt can change under it.
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -591,6 +591,64 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
 
 
 @pytest.mark.db
+def test_a_late_verdict_does_not_fail_the_attempt_that_replaced_it(monkeypatch):
+    """image_info awaits a thread, so the attempt can change under it.
+
+    A stalled attempt one whose inspection finally returns invalid would
+    otherwise pop attempt two, fail the authoritative row, and delete attempt
+    two's objects. The replacement is simulated inside image_info rather than
+    by timing, so the ordering is deterministic.
+    """
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-late-verdict")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "late"}},
+            ).json()["job_id"]
+            dispatch = worker.receive_json()
+            assert client.put(urlsplit(dispatch["upload"]["url"]).path,
+                              content=png_bytes()).status_code == 200
+            key = uuid.UUID(job_id)
+            superseded = jobs.inflight[key]
+            replacement = jobs.InFlight(
+                worker=superseded.worker, storage_key="replacement.png",
+                thumb_storage_key="replacement-thumb.webp",
+                user_id=superseded.user_id, attempt=2,
+            )
+            real_storage = jobs.get_storage()
+
+            class Replacing:
+                """Stands in for storage; swaps the entry mid-inspection."""
+
+                def __getattr__(self, name):
+                    return getattr(real_storage, name)
+
+                async def image_info(self, storage_key):
+                    jobs.inflight[key] = replacement
+                    return None  # the late verdict: attempt one was invalid
+
+            monkeypatch.setattr(jobs, "get_storage", lambda: Replacing())
+            worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                              "width": 512, "height": 512})
+
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                assert jobs.inflight.get(key) is replacement, "the replacement was popped"
+                time.sleep(0.05)
+            state = client.get(f"/api/v1/generations/{job_id}").json()["state"]
+            assert state != "failed", "a superseded attempt failed the live row"
+
+            # Let the job finish so it does not sit running in the shared
+            # database and starve the dispatch loop for every test after this.
+            monkeypatch.undo()
+            jobs.inflight[key] = superseded
+            worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                              "width": 512, "height": 512})
+            poll_until(client, job_id, "succeeded")
+
+
+@pytest.mark.db
 def test_a_rejected_upload_is_not_left_in_storage():
     """Verification rejecting the output must not leave the object behind.
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -3,6 +3,7 @@ real fleet WebSocket. Real inference is the worker's side (worker/tests)."""
 
 import asyncio
 import struct
+import threading
 import time
 import uuid
 import zlib
@@ -626,16 +627,23 @@ def test_a_late_verdict_does_not_fail_the_attempt_that_replaced_it(monkeypatch):
 
                 async def image_info(self, storage_key):
                     jobs.inflight[key] = replacement
-                    return None  # the late verdict: attempt one was invalid
+                    try:
+                        return None  # the late verdict: attempt one was invalid
+                    finally:
+                        inspected.set()
 
+            inspected = threading.Event()
             monkeypatch.setattr(jobs, "get_storage", lambda: Replacing())
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
                               "width": 512, "height": 512})
 
-            deadline = time.monotonic() + 2
-            while time.monotonic() < deadline:
-                assert jobs.inflight.get(key) is replacement, "the replacement was popped"
-                time.sleep(0.05)
+            # The stand-in gives a deterministic hook, so wait on the verdict
+            # rather than polling a negative for two seconds on every run.
+            assert inspected.wait(timeout=5), "the output was never inspected"
+            deadline = time.monotonic() + 0.5
+            while time.monotonic() < deadline and jobs.inflight.get(key) is replacement:
+                time.sleep(0.02)
+            assert jobs.inflight.get(key) is replacement, "the replacement was popped"
             state = client.get(f"/api/v1/generations/{job_id}").json()["state"]
             assert state != "failed", "a superseded attempt failed the live row"
 

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -433,9 +433,10 @@ def test_job_dispatch_and_finish_timestamps():
             deadline = time.monotonic() + 3.0
             while time.monotonic() < deadline:
                 job = asyncio.run(read_job())
-                if job.state == "succeeded":
+                if job.state in ("failed", "succeeded"):
                     break
                 time.sleep(0.05)
+            assert job.state == "failed"
             assert job.finished_at is not None
 
 

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -232,13 +232,40 @@ def test_worker_relay_requires_its_session_and_generated_frames():
 
                 worker_ws.send_json({"type": "session_ready", "session_id": session_id})
                 assert browser_ws.receive_json()["type"] == "ready"
-                worker_ws.send_bytes(
-                    bytes([CANVAS_FRAME]) + uuid.UUID(session_id).bytes + b"not-generated"
-                )
                 generated = bytes([GENERATED_FRAME]) + uuid.UUID(session_id).bytes + b"owned"
                 worker_ws.send_bytes(generated)
+                # Arrives after the foreign frame above was dropped, which is
+                # what proves the drop: a relayed foreign frame would be read
+                # here instead.
                 assert browser_ws.receive_bytes() == generated
                 assert session.worker is realtime.workers["w-session-owner"]
+
+
+def test_assigned_worker_sending_a_canvas_frame_is_a_protocol_violation():
+    """A non-owner's frame is dropped, because reassignment races produce those.
+
+    The assigned worker sending a canvas frame is not a race: nothing in the
+    protocol lets a worker send that direction, so it closes 4000 rather than
+    being ignored while the peer stays connected.
+    """
+    with client.websocket_connect("/api/v1/fleet") as worker_ws:
+        worker_ws.send_json(hello(worker_id="w-wrong-kind"))
+        assert worker_ws.receive_json()["type"] == "registered"
+        with client.websocket_connect("/api/v1/realtime") as browser_ws:
+            browser_ws.send_json({"type": "open", "model_id": "sd-sim"})
+            session_id = worker_ws.receive_json()["session_id"]
+            worker_ws.send_json({"type": "session_ready", "session_id": session_id})
+            assert browser_ws.receive_json()["type"] == "ready"
+            worker_ws.send_bytes(
+                bytes([CANVAS_FRAME]) + uuid.UUID(session_id).bytes + b"wrong-direction"
+            )
+            # Deadline rather than a blocking receive: with the check removed
+            # the frame is merely ignored and receive_json would hang forever,
+            # which is a worse failure than a red test.
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline and "w-wrong-kind" in realtime.workers:
+                time.sleep(0.05)
+            assert "w-wrong-kind" not in realtime.workers, "the violation was ignored"
 
 
 @pytest.mark.db
@@ -537,3 +564,59 @@ def test_hello_refusal_reason_fits_a_close_frame():
             assert closed.value.code == realtime.CLOSE_PROTOCOL_VIOLATION
             encoded = (closed.value.reason or "").encode("utf-8")
             assert len(encoded) <= 123, f"{bad_id[:8]}: {len(encoded)} bytes"
+
+
+@pytest.mark.db
+def test_session_closed_from_another_worker_is_ignored():
+    """The last session-scoped message still routed by UUID alone.
+
+    A worker that held this session earlier still knows its id. Popping the
+    entry on its word drops the current owner's accounting and bills this user
+    for a session it did not run.
+
+    Asserted through the persisted event rather than the in-memory dict: the
+    two sockets are separate tasks, so any assertion timed against a send is a
+    race, and a racy test passes with the check removed.
+    """
+    with TestClient(app) as db_client, \
+            db_client.websocket_connect("/api/v1/fleet") as owner_ws:
+        owner_ws.send_json(hello(worker_id="w-closing-owner"))
+        assert owner_ws.receive_json()["type"] == "registered"
+        with db_client.websocket_connect("/api/v1/fleet") as other_ws:
+            other_ws.send_json(hello(worker_id="w-closing-other"))
+            assert other_ws.receive_json()["type"] == "registered"
+            with db_client.websocket_connect("/api/v1/realtime") as browser_ws:
+                browser_ws.send_json({"type": "open", "model_id": "sd-sim"})
+                session_id = owner_ws.receive_json()["session_id"]
+                owner_ws.send_json({"type": "session_ready", "session_id": session_id})
+                assert browser_ws.receive_json()["type"] == "ready"
+            assert owner_ws.receive_json()["type"] == "close_session"
+
+            async def recorded():
+                assert db.session_factory is not None
+                async with db.session_factory() as session:
+                    rows = (await session.execute(
+                        select(UsageEvent).where(
+                            UsageEvent.kind == "realtime",
+                            UsageEvent.duration_ms.in_((700, 9999)),
+                        )
+                    )).scalars().all()
+                    return [row.frames for row in rows]
+
+            # The stranger acts alone, so nothing races it: give the server a
+            # window in which its claim would have been written, then check.
+            other_ws.send_json({"type": "session_closed", "session_id": session_id,
+                                "frames": 9999, "gpu_ms": 9999, "duration_ms": 9999,
+                                "category": "other"})
+            deadline = time.monotonic() + 1.5
+            while time.monotonic() < deadline:
+                assert 9999 not in asyncio.run(recorded()), "a stranger closed the session"
+                time.sleep(0.05)
+
+            owner_ws.send_json({"type": "session_closed", "session_id": session_id,
+                                "frames": 7, "gpu_ms": 70, "duration_ms": 700,
+                                "category": "other"})
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline and 7 not in asyncio.run(recorded()):
+                time.sleep(0.05)
+            assert 7 in asyncio.run(recorded()), "the owner's close was not recorded"

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -225,10 +225,18 @@ def test_worker_relay_requires_its_session_and_generated_frames():
                 session = realtime.sessions[uuid.UUID(session_id)]
 
                 other_worker_ws.send_json({"type": "session_ready", "session_id": session_id})
-                assert not session.ready.is_set()
                 other_worker_ws.send_bytes(
                     bytes([GENERATED_FRAME]) + uuid.UUID(session_id).bytes + b"foreign"
                 )
+                # Barrier on the stranger's own socket: a connection processes
+                # its messages in order, so once this violation has closed it
+                # the two above have been handled. Asserting straight after a
+                # send is a race that passes with the guard removed.
+                other_worker_ws.send_text("not json at all")
+                with pytest.raises(WebSocketDisconnect) as closed:
+                    other_worker_ws.receive_json()
+                assert closed.value.code == realtime.CLOSE_PROTOCOL_VIOLATION
+                assert not session.ready.is_set(), "a stranger readied the session"
 
                 worker_ws.send_json({"type": "session_ready", "session_id": session_id})
                 assert browser_ws.receive_json()["type"] == "ready"

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -211,6 +211,36 @@ def test_session_and_frame_relay_both_directions():
             assert browser_ws.receive_bytes() == generated
 
 
+def test_worker_relay_requires_its_session_and_generated_frames():
+    with client.websocket_connect("/api/v1/fleet") as worker_ws:
+        worker_ws.send_json(hello(worker_id="w-session-owner"))
+        assert worker_ws.receive_json()["type"] == "registered"
+        with client.websocket_connect("/api/v1/fleet") as other_worker_ws:
+            other_worker_ws.send_json(hello(worker_id="w-session-other"))
+            assert other_worker_ws.receive_json()["type"] == "registered"
+            with client.websocket_connect("/api/v1/realtime") as browser_ws:
+                browser_ws.send_json({"type": "open", "model_id": "sd-sim"})
+                opened = worker_ws.receive_json()
+                session_id = opened["session_id"]
+                session = realtime.sessions[uuid.UUID(session_id)]
+
+                other_worker_ws.send_json({"type": "session_ready", "session_id": session_id})
+                assert not session.ready.is_set()
+                other_worker_ws.send_bytes(
+                    bytes([GENERATED_FRAME]) + uuid.UUID(session_id).bytes + b"foreign"
+                )
+
+                worker_ws.send_json({"type": "session_ready", "session_id": session_id})
+                assert browser_ws.receive_json()["type"] == "ready"
+                worker_ws.send_bytes(
+                    bytes([CANVAS_FRAME]) + uuid.UUID(session_id).bytes + b"not-generated"
+                )
+                generated = bytes([GENERATED_FRAME]) + uuid.UUID(session_id).bytes + b"owned"
+                worker_ws.send_bytes(generated)
+                assert browser_ws.receive_bytes() == generated
+                assert session.worker is realtime.workers["w-session-owner"]
+
+
 @pytest.mark.db
 def test_closed_session_persists_usage_event():
     with TestClient(app) as db_client:

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -108,10 +108,12 @@ class _FakePaginator:
 
 
 class _FakeS3Client:
-    def __init__(self, data, pages=None):
+    def __init__(self, data, pages=None, delete_response=None):
         self.data = data
         self.pages = pages or []
         self.deleted: list[dict] = []
+        # DeleteObjects answers 200 with an Errors list on partial failure.
+        self.delete_response = delete_response or {}
 
     def get_object(self, **kwargs):
         return {
@@ -126,7 +128,7 @@ class _FakeS3Client:
 
     def delete_objects(self, **kwargs):
         self.deleted.extend(kwargs["Delete"]["Objects"])
-        return {}
+        return dict(self.delete_response)
 
 
 def test_s3_storage_reads_uploaded_image_info():
@@ -380,3 +382,23 @@ def test_s3_delete_is_quiet_on_an_unversioned_bucket():
     empty.client = _FakeS3Client(b"", pages=[{}])
     asyncio.run(empty.delete("u/absent.png"))
     assert empty.client.deleted == []
+
+
+def test_s3_delete_raises_when_a_version_could_not_be_removed():
+    """DeleteObjects answers 200 with an Errors list on partial failure.
+
+    Quiet suppresses the successes, not the failures. Discarding the response
+    reports a reclaim that did not happen, and the caller then logs nothing.
+    """
+    storage = S3Storage.__new__(S3Storage)
+    storage.bucket = "bucket"
+    key = "u/j-attempt-1.png"
+    storage.client = _FakeS3Client(
+        b"",
+        pages=[{"Versions": [{"Key": key, "VersionId": "v1"}]}],
+        delete_response={"Errors": [{"Key": key, "VersionId": "v1",
+                                     "Code": "AccessDenied",
+                                     "Message": "Access Denied"}]},
+    )
+    with pytest.raises(RuntimeError, match="AccessDenied"):
+        asyncio.run(storage.delete(key))

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -81,9 +81,14 @@ class _FakeBody:
         self.closed = False
 
     def read(self, amt=None):
-        # botocore's StreamingBody takes an amt; image_info passes one to bound
-        # what a worker can make the API buffer.
-        return self.data if amt is None else self.data[:amt]
+        # botocore's StreamingBody takes an amt and returns at most that many,
+        # not exactly that many. Hand back one byte at a time so a caller that
+        # assumes a single read fills its buffer is caught here.
+        if amt is None:
+            data, self.data = self.data, b""
+            return data
+        data, self.data = self.data[:1], self.data[1:]
+        return data[:amt]
 
     def close(self):
         self.closed = True

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -9,7 +9,13 @@ from fastapi.testclient import TestClient
 from app.files import MAX_UPLOAD_BYTES
 from app.main import app
 from app.settings import Settings
-from app.storage import MAX_VERIFY_BYTES, LocalStorage, S3Storage, get_storage
+from app.storage import (
+    MAX_IMAGE_EDGE,
+    MAX_VERIFY_BYTES,
+    LocalStorage,
+    S3Storage,
+    get_storage,
+)
 
 client = TestClient(app)
 
@@ -244,3 +250,60 @@ def test_image_info_refuses_an_oversized_object(tmp_path, monkeypatch):
     monkeypatch.setattr("app.storage.MAX_VERIFY_BYTES", 8)
     assert asyncio.run(storage.image_info("big.png")) is None
     assert MAX_VERIFY_BYTES > 1024 * 1024
+
+
+def _chunk(kind, body):
+    return (struct.pack(">I", len(body)) + kind + body
+            + struct.pack(">I", zlib.crc32(kind + body) & 0xffffffff))
+
+
+def _header(width, height, depth=8, colour=2, interlace=0):
+    return struct.pack(">IIBBBBB", width, height, depth, colour, 0, 0, interlace)
+
+
+def test_image_info_requires_a_structurally_complete_png(tmp_path):
+    """Checking the header and the last twelve bytes is not structure.
+
+    An IHDR followed by arbitrary bytes and a trailer-shaped tail passed that,
+    so junk was persisted as a successful archival image/png. The walk checks
+    every chunk boundary and CRC without decompressing anything.
+    """
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    sig = b"\x89PNG\r\n\x1a\n"
+    idat = zlib.compress(b"".join(b"\0" + b"\0" * (16 * 3) for _ in range(16)))
+    good = sig + _chunk(b"IHDR", _header(16, 16)) + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")
+
+    bad = {
+        "junk-between": sig + _chunk(b"IHDR", _header(16, 16)) + b"\x00" * 40
+                        + _chunk(b"IEND", b""),
+        "no-idat": sig + _chunk(b"IHDR", _header(16, 16)) + _chunk(b"IEND", b""),
+        "repeat-header": sig + _chunk(b"IHDR", _header(16, 16))
+                         + _chunk(b"IHDR", _header(16, 16)) + _chunk(b"IDAT", idat)
+                         + _chunk(b"IEND", b""),
+        "illegal-depth": sig + _chunk(b"IHDR", _header(16, 16, depth=3))
+                         + _chunk(b"IDAT", idat) + _chunk(b"IEND", b""),
+        "trailing-bytes": good + b"appended",
+        # Same length and kind, one byte of the body changed: only the CRC
+        # tells you the object is damaged.
+        "corrupt-crc": good[:len(sig) + 8 + 13 + 4 + 8] + bytes([good[len(sig) + 8 + 13 + 4 + 8] ^ 0xff])
+                       + good[len(sig) + 8 + 13 + 4 + 9:],
+        "over-edge": sig + _chunk(b"IHDR", _header(MAX_IMAGE_EDGE + 1, 16))
+                     + _chunk(b"IDAT", idat) + _chunk(b"IEND", b""),
+    }
+    for name, data in bad.items():
+        (tmp_path / f"{name}.png").write_bytes(data)
+        assert asyncio.run(storage.image_info(f"{name}.png")) is None, name
+
+    for name, data in {"good": good,
+                       "at-edge": sig + _chunk(b"IHDR", _header(MAX_IMAGE_EDGE, 16))
+                                  + _chunk(b"IDAT", idat) + _chunk(b"IEND", b""),
+                       "interlaced": sig + _chunk(b"IHDR", _header(16, 16, interlace=1))
+                                     + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")}.items():
+        (tmp_path / f"{name}.png").write_bytes(data)
+        assert asyncio.run(storage.image_info(f"{name}.png")) is not None, name
+
+
+def test_max_image_edge_matches_the_largest_real_output():
+    # A factor-4 upscale of the largest shipped generation size. Anything more
+    # only moves the memory question to whatever decodes the file later.
+    assert MAX_IMAGE_EDGE == 4096

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,4 +1,6 @@
 import asyncio
+import struct
+import zlib
 from urllib.parse import parse_qs, urlsplit
 
 import pytest
@@ -7,9 +9,20 @@ from fastapi.testclient import TestClient
 from app.files import MAX_UPLOAD_BYTES
 from app.main import app
 from app.settings import Settings
-from app.storage import LocalStorage, S3Storage, get_storage
+from app.storage import MAX_VERIFY_BYTES, LocalStorage, S3Storage, get_storage
 
 client = TestClient(app)
+
+
+def png_bytes(width=3, height=2):
+    def chunk(kind, data):
+        return (struct.pack(">I", len(data)) + kind + data
+                + struct.pack(">I", zlib.crc32(kind + data) & 0xffffffff))
+
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    rows = b"".join(b"\0" + b"\0" * (width * 3) for _ in range(height))
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", header)
+            + chunk(b"IDAT", zlib.compress(rows)) + chunk(b"IEND", b""))
 
 
 def test_local_storage_rejects_escaping_keys(tmp_path):
@@ -32,6 +45,67 @@ def test_local_storage_urls(tmp_path):
     assert parse_qs(urlsplit(download_url).query) == {
         "download": ["potocolom-20260729-142530-castle.png"],
     }
+
+
+def test_local_storage_reads_uploaded_image_info(tmp_path):
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    path = storage.path("u/j.png")
+    path.parent.mkdir(parents=True)
+    data = png_bytes()
+    path.write_bytes(data)
+
+    info = asyncio.run(storage.image_info("u/j.png"))
+    assert info is not None
+    assert (info.width, info.height, info.size, info.content_type) == (
+        3, 2, len(data), "image/png",
+    )
+    assert asyncio.run(storage.image_info("u/missing.png")) is None
+    path.write_bytes(b"not an image")
+    assert asyncio.run(storage.image_info("u/j.png")) is None
+    oversized = bytearray(data)
+    struct.pack_into(">I", oversized, 16, 2**31)
+    struct.pack_into(">I", oversized, 29, zlib.crc32(oversized[12:29]) & 0xffffffff)
+    path.write_bytes(oversized)
+    assert asyncio.run(storage.image_info("u/j.png")) is None
+
+
+class _FakeBody:
+    def __init__(self, data):
+        self.data = data
+        self.closed = False
+
+    def read(self, amt=None):
+        # botocore's StreamingBody takes an amt; image_info passes one to bound
+        # what a worker can make the API buffer.
+        return self.data if amt is None else self.data[:amt]
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeS3Client:
+    def __init__(self, data):
+        self.data = data
+
+    def get_object(self, **kwargs):
+        return {
+            "Body": _FakeBody(self.data),
+            "ContentLength": len(self.data),
+            "ContentType": "image/png",
+        }
+
+
+def test_s3_storage_reads_uploaded_image_info():
+    storage = S3Storage.__new__(S3Storage)
+    storage.bucket = "bucket"
+    data = png_bytes(5, 7)
+    storage.client = _FakeS3Client(data)
+
+    info = asyncio.run(storage.image_info("u/j.png"))
+    assert info is not None
+    assert (info.width, info.height, info.size, info.content_type) == (
+        5, 7, len(data), "image/png",
+    )
 
 
 def test_s3_storage_presigns_offline():
@@ -105,3 +179,44 @@ def test_upload_ceiling_admits_a_lossless_upscale_master():
     """
     pixels = (1024 * 4) ** 2
     assert MAX_UPLOAD_BYTES >= pixels * 3  # raw RGB, which PNG does not exceed in practice
+
+
+def _png(width, height, idat):
+    def chunk(kind, data):
+        return (struct.pack(">I", len(data)) + kind + data
+                + struct.pack(">I", zlib.crc32(kind + data) & 0xffffffff))
+
+    header = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", header)
+            + chunk(b"IDAT", idat) + chunk(b"IEND", b""))
+
+
+def test_image_info_refuses_a_decompression_bomb(tmp_path):
+    """Validating the output must not be a way to exhaust the API.
+
+    The IDAT of a structurally valid PNG can be a zip bomb: 400 KB on the wire
+    expanded to 831 MB in process before this was bounded, and the parser
+    reported it as a well-formed 16x16 image. The ceiling comes from the
+    declared dimensions, so a genuine image of that size still passes.
+    """
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    bomb = zlib.compress(b"\x00" * (64 * 1024 * 1024), 9)
+    (tmp_path / "bomb.png").write_bytes(_png(16, 16, bomb))
+    assert len(_png(16, 16, bomb)) < 100_000
+    assert asyncio.run(storage.image_info("bomb.png")) is None
+
+    rows = b"".join(b"\0" + b"\0" * (16 * 3) for _ in range(16))
+    (tmp_path / "real.png").write_bytes(_png(16, 16, zlib.compress(rows)))
+    info = asyncio.run(storage.image_info("real.png"))
+    assert (info.width, info.height) == (16, 16)
+
+
+def test_image_info_refuses_an_oversized_object(tmp_path, monkeypatch):
+    # The local PUT route caps uploads, but a presigned S3 PUT carries no size
+    # condition, so the inspection itself has to refuse to buffer the object.
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    rows = b"".join(b"\0" + b"\0" * (16 * 3) for _ in range(16))
+    (tmp_path / "big.png").write_bytes(_png(16, 16, zlib.compress(rows)))
+    monkeypatch.setattr("app.storage.MAX_VERIFY_BYTES", 8)
+    assert asyncio.run(storage.image_info("big.png")) is None
+    assert MAX_VERIFY_BYTES > 1024 * 1024

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -94,9 +94,24 @@ class _FakeBody:
         self.closed = True
 
 
+class _FakePaginator:
+    def __init__(self, pages):
+        self.pages = pages
+
+    def paginate(self, **kwargs):
+        prefix = kwargs.get("Prefix", "")
+        for page in self.pages:
+            yield {
+                group: [e for e in page.get(group, []) if e["Key"].startswith(prefix)]
+                for group in ("Versions", "DeleteMarkers")
+            }
+
+
 class _FakeS3Client:
-    def __init__(self, data):
+    def __init__(self, data, pages=None):
         self.data = data
+        self.pages = pages or []
+        self.deleted: list[dict] = []
 
     def get_object(self, **kwargs):
         return {
@@ -104,6 +119,14 @@ class _FakeS3Client:
             "ContentLength": len(self.data),
             "ContentType": "image/png",
         }
+
+    def get_paginator(self, name):
+        assert name == "list_object_versions"
+        return _FakePaginator(self.pages)
+
+    def delete_objects(self, **kwargs):
+        self.deleted.extend(kwargs["Delete"]["Objects"])
+        return {}
 
 
 def test_s3_storage_reads_uploaded_image_info():
@@ -312,3 +335,48 @@ def test_max_image_edge_matches_the_largest_real_output():
     # A factor-4 upscale of the largest shipped generation size. Anything more
     # only moves the memory question to whatever decodes the file later.
     assert MAX_IMAGE_EDGE == 4096
+
+
+def test_s3_delete_removes_every_version_of_exactly_that_key():
+    """A delete marker hides the object and keeps billing for the bytes.
+
+    The terminal paths in jobs.py delete to reclaim storage from a peer that
+    can upload whatever it likes, so a plain delete_object is not enough on the
+    cloud bucket, which has versioning on.
+    """
+    storage = S3Storage.__new__(S3Storage)
+    storage.bucket = "bucket"
+    key = "u/j-attempt-1.png"
+    storage.client = _FakeS3Client(b"", pages=[
+        {"Versions": [{"Key": key, "VersionId": "v1"},
+                      {"Key": key, "VersionId": "v2"},
+                      # Same prefix, different object: attempt 10, not attempt 1.
+                      {"Key": "u/j-attempt-10.png", "VersionId": "other"}],
+         "DeleteMarkers": [{"Key": key, "VersionId": "marker"}]},
+        {"Versions": [{"Key": key, "VersionId": "v3"}]},
+    ])
+
+    asyncio.run(storage.delete(key))
+    assert storage.client.deleted == [
+        {"Key": key, "VersionId": "v1"},
+        {"Key": key, "VersionId": "v2"},
+        {"Key": key, "VersionId": "marker"},
+        {"Key": key, "VersionId": "v3"},
+    ]
+
+
+def test_s3_delete_is_quiet_on_an_unversioned_bucket():
+    # An unversioned bucket reports VersionId "null"; the same path works.
+    storage = S3Storage.__new__(S3Storage)
+    storage.bucket = "bucket"
+    storage.client = _FakeS3Client(b"", pages=[
+        {"Versions": [{"Key": "u/j.png", "VersionId": "null"}]},
+    ])
+    asyncio.run(storage.delete("u/j.png"))
+    assert storage.client.deleted == [{"Key": "u/j.png", "VersionId": "null"}]
+
+    empty = S3Storage.__new__(S3Storage)
+    empty.bucket = "bucket"
+    empty.client = _FakeS3Client(b"", pages=[{}])
+    asyncio.run(empty.delete("u/absent.png"))
+    assert empty.client.deleted == []

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -191,24 +191,48 @@ def _png(width, height, idat):
             + chunk(b"IDAT", idat) + chunk(b"IEND", b""))
 
 
-def test_image_info_refuses_a_decompression_bomb(tmp_path):
-    """Validating the output must not be a way to exhaust the API.
+def test_image_info_does_not_decompress_and_bounds_dimensions(tmp_path):
+    """The validator reads structure, never pixels.
 
-    The IDAT of a structurally valid PNG can be a zip bomb: 400 KB on the wire
-    expanded to 831 MB in process before this was bounded, and the parser
-    reported it as a well-formed 16x16 image. The ceiling comes from the
-    declared dimensions, so a genuine image of that size still passes.
+    It decompressed once, to prove the image decoded, and that was twice a
+    denial of service: unbounded it turned 400 KB into 831 MB, and bounded by
+    the declared dimensions it granted an 80 GB ceiling to a 65 KB object
+    claiming 100000x100000. Deciding how much memory to spend from a number the
+    peer supplied cannot be made safe, so a bomb is now simply bytes we never
+    expand, and the defence is a fixed dimension cap plus the size cap.
     """
     storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
     bomb = zlib.compress(b"\x00" * (64 * 1024 * 1024), 9)
+
+    # Honest dimensions: accepted, and cost nothing because nothing inflates.
     (tmp_path / "bomb.png").write_bytes(_png(16, 16, bomb))
-    assert len(_png(16, 16, bomb)) < 100_000
-    assert asyncio.run(storage.image_info("bomb.png")) is None
+    info = asyncio.run(storage.image_info("bomb.png"))
+    assert (info.width, info.height) == (16, 16)
+
+    # The bypass: a ceiling derived from the header is a ceiling the peer sets.
+    (tmp_path / "huge.png").write_bytes(_png(100000, 100000, bomb))
+    assert asyncio.run(storage.image_info("huge.png")) is None
+
+    (tmp_path / "empty.png").write_bytes(_png(16, 0, bomb))
+    assert asyncio.run(storage.image_info("empty.png")) is None
 
     rows = b"".join(b"\0" + b"\0" * (16 * 3) for _ in range(16))
     (tmp_path / "real.png").write_bytes(_png(16, 16, zlib.compress(rows)))
     info = asyncio.run(storage.image_info("real.png"))
     assert (info.width, info.height) == (16, 16)
+
+
+def test_image_info_requires_a_complete_object(tmp_path):
+    # Truncation is the likeliest real failure, and the trailer is fixed width
+    # so checking it costs nothing.
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    rows = b"".join(b"\0" + b"\0" * (16 * 3) for _ in range(16))
+    complete = _png(16, 16, zlib.compress(rows))
+    (tmp_path / "cut.png").write_bytes(complete[:-12])
+    assert asyncio.run(storage.image_info("cut.png")) is None
+    (tmp_path / "not-png.png").write_bytes(b"GIF89a" + complete[6:])
+    assert asyncio.run(storage.image_info("not-png.png")) is None
+    assert asyncio.run(storage.image_info("absent.png")) is None
 
 
 def test_image_info_refuses_an_oversized_object(tmp_path, monkeypatch):

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -95,14 +95,20 @@ Certificates: ACM in us-east-1 for both CloudFront domains, ACM in eu-west-1 for
 One cluster, three services (API public repo; billing and autoscaler from the private repo). Two IAM roles per service:
 
 - Execution role: the managed `AmazonECSTaskExecutionRolePolicy` plus `ssm:GetParameters` and `kms:Decrypt` scoped to `/potocolom/<env>/*`, so tasks pull secrets at start.
-- API task role (what the running code can do):
+- API task role (what the running code can do). The bucket is versioned, so reclaiming an
+  output means deleting its versions, not writing a delete marker: the API lists versions on
+  the bucket and deletes them on the objects. Without those four actions the terminal
+  cleanup paths fail with AccessDenied and a rejected upload stays billable forever.
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
-    {"Effect": "Allow", "Action": ["s3:PutObject", "s3:GetObject"],
+    {"Effect": "Allow", "Action": ["s3:PutObject", "s3:GetObject",
+                                   "s3:DeleteObject", "s3:DeleteObjectVersion"],
      "Resource": "arn:aws:s3:::potocolom-images/*"},
+    {"Effect": "Allow", "Action": ["s3:ListBucketVersions"],
+     "Resource": "arn:aws:s3:::potocolom-images"},
     {"Effect": "Allow", "Action": "ses:SendEmail", "Resource": "*",
      "Condition": {"StringEquals": {"ses:FromAddress": "no-reply@potocolom.com"}}},
     {"Effect": "Allow", "Action": "cloudwatch:PutMetricData", "Resource": "*",

--- a/docs/cloud-infrastructure.md
+++ b/docs/cloud-infrastructure.md
@@ -168,7 +168,7 @@ The stated tolerance at launch: an availability zone failure may cost up to five
 
 - RDS runs single AZ with point in time recovery and automated snapshots (14 day window). Multi-AZ is a checkbox to enable when revenue justifies roughly 30 USD per month of insurance.
 - Redis is a cache and a queue, never a source of truth. If it fails, sessions fall back to PostgreSQL (nobody gets logged out), generation and realtime features degrade behind a status banner, and the queue is rebuilt from job rows in the `queued` state when Redis returns.
-- The images bucket has versioning enabled, so an application bug that deletes objects is recoverable; S3 durability covers the hardware side.
+- The images bucket has versioning enabled, so an ordinary delete writes a marker and an application bug that removes an object is recoverable; S3 durability covers the hardware side. The exception is terminal job cleanup, which purges by version id on purpose: it exists to reclaim storage from a worker that uploaded something the API rejected, and a delete marker would keep paying for those bytes. A bug in that path is therefore not recoverable from S3, which is the trade for not letting an untrusted peer bill the install indefinitely.
 - Worker machines are expected to vanish: queued jobs retry once on another worker, realtime sessions reattach through the recovery flow, both specified in [architecture.md](architecture.md).
 
 ## Observability


### PR DESCRIPTION
Closes #204. Implemented by Codex (gpt-5.6-luna); I reviewed the diff, found three defects in it, and added the tests it was missing.

Authentication (#206) established which worker is connected. None of the four parts here asks that question, which is why they were not superseded by it.

| Part | Was |
|---|---|
| Session routing | Worker frames and `session_ready` routed by session UUID alone, so any worker that learned an id could inject frames into another worker's session or satisfy a replacement worker's readiness wait. The browser direction already checked both the session and the frame kind. |
| `job_done` | Committed `succeeded` and built the asset row from claimed dimensions with no evidence the object existed. `test_metrics.py` demonstrated this by sending `job_done` with no upload and observing success. |
| Completion fields | Converted after `inflight.pop`, so a raise left the row `running` forever: `on_worker_lost` cannot requeue a missing entry and the stall sweep only walks `inflight`. |
| Upload keys | Every attempt reused one key, so a stalled attempt could overwrite the winner and a stale presigned PUT stayed valid for an hour. |

## Three defects I found in the generated code

**The PNG validation was a decompression bomb.** A structurally valid 407 KB object expanded to **831 MB** in the API process, and the parser reported it as a well-formed 16x16 image:

```
crafted PNG on the wire: 407,742 bytes
parser accepts it -> (16, 16)
peak RSS after parse: 831 MiB
```

The guard added to validate worker output was itself a denial of service on a peer-controlled path. Decompression is now bounded by the declared dimensions, and the object read is bounded too, because the presigned S3 PUT carries no size condition even though the local route caps at 20 MB.

**Per-attempt keys stop an overwrite and start a leak.** The earlier attempt's blobs are no longer overwritten and nothing else collects them, because the asset row only ever names the winning key. Every retry would have left a full-size PNG behind permanently. A successful attempt now removes the ones before it.

**The orphan-thumbnail cleanup only handled one attempt** and deleted the wrong key when the attempt was the first.

## Tests

`make verify` green: backend 167, worker 90, frontend build and CSP.

Codex could not run pytest (no Docker in its sandbox) and shipped two failing tests plus one existing failure. That existing failure is the feature working: `test_upscale_dispatch_includes_input_url` claimed 1024 while uploading a 512px image, so it now uploads a genuinely 1024px one rather than weakening the assertion.

Every fix has a test that fails when that fix alone is reverted, verified one at a time: session binding, output verification, validate-before-pop, the bomb bound, the size cap, and the orphan cleanup. The last three are mine, and the orphan cleanup initially had no test at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of retried image-generation jobs with attempt-specific uploads and cleanup of stale results.
  * Invalid, malformed, oversized, incomplete, or structurally unsafe PNG outputs are now rejected automatically.
  * Image dimensions and metadata are verified from uploaded files for more accurate results.
  * Prevented outdated workers from affecting active sessions or sending unauthorized frames.
  * Improved handling of worker timing data and failed job completion.
  * Cleaned up abandoned outputs, thumbnails, and stored file versions after retries or rejected uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->