### PR TITLE
Say that local and oauth refuse to start, everywhere they appear

### DIFF
--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -123,7 +123,7 @@ Environment for the API task, values resolved from SSM where secret:
 
 | Variable | Value |
 |---|---|
-| AUTH_MODE | `oauth` |
+| AUTH_MODE | `oauth` (target state: the API refuses to start with it until #9; do not deploy this stack to a public ALB before then) |
 | OAUTH_PROVIDERS | `google,github` |
 | BILLING_ENABLED | `true` |
 | SAFETY_CHECKS | `true` |

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -7,7 +7,7 @@ This document sits between [architecture.md](architecture.md) and real code. It 
 All mode differences are environment variables read once at startup into a settings object. Nothing branches on "self-hosted or cloud"; code branches on the specific setting.
 
 ```
-AUTH_MODE            = none | local | oauth      # default none
+AUTH_MODE            = none | local | oauth      # default none; local refuses to start until #5, oauth until #9
 OAUTH_PROVIDERS      = google,github             # only read when AUTH_MODE=oauth
 BILLING_ENABLED      = false | true              # default false
 SAFETY_CHECKS        = false | true              # prompt screen + output checker, default false
@@ -464,7 +464,7 @@ services:
     image: ghcr.io/portocolom-studio/potocolom-api:v0.x
     ports: ["8080:8080"]
     environment:
-      AUTH_MODE: none            # or local
+      AUTH_MODE: none            # the only mode that starts; local lands with #5, oauth with #9
       DATABASE_URL: postgresql://potocolom:...@postgres/potocolom
       STORAGE_BACKEND: local
       FLEET_TOKEN_KEY: ${FLEET_SECRET}

--- a/docs/deployment-profiles.md
+++ b/docs/deployment-profiles.md
@@ -48,6 +48,8 @@ flowchart LR
 
 The scaled self-hosted column deserves a note: it is not a separately designed product. Setting `REDIS_URL` switches dispatch and the frame relay to the Redis implementations, and additional worker containers simply dial the same fleet endpoint. A lab or studio with three GPU machines gets multi-worker scheduling with the exact scheduler the cloud runs (issue #20), for the cost of one Redis container.
 
+The `AUTH_MODE` row is target state. Only `none` is implemented; the API refuses to start with `local` until issue #5 lands it and with `oauth` until issue #9 lands it.
+
 > Shipped status (2026-07-30): **not yet implemented.** Setting `REDIS_URL` currently changes neither job dispatch nor realtime relay, and the backend has no Redis dependency. This remains the migration target under "Redis-optional Queues and FrameBus contracts" and issue #20, "Multi-Worker Scheduling".
 
 ## What is shared, layer by layer

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -111,9 +111,10 @@ user, and that user holds the `admin` role, so anyone who can reach the API can 
 the install can do. Keep it on a trusted network, and see the fleet secret above for the
 worker side of the same question.
 
-Do not set `AUTH_MODE=local` or `AUTH_MODE=oauth`. Neither is implemented: they are accepted
-today and behave exactly like `none`, which means an install configured for authentication
-performs none (issue #241 makes that a startup failure instead).
+`AUTH_MODE=local` and `AUTH_MODE=oauth` are refused: the API will not start with either,
+because neither is implemented and an install configured for authentication that performs
+none is worse than one that will not boot. `local` becomes available with issue #5
+and `oauth` with issue #9.
 
 Multi-user is the intended shape, not a maybe: an operator holding `admin`, invited people
 signing in with a local email and password or with Google or GitHub, and a read-only `viewer`


### PR DESCRIPTION
Documentation only, following #255.

That PR made the API refuse to boot on an unimplemented `AUTH_MODE` and updated `SECURITY.md`. Four other documents still present those modes as configuration a reader can use, and a review of the duplicate #257 found them.

- **`docs/self-hosting.md`** said issue #241 "makes that a startup failure instead". True when written, now a description of the past.
- **`docs/blueprint.md`** is the normative config surface, and its sample compose block offered `# or local` as an alternative.
- **`docs/deployment-profiles.md`** has a matrix row assigning `local` and `oauth` to four of five profiles. That is target state and reads as current.
- **`docs/aws-setup.md`** is a runbook, so its `oauth` row is something a reader pastes into a deployment.

The target design stays in all four. These are annotations of what starts today, not a redesign; the modes arrive with #5 and #9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication configuration across deployment and self-hosting guides.
  * Documented that `AUTH_MODE=none` is currently the only mode that allows the API to start.
  * Noted that `local` and `oauth` authentication modes prevent startup until the related authentication work is completed.
  * Updated the OAuth deployment guidance to distinguish the intended target configuration from the currently supported setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->