### PR TITLE
Refuse to start in an AUTH_MODE that authenticates nobody

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ Read the list below before reporting. Several open surfaces here are recorded de
 Known and deliberate, so not vulnerabilities:
 
 - **The fleet WebSocket (`/api/v1/fleet`) authenticates workers with a shared secret in `FLEET_TOKEN_KEY`, compared in constant time.** When the secret is unset the socket stays permissive for compatibility with existing installs, but only for a peer whose address cannot route from the public internet. That restriction is a mitigation and not a boundary: a connection arriving over IPv6 reaches an IPv4-only container through Docker's userland proxy and so appears local. Any host with a public address should set the secret. Both WebSocket endpoints reject a browser `Origin` that is not allowlisted, so a page you merely visit cannot reach them; a process on the same network still can, which is what worker authentication is for. Tracked in #245.
-- **`AUTH_MODE=none` is the shipped default** and resolves every request to one local user. Only that mode exists; `local` and `oauth` are seams, not implementations. Tracked in #5 and #9.
+- **`AUTH_MODE=none` is the shipped default** and resolves every request to one local user. Setting `local` or `oauth` now refuses to start rather than silently behaving as `none`; they are seams, not implementations. Tracked in #5 and #9.
 - **There is no rate limiting.** Deferred by recorded decision, see [docs/decisions.md](docs/decisions.md).
 - **Pull requests execute contributor code on a self-hosted runner.** Accepted for a solo org and documented in [docs/self-hosted-runner.md](docs/self-hosted-runner.md).
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,19 +29,28 @@ from app.telemetry import DESTINATION, telemetry_loop
 from app.telemetry import router as telemetry_router
 
 
+def _reject_unimplemented_auth_mode(mode: str) -> None:
+    if mode == "none":
+        # none is the only implemented mode, so it must keep working.
+        return
+    # Refusing to boot is deliberate rather than a warning, because a
+    # warning is exactly what an operator misses while the API resolves
+    # every request to the local admin user.
+    raise RuntimeError(
+        f"AUTH_MODE={mode} is not implemented and "
+        "authenticates nobody, so every request would resolve to the local "
+        "admin user. Unset AUTH_MODE or set it to none (local is tracked "
+        "in #5, oauth in #9)."
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
-    if settings.auth_mode != "none":
-        # Refusing to boot is deliberate rather than a warning, because a
-        # warning is exactly what an operator misses while the API resolves
-        # every request to the local admin user.
-        raise RuntimeError(
-            f"AUTH_MODE={settings.auth_mode} is not implemented and "
-            "authenticates nobody, so every request would resolve to the local "
-            "admin user. Unset AUTH_MODE or set it to none (local is tracked "
-            "in #5, oauth in #9)."
-        )
+    # The import-time check cannot see an environment that changes after
+    # import, and get_settings caches per process, so startup re-checks with
+    # the settings this process actually runs under.
+    _reject_unimplemented_auth_mode(settings.auth_mode)
     setup_logging(settings.log_format)
     if not settings.fleet_token_key:
         logging.getLogger("potocolom.realtime").warning(
@@ -96,6 +105,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
             await task
     await db.dispose()
 
+
+# The gate runs at import time because the ASGI lifespan protocol is optional:
+# uvicorn --lifespan off and a TestClient outside a context manager serve the
+# app without it, so a lifespan-only check is bypassable. No server flag or
+# embedder can avoid importing the module that defines app.
+_reject_unimplemented_auth_mode(get_settings().auth_mode)
 
 app = FastAPI(
     title="potocolom",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -32,6 +32,16 @@ from app.telemetry import router as telemetry_router
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
+    if settings.auth_mode != "none":
+        # Refusing to boot is deliberate rather than a warning, because a
+        # warning is exactly what an operator misses while the API resolves
+        # every request to the local admin user.
+        raise RuntimeError(
+            f"AUTH_MODE={settings.auth_mode} is not implemented and "
+            "authenticates nobody, so every request would resolve to the local "
+            "admin user. Unset AUTH_MODE or set it to none (local is tracked "
+            "in #5, oauth in #9)."
+        )
     setup_logging(settings.log_format)
     if not settings.fleet_token_key:
         logging.getLogger("potocolom.realtime").warning(

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,11 +1,13 @@
 """Self-hosted SPA static serving and the AUTH_MODE startup gate."""
 
+import importlib
 from pathlib import Path
 
 import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
+import app.main as main_module
 from app.main import SPAStaticFiles, app
 from app.settings import get_settings
 
@@ -27,6 +29,27 @@ def test_unimplemented_auth_mode_refuses_to_start(monkeypatch, mode):
                 pass
     finally:
         get_settings.cache_clear()
+
+
+def test_unimplemented_auth_mode_cannot_even_import(monkeypatch):
+    """An unimplemented AUTH_MODE must refuse to import, not just to start.
+
+    The ASGI lifespan protocol is optional: uvicorn --lifespan off and a
+    TestClient outside a context manager serve the app without it, so a gate
+    that runs only inside lifespan is bypassable. Importing the module is
+    unavoidable, so the gate must fire there too.
+    """
+    monkeypatch.setenv("AUTH_MODE", "local")
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(RuntimeError, match="AUTH_MODE"):
+            importlib.reload(main_module)
+    finally:
+        monkeypatch.delenv("AUTH_MODE", raising=False)
+        get_settings.cache_clear()
+        # Reload with the environment restored so the module left in
+        # sys.modules is the good one and later tests are not poisoned.
+        importlib.reload(main_module)
 
 
 def test_auth_mode_none_starts(monkeypatch):

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -24,7 +24,10 @@ def test_unimplemented_auth_mode_refuses_to_start(monkeypatch, mode):
     monkeypatch.setenv("AUTH_MODE", mode)
     get_settings.cache_clear()
     try:
-        with pytest.raises(RuntimeError, match="AUTH_MODE"):
+        # Match the mode as well as the variable: a message naming a mode the
+        # operator never set would satisfy the looser check while telling them
+        # to fix the wrong thing.
+        with pytest.raises(RuntimeError, match=f"AUTH_MODE={mode}"):
             with TestClient(app):
                 pass
     finally:
@@ -42,7 +45,7 @@ def test_unimplemented_auth_mode_cannot_even_import(monkeypatch):
     monkeypatch.setenv("AUTH_MODE", "local")
     get_settings.cache_clear()
     try:
-        with pytest.raises(RuntimeError, match="AUTH_MODE"):
+        with pytest.raises(RuntimeError, match="AUTH_MODE=local"):
             importlib.reload(main_module)
     finally:
         monkeypatch.delenv("AUTH_MODE", raising=False)

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,11 +1,59 @@
-"""Self-hosted SPA static serving."""
+"""Self-hosted SPA static serving and the AUTH_MODE startup gate."""
 
 from pathlib import Path
 
+import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
-from app.main import SPAStaticFiles
+from app.main import SPAStaticFiles, app
+from app.settings import get_settings
+
+
+@pytest.mark.parametrize("mode", ["local", "oauth"])
+def test_unimplemented_auth_mode_refuses_to_start(monkeypatch, mode):
+    """An unimplemented AUTH_MODE must fail startup loudly, not silently downgrade.
+
+    current_user never reads the mode and resolves every request to the local
+    admin user, so leaving local or oauth configured would serve the API with
+    no authentication at all. The lifespan raises on entry, before the rest of
+    the process comes up.
+    """
+    monkeypatch.setenv("AUTH_MODE", mode)
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(RuntimeError, match="AUTH_MODE"):
+            with TestClient(app):
+                pass
+    finally:
+        get_settings.cache_clear()
+
+
+def test_auth_mode_none_starts(monkeypatch):
+    """AUTH_MODE=none is the only implemented mode and must not be refused.
+
+    The full lifespan can run here without a database: an unreachable one
+    degrades startup (app/db.py) instead of raising, so entering the lifespan
+    asserts the gate itself.
+    """
+    monkeypatch.setenv("AUTH_MODE", "none")
+    get_settings.cache_clear()
+    try:
+        with TestClient(app):
+            pass
+    finally:
+        get_settings.cache_clear()
+
+
+def test_auth_mode_unset_starts(monkeypatch):
+    """An unset AUTH_MODE falls back to the shipped none default, not a refusal."""
+    monkeypatch.delenv("AUTH_MODE", raising=False)
+    get_settings.cache_clear()
+    try:
+        with TestClient(app):
+            pass
+    finally:
+        get_settings.cache_clear()
 
 
 def test_spa_static_files_fallback_to_index(tmp_path: Path):


### PR DESCRIPTION
# Description

Closes #241. `AUTH_MODE` accepted `local` and `oauth` and implemented neither, so both silently
behaved as `none`. The API refuses to start in those modes now, rather than serving with no
authentication.

# Functionality

- `lifespan` raises before anything else when `auth_mode` is not `none`, naming the value, the
  consequence and the fix, and pointing at #5 for local and #9 for oauth.
- `AUTH_MODE=none` is unchanged. It is the shipped default and what makes the one-command
  self-hosted start work.
- The `Literal` in `settings.py` keeps all three values, so the configuration surface stays
  declared and #5 and #9 replace this rejection with real resolution rather than removing it.

# Details

`current_user` never read the mode, a cookie or a header: it returned `db.local_user_id`, which
startup promotes to admin. An operator who set `AUTH_MODE=local` therefore got an API that
advertised a login method through `/api/v1/config`, performed no authentication, and handed
every caller the install owner's role, with `require_role("admin")` passing for anyone who could
reach the port. Nothing logged it and the config endpoint claimed otherwise.

Refusing to boot is deliberate rather than a warning. A warning is what an operator misses while
the API serves unauthenticated, and the difference between the two is the whole of this issue.

Not in scope, both recorded: what `AUTH_MODE=none` does, and that `require_role` is vacuous under
it because every caller is the same admin user.

# Verification

`ruff`, `mypy` over 22 source files and 213 backend tests pass.

Behaviour checked by running the app rather than only the suite:

| `AUTH_MODE` | result |
|---|---|
| `local` | refuses to start |
| `oauth` | refuses to start |
| `none` | serves, `auth_methods` empty |
| unset | serves, `auth_methods` empty |

Mutation tested in both directions: disabling the gate fails the two refusal tests, and widening
it to refuse every mode fails the two startup tests. The tests are guards rather than restatements
of the code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The application now refuses to start when an unsupported authentication mode (`local` or `oauth`) is configured, rather than silently running without authentication.
  * The default and unset authentication modes continue to start normally.

* **Documentation**
  * Updated security guidance to clarify startup behavior for unsupported authentication modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->