### PR TITLE
Refuse to start when AUTH_MODE names an unimplemented mode

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,16 @@ from app.telemetry import router as telemetry_router
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     settings = get_settings()
     setup_logging(settings.log_format)
+    if settings.auth_mode != "none":
+        # An install configured for authentication that performs none is worse
+        # than one that will not start: nothing in the running system reveals
+        # the difference, so the operator would never find out.
+        raise RuntimeError(
+            f"AUTH_MODE={settings.auth_mode} is not implemented and would "
+            "authenticate nobody: every request would resolve to the local "
+            "admin user. Set AUTH_MODE=none until issues #5 and #9 land local "
+            "and OAuth accounts."
+        )
     if not settings.fleet_token_key:
         logging.getLogger("potocolom.realtime").warning(
             "FLEET_TOKEN_KEY is unset; fleet authentication is permissive for "

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -3,6 +3,7 @@
 import asyncio
 from pathlib import Path
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -12,6 +13,7 @@ from app.security import (
     SecurityHeadersMiddleware,
     unhandled_exception_response,
 )
+from app.settings import get_settings
 
 client = TestClient(app)
 
@@ -181,3 +183,18 @@ def test_csp_img_src_allows_http_object_store():
     )
     tokens = img_src.split()[1:]
     assert tokens == ["'self'", "https:", "http:"]
+
+
+@pytest.mark.parametrize("mode", ["local", "oauth"])
+def test_unimplemented_auth_modes_refuse_to_start(monkeypatch, mode):
+    """Entering the app must fail, not boot unauthenticated in disguise."""
+    monkeypatch.setattr(get_settings(), "auth_mode", mode)
+    with pytest.raises(RuntimeError, match="authenticate nobody"):
+        with TestClient(app):
+            pass
+
+
+def test_auth_mode_none_starts():
+    """The default mode keeps the existing startup path."""
+    with TestClient(app):
+        pass

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -111,9 +111,9 @@ user, and that user holds the `admin` role, so anyone who can reach the API can 
 the install can do. Keep it on a trusted network, and see the fleet secret above for the
 worker side of the same question.
 
-Do not set `AUTH_MODE=local` or `AUTH_MODE=oauth`. Neither is implemented: they are accepted
-today and behave exactly like `none`, which means an install configured for authentication
-performs none (issue #241 makes that a startup failure instead).
+`AUTH_MODE=local` and `AUTH_MODE=oauth` are refused: the API will not start with either,
+because neither is implemented and an install configured for authentication that performs
+none is worse than one that will not boot. They become available with issues #5 and #9.
 
 Multi-user is the intended shape, not a maybe: an operator holding `admin`, invited people
 signing in with a local email and password or with Google or GitHub, and a read-only `viewer`


### PR DESCRIPTION
Closes #241. Implemented by OpenCode (`deepseek-v4-flash`, max effort); I wrote the design and the exact wording, reviewed the diff and re-verified independently.

`AUTH_MODE` accepts `local` and `oauth`. Neither is implemented: `current_user` never reads the mode, a cookie, a header or any credential, and `db.py` promotes the single local user to `admin` on every startup. An operator who configured authentication therefore got an API that advertised a login method through `/api/v1/config`, performed none, and handed every caller the install owner's role.

It refuses to boot now. That is the harsher option and the right one: an install configured for authentication that performs none is worse than one that will not start, because nothing in the running system reveals the difference.

Deliberately untouched: the `AUTH_MODE=none` behaviour and the admin promotion, both recorded in `docs/decisions.md`; the `Literal` type, so a typo still fails as a typo rather than as this; and `auth_methods`, which is unreachable for the refused modes and belongs to #5 and #9.

## Verified independently

Not on the delegate's word:

- `make verify` green here: backend 231, worker 90, frontend build and CSP.
- Removing the guard fails exactly the two new parametrised tests.
- Drove the real startup path with `auth_mode = "local"` and got the refusal, not a boot.
- Non-ASCII sweep over all three files: clean.

## Background

An external scan reported this as broken authentication at high severity. The mechanics were accurate; the severity overstated the shipped risk, since `none` is the default and the profile is a documented private network. What it got right is that the seam fails open rather than closed, and that is a one-line difference. The earlier internal triage dismissed it after reading the `auth.py` docstring, which predates the role tiers added in ea5e1be and still describes `current_user` as the whole auth surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The API now refuses to start when unsupported authentication modes are configured, preventing insecure fallback behavior.
  * The `none` authentication mode continues to start successfully.

* **Documentation**
  * Updated self-hosting guidance to clarify supported authentication settings and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->