### PR TITLE
Cover three guards the committed tests were leaving unheld

### DIFF
--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -715,6 +715,64 @@ def test_a_rejected_upload_is_not_left_in_storage():
             assert not storage.path(key).exists(), "rejected upload was left behind"
 
 
+@pytest.mark.db
+def test_a_rejected_retry_collects_every_attempt(monkeypatch):
+    """Per-attempt keys stop a stale worker overwriting the winning output, and
+    start leaking: a stalled attempt's blobs are overwritten by nothing and
+    named by no asset row, and when the retry is then rejected, the success
+    path never runs. The rejection path is the only collector those blobs have,
+    so it must walk every attempt, not just the rejected one; a first-attempt
+    test proves only the loop's last iteration.
+    """
+    monkeypatch.setenv("JOB_STALL_SECONDS", "0.05")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-rejected-retry")
+                job_id = client.post(
+                    "/api/v1/generations",
+                    json={"model_id": "sd-test", "params": {"prompt": "rejected retry"}},
+                ).json()["job_id"]
+                first = worker.receive_json()
+                first_path = urlsplit(first["upload"]["url"]).path
+                first_thumb = urlsplit(first["thumb_upload"]["url"]).path
+
+                # The first attempt uploaded before it stalled.
+                poll_until_attempt(client, job_id, 2, timeout=3.0)
+                second = worker.receive_json()
+                storage = jobs.get_storage()
+                first_key = first_path.rsplit("/api/v1/files/", 1)[-1]
+                first_thumb_key = first_thumb.rsplit("/api/v1/files/", 1)[-1]
+                asyncio.run(_write_blob(storage, first_key, png_bytes()))
+                asyncio.run(_write_blob(storage, first_thumb_key, png_bytes()))
+
+                # The retry's output is rejected: the key is still inflight so
+                # the PUT succeeds, and the invalid bytes fail verification.
+                second_path = urlsplit(second["upload"]["url"]).path
+                assert client.put(second_path,
+                                  content=b"not a png at all").status_code == 200
+                second_key = second_path.rsplit("/api/v1/files/", 1)[-1]
+
+                worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                                  "width": 512, "height": 512})
+                poll_until(client, job_id, "failed")
+                deadline = time.monotonic() + 3
+                keys = (first_key, first_thumb_key, second_key)
+                while time.monotonic() < deadline and any(storage.path(k).exists()
+                                                          for k in keys):
+                    time.sleep(0.05)
+
+                assert not storage.path(first_key).exists(), "stalled attempt left behind"
+                assert not storage.path(first_thumb_key).exists(), \
+                    "stalled attempt's thumbnail left behind"
+                assert not storage.path(second_key).exists(), "rejected upload left behind"
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
+
+
 async def _write_blob(storage, key, data):
     storage.path(key).parent.mkdir(parents=True, exist_ok=True)
     storage.path(key).write_bytes(data)

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -299,7 +299,6 @@ def test_s3_image_info_refuses_an_oversized_object(monkeypatch):
     head, iend = data[:-12], data[-12:]
     at_limit = head + _chunk(b"prVt", b"pad") + iend
     one_past = head + _chunk(b"prVt", b"padd") + iend
-    trailing = at_limit + b"\x00"
     monkeypatch.setattr("app.storage.MAX_VERIFY_BYTES", len(at_limit))
 
     storage.client = _FakeS3Client(at_limit)
@@ -308,9 +307,6 @@ def test_s3_image_info_refuses_an_oversized_object(monkeypatch):
     assert info.size == len(at_limit)
 
     storage.client = _FakeS3Client(one_past)
-    assert asyncio.run(storage.image_info("u/j.png")) is None
-
-    storage.client = _FakeS3Client(trailing)
     assert asyncio.run(storage.image_info("u/j.png")) is None
 
 

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -11,6 +11,7 @@ from app.main import app
 from app.settings import Settings
 from app.storage import (
     MAX_IMAGE_EDGE,
+    MAX_PNG_CHUNKS,
     MAX_VERIFY_BYTES,
     LocalStorage,
     S3Storage,
@@ -282,6 +283,37 @@ def test_image_info_refuses_an_oversized_object(tmp_path, monkeypatch):
     assert MAX_VERIFY_BYTES > 1024 * 1024
 
 
+def test_s3_image_info_refuses_an_oversized_object(monkeypatch):
+    """The local PUT route caps upload size, but a presigned S3 PUT constrains
+    bucket, key and content type, never size, so this check is the only bound
+    on how many peer-chosen bytes the API process buffers to verify a
+    completion. The read goes one byte past the bound because read(amt) may
+    return less than amt, and an object exactly at the bound must be admitted
+    while one a byte larger must not. The constant is 64 MiB, so the test
+    patches it down to the size of an object it builds rather than allocating
+    the real bound.
+    """
+    storage = S3Storage.__new__(S3Storage)
+    storage.bucket = "bucket"
+    data = png_bytes(5, 7)
+    head, iend = data[:-12], data[-12:]
+    at_limit = head + _chunk(b"prVt", b"pad") + iend
+    one_past = head + _chunk(b"prVt", b"padd") + iend
+    trailing = at_limit + b"\x00"
+    monkeypatch.setattr("app.storage.MAX_VERIFY_BYTES", len(at_limit))
+
+    storage.client = _FakeS3Client(at_limit)
+    info = asyncio.run(storage.image_info("u/j.png"))
+    assert info is not None
+    assert info.size == len(at_limit)
+
+    storage.client = _FakeS3Client(one_past)
+    assert asyncio.run(storage.image_info("u/j.png")) is None
+
+    storage.client = _FakeS3Client(trailing)
+    assert asyncio.run(storage.image_info("u/j.png")) is None
+
+
 def _chunk(kind, body):
     return (struct.pack(">I", len(body)) + kind + body
             + struct.pack(">I", zlib.crc32(kind + body) & 0xffffffff))
@@ -331,6 +363,31 @@ def test_image_info_requires_a_structurally_complete_png(tmp_path):
                                      + _chunk(b"IDAT", idat) + _chunk(b"IEND", b"")}.items():
         (tmp_path / f"{name}.png").write_bytes(data)
         assert asyncio.run(storage.image_info(f"{name}.png")) is not None, name
+
+
+def test_image_info_refuses_a_png_past_the_chunk_cap(tmp_path):
+    """A stored object is peer-supplied and the walk's cost is per chunk.
+
+    Bounded only by MAX_VERIFY_BYTES, one object could force millions of chunk
+    iterations (a 64 MiB object of empty chunks is about five million), each
+    seeding a CRC. MAX_PNG_CHUNKS is far beyond any real encoder, so a file
+    past the cap is junk, not an output worth inspecting, and a file exactly at
+    it must still be accepted: the guard is a ceiling on abuse, and an
+    off-by-one in either direction is a real bug.
+    """
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    sig = b"\x89PNG\r\n\x1a\n"
+    idat = zlib.compress(b"".join(b"\0" + b"\0" * (16 * 3) for _ in range(16)))
+    filler = _chunk(b"prVt", b"")
+    at_cap = (sig + _chunk(b"IHDR", _header(16, 16)) + _chunk(b"IDAT", idat)
+              + filler * (MAX_PNG_CHUNKS - 3) + _chunk(b"IEND", b""))
+    over_cap = (sig + _chunk(b"IHDR", _header(16, 16)) + _chunk(b"IDAT", idat)
+                + filler * (MAX_PNG_CHUNKS - 2) + _chunk(b"IEND", b""))
+
+    (tmp_path / "at-cap.png").write_bytes(at_cap)
+    assert asyncio.run(storage.image_info("at-cap.png")) is not None
+    (tmp_path / "over-cap.png").write_bytes(over_cap)
+    assert asyncio.run(storage.image_info("over-cap.png")) is None
 
 
 def test_max_image_edge_matches_the_largest_real_output():


### PR DESCRIPTION
# Description

Closes #253. Three guards added in #204 were mutation-tested during development but only through
paths the committed tests do not take, so reverting any one of them alone left the suite green.

# Functionality

- `test_s3_image_info_refuses_an_oversized_object`. The existing oversized test uses
  `LocalStorage`, which has its own independent `stat` bound, so the S3 branch never saw the
  limit.
- `test_image_info_refuses_a_png_past_the_chunk_cap`. Nothing built a file past `MAX_PNG_CHUNKS`.
- `test_a_rejected_retry_collects_every_attempt`. The rejection path deletes the blobs of every
  earlier attempt, but the existing test rejected a first attempt, so the loop never ran with
  anything to collect.

# Details

No fixtures added and no dependency: the boundary is moved to the data by monkeypatching the
constant, which is what the existing local oversized test already does, and the S3 cases reuse
`_FakeS3Client` with its deliberately one-byte-at-a-time body.

Versioned deletion on S3 stays uncovered. A fake can show `delete` issues versioned deletes, but
not that S3 keeps the bytes behind a delete marker, which needs a real versioned bucket. That
belongs with #252.

# Verification

`ruff`, `mypy` over 22 source files, and 236 backend tests pass, up from 233.

Each guard reverted in turn fails its own test and only its own:

| Reverted guard | Failing test |
|---|---|
| `len(data) > MAX_VERIFY_BYTES` in `S3Storage.image_info` | `test_s3_image_info_refuses_an_oversized_object` |
| `chunks > MAX_PNG_CHUNKS` in `_png_dimensions` | `test_image_info_refuses_a_png_past_the_chunk_cap` |
| `range(1, attempt + 1)` in the rejection cleanup | `test_a_rejected_retry_collects_every_attempt` |

The attempt-cleanup test is `@pytest.mark.db` and was confirmed to run against PostgreSQL rather
than skip, since a skipped test cannot go red and the mutation check would otherwise prove
nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage ensuring failed retried jobs clean up output files from all attempts.
  * Added image validation coverage confirming files at supported size and PNG chunk limits are accepted.
  * Confirmed oversized images and files exceeding the PNG chunk limit are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->