### PR TITLE
Record that a self-hosted install is meant to be multi-user

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -799,6 +799,18 @@ The honest limit of this control, measured on Docker 29.6.1 with a published `80
 
 Rejected alternatives: flipping to closed-by-default now, which is the breaking change the entry above assigns to a release boundary; binding the published port to loopback in compose, which also removes the studio from every other machine on the LAN and so breaks a legitimate self-hosted setup to fix the fleet socket; gating on a new development-only flag, which is closed-by-default wearing a different name and still makes every existing install edit its environment on upgrade; trusting `X-Forwarded-For` so proxied deployments could be distinguished, which lets the peer assert its own trustworthiness.
 
+## Self-hosted installs are multi-user
+
+Sharpens "Authentication: built-in module", "OAuth at launch: Google and GitHub" and "Roles: three tiers on the user row" into one statement about who uses a self-hosted install, because those three entries each describe a piece and none says the shape.
+
+A self-hosted install is not assumed to be one person. The operator runs it, holds `admin`, and configures the install; the people they invite hold `user` and generate, star and manage their own work; `viewer` stays read-only for someone who should see the gallery without spending the GPU. That is the existing three-tier model unchanged, applied to a household or a small team rather than to the cloud alone.
+
+Those people sign in with a local email and password, or with Google or GitHub. Both halves ship for self-hosters, not only for the cloud: local accounts serve an install with no external dependency, and the providers serve people who would rather not hold another password. `AUTH_MODE=none` remains the default and the zero-configuration path for a single operator who wants no accounts at all.
+
+Generic OIDC against an operator's own identity provider is rejected. Authentik, Keycloak, Authelia and Entra would each be reachable through one OIDC client implementation, and it is the obvious request from a self-hoster who already runs an identity provider, but it is a larger surface than the two providers plus local accounts, it needs discovery, key rotation and claim mapping to be correct rather than merely working, and nobody has asked for it. It layers on the same seam later if they do.
+
+Rejected alternatives: treating self-hosted as single-user and putting accounts in the cloud only, which is what the current code implies and which makes a shared install impossible without sharing one identity; a fourth tier between `user` and `viewer` for people who may generate but not manage their own history, which nobody asked for and which the three tiers already approximate; generic OIDC now, for the reasons above.
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -104,6 +104,23 @@ docker compose -f deploy/compose/compose.yml --profile gpu up -d --build
   rebuild the image) and restart the worker; see
   [third-party-models.md](third-party-models.md) for licensing notes.
 
+## Accounts
+
+There are none yet. `AUTH_MODE` defaults to `none`, every request resolves to a single local
+user, and that user holds the `admin` role, so anyone who can reach the API can do anything
+the install can do. Keep it on a trusted network, and see the fleet secret above for the
+worker side of the same question.
+
+Do not set `AUTH_MODE=local` or `AUTH_MODE=oauth`. Neither is implemented: they are accepted
+today and behave exactly like `none`, which means an install configured for authentication
+performs none (issue #241 makes that a startup failure instead).
+
+Multi-user is the intended shape, not a maybe: an operator holding `admin`, invited people
+signing in with a local email and password or with Google or GitHub, and a read-only `viewer`
+tier for someone who should see the gallery without spending the GPU. That is recorded in
+[decisions.md](decisions.md) under "Self-hosted installs are multi-user" and tracked in issues
+#5 and #9. Until those land, treat the install as single-operator.
+
 ## Gated models
 
 `sd35-medium` (Stable Diffusion 3.5 Medium) is a gated Hugging Face


### PR DESCRIPTION
Documentation only, no code.

Three existing decisions each describe a piece of this and none states the shape. "Authentication: built-in module" says email and password plus OAuth live in the backend. "OAuth at launch: Google and GitHub" calls GitHub the self-hosting crowd's provider. "Roles: three tiers on the user row" defines admin, user and viewer. Read together they imply a single-operator box with accounts arriving for the cloud, which is the opposite of the intent.

Stated once now: the operator holds `admin`, invited people hold `user` and sign in with a local email and password or with Google or GitHub, and `viewer` stays read-only for someone who should see the gallery without spending the GPU. Both halves ship for self-hosters. `AUTH_MODE=none` remains the default for an operator who wants no accounts at all. No new tier and no change to what the existing three mean.

**Generic OIDC is rejected with its reasoning**, because it is the obvious next request from anyone already running Authentik or Keycloak, and the answer should be on record before it is asked rather than re-argued each time.

`docs/self-hosting.md` gains an Accounts section describing what ships today, which is nothing: every request resolves to the single local user and that user is `admin`. It also tells operators not to set `AUTH_MODE=local` or `oauth`, since both are accepted and unimplemented and an install configured for authentication currently performs none. That is #241.

Deliberately not included: the internal review workflow. That is how we work, not a rule for contributors, so it lives in the gitignored internals notes rather than `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented self-hosted installations as multi-user by default while retaining admin, user, and viewer roles.
  * Clarified supported authentication options, including local authentication, Google/GitHub OAuth, and single-operator mode.
  * Added guidance on current single-user behavior and planned multi-user capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->