### PR TITLE
Bind a dispatch to a token, and make outputs write-once

### DIFF
--- a/backend/app/files.py
+++ b/backend/app/files.py
@@ -7,7 +7,8 @@ Keys are minted server side at dispatch time, but a key is not authority: every
 part of it is derivable by any worker that was ever dispatched the job, so the
 PUT carries the dispatch token as well (issue #247). Uploads are write-once:
 the object the API verified must still be that object when a client reads it
-(issue #249).
+(issue #249). The local backend publishes by linking a temporary into place,
+so STORAGE_LOCAL_PATH must be on a filesystem that supports hard links.
 """
 
 import asyncio
@@ -60,38 +61,47 @@ async def upload(key: str, request: Request) -> dict:
             raise HTTPException(status_code=413, detail="upload too large")
         body.extend(chunk)
 
-    # The first check ran before the body arrived and reading it can take a
-    # long time, so a stall could hold this request open while a retry
-    # supersedes it; re-check now that the bytes are in hand, before anything
-    # is published.
-    if not jobs.upload_authorized(key, request.headers.get(UPLOAD_TOKEN_HEADER)):
-        raise HTTPException(status_code=403, detail="upload not authorized")
-
-    def write_file() -> None:
+    def write_file() -> str:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # Publish atomically: writing the key directly would expose a truncated
-        # prefix while the body is still landing, and a job_done racing its own
-        # PUT could have that prefix inspected and approved. The temporary is
-        # linked into place, and link refuses to replace an existing key, which
-        # also keeps a second PUT from overwriting bytes the API verified.
-        descriptor, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name)
+        # A process death between write and link leaves this file behind; the
+        # .upload- prefix marks it as debris, and nothing collects it,
+        # deliberately.
+        descriptor, temporary = tempfile.mkstemp(dir=path.parent, prefix=".upload-")
         try:
             with os.fdopen(descriptor, "wb") as handle:
                 handle.write(body)
-            os.link(temporary, path)
-        finally:
-            # Only the temporary this request created is removed; the
-            # destination may belong to a different upload.
+        except BaseException:
             os.unlink(temporary)
+            raise
+        return temporary
 
+    temporary = await asyncio.to_thread(write_file)
     try:
-        await asyncio.to_thread(write_file)
+        # The first check ran before the body arrived and reading it can take
+        # a long time, so a stall could hold this request open while a retry
+        # supersedes it; re-check now that the bytes are on disk, and link
+        # with no await in between so the authority cannot change under the
+        # publication.
+        if not jobs.upload_authorized(key, request.headers.get(UPLOAD_TOKEN_HEADER)):
+            raise HTTPException(status_code=403, detail="upload not authorized")
+        # Publish atomically: writing the key directly would expose a truncated
+        # prefix while the body is still landing, and a job_done racing its own
+        # PUT could have that prefix inspected and approved. Link refuses to
+        # replace an existing key, which also keeps a second PUT from
+        # overwriting bytes the API verified. One syscall does not need a
+        # thread, and a thread here would reopen the window the re-check just
+        # closed.
+        os.link(temporary, path)
     except FileExistsError:
         # Either a retry whose first upload actually landed, which is benign,
         # or a replay. Refusing costs the caller nothing either way: a real
         # retry is a new attempt and writes to a new key.
         logger.warning("refused a second upload of %s", key)
         raise HTTPException(status_code=409, detail="already uploaded") from None
+    finally:
+        # Only the temporary this request created is removed; the
+        # destination may belong to a different upload.
+        os.unlink(temporary)
 
     return {"stored": key}
 

--- a/backend/app/files.py
+++ b/backend/app/files.py
@@ -12,6 +12,8 @@ the object the API verified must still be that object when a client reads it
 
 import asyncio
 import logging
+import os
+import tempfile
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
@@ -58,12 +60,29 @@ async def upload(key: str, request: Request) -> dict:
             raise HTTPException(status_code=413, detail="upload too large")
         body.extend(chunk)
 
+    # The first check ran before the body arrived and reading it can take a
+    # long time, so a stall could hold this request open while a retry
+    # supersedes it; re-check now that the bytes are in hand, before anything
+    # is published.
+    if not jobs.upload_authorized(key, request.headers.get(UPLOAD_TOKEN_HEADER)):
+        raise HTTPException(status_code=403, detail="upload not authorized")
+
     def write_file() -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        # Exclusive: a second PUT to a key must not replace bytes the API has
-        # already inspected and committed an asset row for.
-        with open(path, "xb") as handle:
-            handle.write(body)
+        # Publish atomically: writing the key directly would expose a truncated
+        # prefix while the body is still landing, and a job_done racing its own
+        # PUT could have that prefix inspected and approved. The temporary is
+        # linked into place, and link refuses to replace an existing key, which
+        # also keeps a second PUT from overwriting bytes the API verified.
+        descriptor, temporary = tempfile.mkstemp(dir=path.parent, prefix=path.name)
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(body)
+            os.link(temporary, path)
+        finally:
+            # Only the temporary this request created is removed; the
+            # destination may belong to a different upload.
+            os.unlink(temporary)
 
     try:
         await asyncio.to_thread(write_file)
@@ -73,9 +92,6 @@ async def upload(key: str, request: Request) -> dict:
         # retry is a new attempt and writes to a new key.
         logger.warning("refused a second upload of %s", key)
         raise HTTPException(status_code=409, detail="already uploaded") from None
-    except Exception:
-        path.unlink(missing_ok=True)
-        raise
 
     return {"stored": key}
 

--- a/backend/app/files.py
+++ b/backend/app/files.py
@@ -3,17 +3,24 @@
 With STORAGE_BACKEND=s3 these routes answer 404: uploads go straight to the
 bucket via presigned URLs and never pass through the API.
 
-Keys are minted server side at dispatch time and contain a job UUID, so an
-upload URL is unguessable; fleet authentication tightens this further when it
-lands (docs/blueprint.md, FLEET_TOKEN_KEY).
+Keys are minted server side at dispatch time, but a key is not authority: every
+part of it is derivable by any worker that was ever dispatched the job, so the
+PUT carries the dispatch token as well (issue #247). Uploads are write-once:
+the object the API verified must still be that object when a client reads it
+(issue #249).
 """
 
 import asyncio
+import logging
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse
 
-from app.storage import LocalStorage, get_storage, validate_download_name
+from app.storage import (
+    UPLOAD_TOKEN_HEADER, LocalStorage, get_storage, validate_download_name,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -36,7 +43,7 @@ def local_storage() -> LocalStorage:
 async def upload(key: str, request: Request) -> dict:
     from app import jobs
 
-    if not jobs.storage_key_in_flight(key):
+    if not jobs.upload_authorized(key, request.headers.get(UPLOAD_TOKEN_HEADER)):
         raise HTTPException(status_code=403, detail="upload not authorized")
 
     storage = local_storage()
@@ -53,10 +60,19 @@ async def upload(key: str, request: Request) -> dict:
 
     def write_file() -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(body)
+        # Exclusive: a second PUT to a key must not replace bytes the API has
+        # already inspected and committed an asset row for.
+        with open(path, "xb") as handle:
+            handle.write(body)
 
     try:
         await asyncio.to_thread(write_file)
+    except FileExistsError:
+        # Either a retry whose first upload actually landed, which is benign,
+        # or a replay. Refusing costs the caller nothing either way: a real
+        # retry is a new attempt and writes to a new key.
+        logger.warning("refused a second upload of %s", key)
+        raise HTTPException(status_code=409, detail="already uploaded") from None
     except Exception:
         path.unlink(missing_ok=True)
         raise

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1196,9 +1196,17 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     # The identity check alone cannot separate two attempts: a stall requeue
     # can hand the job back to the same Worker object, and then attempt one's
     # late job_done is indistinguishable from attempt two's. The token is per
-    # dispatch, so it can. An N-1 worker sends none and is still believed
-    # (docs/connection-handling.md), which is the compatibility floor.
+    # dispatch, so it can. A protocol 2 worker sends none and is still
+    # believed (docs/connection-handling.md), which is the compatibility
+    # floor; that acceptance disappears when the floor moves to 3.
     presented = control.get("dispatch_token")
+    if (presented is None and worker.protocol_version is not None
+            and worker.protocol_version >= 3):
+        # A current worker omitting the token is as stale as one presenting a
+        # wrong token, and gets the same warning.
+        logger.warning("worker %s sent a stale dispatch token for job %s; ignored",
+                       worker.id, job_id)
+        return
     if presented is not None:
         # compare_digest raises TypeError on a non-ASCII str, and TypeError is
         # not in the fleet handler's except tuple; such a token is stale, not

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -107,7 +107,9 @@ def upload_authorized(key: str, token: object) -> bool:
     what attempt two uploaded. The token is minted per dispatch and only the
     worker that received that dispatch has it.
     """
-    if not isinstance(token, str) or not token:
+    # compare_digest raises TypeError on a non-ASCII str, which a caller
+    # presents as a worker-supplied header; such a token is wrong, not a bug.
+    if not isinstance(token, str) or not token or not token.isascii():
         return False
     for entry in inflight.values():
         if key not in (entry.storage_key, entry.thumb_storage_key):
@@ -1198,7 +1200,10 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     # (docs/connection-handling.md), which is the compatibility floor.
     presented = control.get("dispatch_token")
     if presented is not None:
-        if (not isinstance(presented, str)
+        # compare_digest raises TypeError on a non-ASCII str, and TypeError is
+        # not in the fleet handler's except tuple; such a token is stale, not
+        # a crash.
+        if (not isinstance(presented, str) or not presented.isascii()
                 or not hmac.compare_digest(presented, current.dispatch_token)):
             logger.warning("worker %s sent a stale dispatch token for job %s; ignored",
                            worker.id, job_id)
@@ -1222,6 +1227,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         return
     image_dimensions = (0, 0)
     has_thumbnail = control.get("has_thumbnail") is True
+    thumb = None
     if control["type"] == "job_done":
         gpu_ms = _worker_int(control.get("gpu_ms"))
         phase_ms = {
@@ -1273,9 +1279,14 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
                 thumb = None
             if inflight.get(job_id) is not current:
                 return  # a requeue replaced this attempt during the inspection
-            if thumb is None or thumb.size <= 0 or thumb.content_type != "image/webp":
+            # The edge cap is enforced here, not by derivation from the master
+            # below: a 4096 px WebP would otherwise be recorded as a small
+            # thumbnail and served to gallery views as one.
+            if (thumb is None or thumb.size <= 0 or thumb.content_type != "image/webp"
+                    or max(thumb.width, thumb.height) > THUMBNAIL_MAX_EDGE):
                 logger.warning("worker %s claimed a thumbnail for job %s that is not a "
                                "usable WebP; dropping it", worker.id, job_id)
+                thumb = None
                 has_thumbnail = False
 
     entry = inflight.pop(job_id, None)
@@ -1310,22 +1321,18 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             )
             session.add(full)
             await session.flush()
-            if has_thumbnail:
-                edge = THUMBNAIL_MAX_EDGE
-                thumb_width = min(width, edge) if width else 0
-                thumb_height = min(height, edge) if height else 0
-                if width and height and max(width, height) > edge:
-                    scale = edge / max(width, height)
-                    thumb_width = int(width * scale)
-                    thumb_height = int(height * scale)
+            if thumb is not None:
+                # The inspected dimensions are the truth: the edge cap above
+                # has already admitted them, and the master's scaled-down
+                # numbers would only contradict what the object is.
                 session.add(Asset(
                     user_id=entry.user_id,
                     job_id=job_id,
                     parent_asset_id=full.id,
                     storage_key=entry.thumb_storage_key,
                     mime="image/webp",
-                    width=thumb_width,
-                    height=thumb_height,
+                    width=thumb.width,
+                    height=thumb.height,
                 ))
             await session.commit()
         orphans = []

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -10,10 +10,12 @@ the queue is rebuilt from them on startup.
 
 import asyncio
 import heapq
+import hmac
 import json
 import logging
 import math
 import re
+import secrets
 import time
 import unicodedata
 import uuid
@@ -89,6 +91,7 @@ class InFlight:
     storage_key: str
     thumb_storage_key: str
     user_id: uuid.UUID
+    dispatch_token: str
     attempt: int = 1
 
 
@@ -96,10 +99,20 @@ inflight: dict[uuid.UUID, InFlight] = {}
 lost_jobs: list[uuid.UUID] = []  # drained by the dispatch loop
 
 
-def storage_key_in_flight(key: str) -> bool:
-    for job_id, entry in inflight.items():
-        expected = storage_keys_for_attempt(entry.user_id, job_id, entry.attempt)
-        if key in expected:
+def upload_authorized(key: str, token: object) -> bool:
+    """Whether this key may be written by whoever presented this token.
+
+    The key alone is not authority: every part of it is derivable by any
+    worker that was ever dispatched this job, so attempt one could overwrite
+    what attempt two uploaded. The token is minted per dispatch and only the
+    worker that received that dispatch has it.
+    """
+    if not isinstance(token, str) or not token:
+        return False
+    for entry in inflight.values():
+        if key not in (entry.storage_key, entry.thumb_storage_key):
+            continue
+        if hmac.compare_digest(token, entry.dispatch_token):
             return True
     return False
 
@@ -1120,14 +1133,15 @@ async def dispatch(job_id: uuid.UUID) -> bool:
         storage_key, thumb_storage_key = storage_keys_for_attempt(
             job.user_id, job.id, job.attempt
         )
-        target = await get_storage().upload_target(storage_key)
-        thumb_target = await get_storage().upload_target(thumb_storage_key)
+        dispatch_token = secrets.token_urlsafe(16)
+        target = await get_storage().upload_target(storage_key, dispatch_token)
+        thumb_target = await get_storage().upload_target(thumb_storage_key, dispatch_token)
         # Bookkeeping before the send: if the worker dies from here on, its
         # disconnect handler finds the inflight entry and requeues the job.
         worker.jobs_in_flight += 1
         inflight[job.id] = InFlight(
             worker=worker, storage_key=storage_key, thumb_storage_key=thumb_storage_key,
-            user_id=job.user_id, attempt=job.attempt,
+            user_id=job.user_id, dispatch_token=dispatch_token, attempt=job.attempt,
         )
         last_progress_at[job_id] = time.monotonic()
         job.state = "running"
@@ -1137,6 +1151,7 @@ async def dispatch(job_id: uuid.UUID) -> bool:
             "job_id": str(job.id),
             "model_id": job.model_id,
             "params": job.params,
+            "dispatch_token": dispatch_token,
             "upload": {"url": target.url, "headers": target.headers},
             "thumb_upload": {"url": thumb_target.url, "headers": thumb_target.headers},
         }
@@ -1176,6 +1191,18 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     current = inflight.get(job_id)
     if current is None or current.worker is not worker:
         return  # stale report from a previous incarnation or attempt
+    # The identity check alone cannot separate two attempts: a stall requeue
+    # can hand the job back to the same Worker object, and then attempt one's
+    # late job_done is indistinguishable from attempt two's. The token is per
+    # dispatch, so it can. An N-1 worker sends none and is still believed
+    # (docs/connection-handling.md), which is the compatibility floor.
+    presented = control.get("dispatch_token")
+    if presented is not None:
+        if (not isinstance(presented, str)
+                or not hmac.compare_digest(presented, current.dispatch_token)):
+            logger.warning("worker %s sent a stale dispatch token for job %s; ignored",
+                           worker.id, job_id)
+            return
     if control["type"] == "job_progress":
         # float() raises TypeError on the list or dict json.loads accepts, and
         # OverflowError on the arbitrary-precision int it also accepts.
@@ -1194,6 +1221,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         publish(job_id, {"state": "running", "progress": progress})
         return
     image_dimensions = (0, 0)
+    has_thumbnail = control.get("has_thumbnail") is True
     if control["type"] == "job_done":
         gpu_ms = _worker_int(control.get("gpu_ms"))
         phase_ms = {
@@ -1233,6 +1261,22 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             await purge_attempt_blobs(entry.user_id, job_id, entry.attempt)
             return
         image_dimensions = (image.width, image.height)
+        if has_thumbnail:
+            # The thumbnail row used to exist on the worker's word alone, so a
+            # worker could have the studio serve arbitrary bytes as an image.
+            # A bad one is cosmetic, so it costs the row and the object, never
+            # the job.
+            try:
+                thumb = await get_storage().image_info(current.thumb_storage_key)
+            except Exception:
+                logger.exception("could not inspect thumbnail for job %s", job_id)
+                thumb = None
+            if inflight.get(job_id) is not current:
+                return  # a requeue replaced this attempt during the inspection
+            if thumb is None or thumb.size <= 0 or thumb.content_type != "image/webp":
+                logger.warning("worker %s claimed a thumbnail for job %s that is not a "
+                               "usable WebP; dropping it", worker.id, job_id)
+                has_thumbnail = False
 
     entry = inflight.pop(job_id, None)
     live_progress.pop(job_id, None)
@@ -1266,7 +1310,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             )
             session.add(full)
             await session.flush()
-            if control.get("has_thumbnail") is True:
+            if has_thumbnail:
                 edge = THUMBNAIL_MAX_EDGE
                 thumb_width = min(width, edge) if width else 0
                 thumb_height = min(height, edge) if height else 0
@@ -1285,8 +1329,9 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
                 ))
             await session.commit()
         orphans = []
-        if control.get("has_thumbnail") is not True:
-            # This attempt may have uploaded a thumbnail it did not report.
+        if not has_thumbnail:
+            # This attempt may have uploaded a thumbnail it did not report, or
+            # reported one the inspection below rejected.
             orphans.append(entry.thumb_storage_key)
         # Attempts no longer share one key, so a retry leaves the earlier
         # attempt's blobs behind instead of overwriting them. Nothing else

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -30,7 +30,7 @@ from app import db
 logger = logging.getLogger("potocolom.realtime")
 
 # Wire constants; keep in sync with worker/worker/client.py.
-PROTOCOL_VERSION = 2
+PROTOCOL_VERSION = 3
 MIN_SUPPORTED_VERSION = PROTOCOL_VERSION - 1
 
 CANVAS_FRAME = 0x01
@@ -253,6 +253,7 @@ class Worker:
     realtime_slots: int
     device: str | None = None
     memory_mode: str | None = None
+    protocol_version: int | None = None
     slots_in_use: int = 0
     jobs_in_flight: int = 0  # queued jobs; capped at JOB_DISPATCH_DEPTH in jobs.py
     last_seen: float = field(default_factory=time.monotonic)
@@ -445,7 +446,8 @@ async def fleet(ws: WebSocket) -> None:
         worker = Worker(id=hello["worker_id"], ws=ws, manifests=worker_manifests,
                         realtime_slots=hello["realtime_slots"],
                         device=hello.get("device"),
-                        memory_mode=hello.get("memory_mode"))
+                        memory_mode=hello.get("memory_mode"),
+                        protocol_version=version)
         if not (isinstance(version, int) and isinstance(worker.id, str)
                 and isinstance(worker.realtime_slots, int)
                 and (worker.device is None or isinstance(worker.device, str))

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -63,7 +63,7 @@ class ImageInfo:
 # width and height is a ceiling the peer sets. 4096 is the real maximum, a
 # factor-4 upscale of the largest shipped generation size.
 MAX_IMAGE_EDGE = 4096
-# Enough for any real encoder, and it bounds the walk below.
+# Enough for any real encoder, and it bounds both walks below.
 MAX_PNG_CHUNKS = 4096
 
 # Bit depths each PNG colour type allows (PNG spec, table 11.1).
@@ -141,32 +141,77 @@ def _webp_dimensions(data: bytes) -> tuple[int, int]:
 
     Thumbnails are the only WebP the fleet uploads, and until now nothing read
     them: job_done created the thumbnail row on the worker's word alone. This
-    reads the RIFF container and the first chunk header, which is all three
-    WebP flavours need to state their canvas, and like the PNG walk above it
-    never decodes a pixel.
+    walks the chunk list like the PNG walk above and never decodes a pixel: a
+    simple file is one VP8 or VP8L frame, an extended one starts with a VP8X
+    header that states the canvas, and a chunk whose declared length does not
+    fit the RIFF payload is a fabricated container, not a thumbnail.
     """
-    if len(data) < 30 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
+    if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         raise ValueError("stored object is not a WebP")
     # The RIFF length counts everything after it, so it must fit the object.
-    if struct.unpack_from("<I", data, 4)[0] + 8 > len(data):
+    riff_size = struct.unpack_from("<I", data, 4)[0]
+    if riff_size + 8 > len(data):
         raise ValueError("stored WebP is truncated")
-    kind = data[12:16]
-    if kind == b"VP8X":
-        width = int.from_bytes(data[24:27], "little") + 1
-        height = int.from_bytes(data[27:30], "little") + 1
-    elif kind == b"VP8 ":
-        if data[23:26] != b"\x9d\x01\x2a":
-            raise ValueError("stored WebP has no lossy keyframe")
-        width = struct.unpack_from("<H", data, 26)[0] & 0x3fff
-        height = struct.unpack_from("<H", data, 28)[0] & 0x3fff
-    elif kind == b"VP8L":
-        if data[20] != 0x2f:
-            raise ValueError("stored WebP has no lossless signature")
-        bits = int.from_bytes(data[21:25], "little")
-        width = (bits & 0x3fff) + 1
-        height = ((bits >> 14) & 0x3fff) + 1
-    else:
-        raise ValueError("stored WebP has an unknown first chunk")
+    view = memoryview(data)
+    payload_end = riff_size + 8
+    position = 12
+    width = height = 0
+    chunks = 0
+    saw_vp8x = False
+    saw_image = False
+    while position + 8 <= payload_end:
+        chunks += 1
+        if chunks > MAX_PNG_CHUNKS:
+            raise ValueError("stored WebP has too many chunks")
+        length = struct.unpack_from("<I", view, position + 4)[0]
+        # Chunk payloads are padded to an even length.
+        end = position + 8 + length + (length & 1)
+        if end > payload_end:
+            raise ValueError("stored WebP has a truncated chunk")
+        kind = bytes(view[position:position + 4])
+        if kind == b"VP8X":
+            # The extended form only exists as the first chunk, declared
+            # exactly 10 bytes, and its header states the canvas for the file.
+            if chunks != 1 or length != 10:
+                raise ValueError("stored WebP has a misplaced VP8X header")
+            saw_vp8x = True
+            width = int.from_bytes(view[position + 12:position + 15], "little") + 1
+            height = int.from_bytes(view[position + 15:position + 18], "little") + 1
+        else:
+            # A simple file is exactly one VP8 or VP8L chunk; any chunk after
+            # one is neither simple nor extended.
+            if not saw_vp8x and chunks != 1:
+                raise ValueError("stored WebP has a chunk after a simple image")
+            if kind == b"VP8 ":
+                if length < 10:
+                    raise ValueError("stored WebP has a truncated frame")
+                if bytes(view[position + 11:position + 14]) != b"\x9d\x01\x2a":
+                    raise ValueError("stored WebP has no lossy keyframe")
+                if width == 0:
+                    width = struct.unpack_from("<H", view, position + 14)[0] & 0x3fff
+                    height = struct.unpack_from("<H", view, position + 16)[0] & 0x3fff
+                saw_image = True
+            elif kind == b"VP8L":
+                if length < 5:
+                    raise ValueError("stored WebP has a truncated lossless frame")
+                if view[position + 8] != 0x2f:
+                    raise ValueError("stored WebP has no lossless signature")
+                bits = int.from_bytes(view[position + 9:position + 13], "little")
+                if bits >> 29:
+                    raise ValueError("stored WebP has an unknown lossless version")
+                if width == 0:
+                    width = (bits & 0x3fff) + 1
+                    height = ((bits >> 14) & 0x3fff) + 1
+                saw_image = True
+            elif kind == b"ANMF":
+                saw_image = True
+            elif kind not in (b"ALPH", b"ICCP", b"EXIF", b"XMP"):
+                raise ValueError("stored WebP has an unknown chunk")
+        position = end
+    if position != payload_end:
+        raise ValueError("stored WebP has a truncated chunk")
+    if not saw_image:
+        raise ValueError("stored WebP carries no image data")
     if width == 0 or height == 0:
         raise ValueError("stored WebP has empty dimensions")
     if width > MAX_IMAGE_EDGE or height > MAX_IMAGE_EDGE:

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -143,8 +143,9 @@ def _webp_dimensions(data: bytes) -> tuple[int, int]:
     them: job_done created the thumbnail row on the worker's word alone. This
     walks the chunk list like the PNG walk above and never decodes a pixel: a
     simple file is one VP8 or VP8L frame, an extended one starts with a VP8X
-    header that states the canvas, and a chunk whose declared length does not
-    fit the RIFF payload is a fabricated container, not a thumbnail.
+    header whose canvas the frame must match, and a chunk whose declared
+    length does not fit the RIFF payload is a fabricated container, not a
+    thumbnail.
     """
     if len(data) < 12 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
         raise ValueError("stored object is not a WebP")
@@ -187,9 +188,13 @@ def _webp_dimensions(data: bytes) -> tuple[int, int]:
                     raise ValueError("stored WebP has a truncated frame")
                 if bytes(view[position + 11:position + 14]) != b"\x9d\x01\x2a":
                     raise ValueError("stored WebP has no lossy keyframe")
-                if width == 0:
-                    width = struct.unpack_from("<H", view, position + 14)[0] & 0x3fff
-                    height = struct.unpack_from("<H", view, position + 16)[0] & 0x3fff
+                frame_width = struct.unpack_from("<H", view, position + 14)[0] & 0x3fff
+                frame_height = struct.unpack_from("<H", view, position + 16)[0] & 0x3fff
+                if saw_image:
+                    raise ValueError("stored WebP has a second bitstream")
+                if saw_vp8x and (width != frame_width or height != frame_height):
+                    raise ValueError("stored WebP frame contradicts its VP8X canvas")
+                width, height = frame_width, frame_height
                 saw_image = True
             elif kind == b"VP8L":
                 if length < 5:
@@ -199,14 +204,20 @@ def _webp_dimensions(data: bytes) -> tuple[int, int]:
                 bits = int.from_bytes(view[position + 9:position + 13], "little")
                 if bits >> 29:
                     raise ValueError("stored WebP has an unknown lossless version")
-                if width == 0:
-                    width = (bits & 0x3fff) + 1
-                    height = ((bits >> 14) & 0x3fff) + 1
+                frame_width = (bits & 0x3fff) + 1
+                frame_height = ((bits >> 14) & 0x3fff) + 1
+                if saw_image:
+                    raise ValueError("stored WebP has a second bitstream")
+                if saw_vp8x and (width != frame_width or height != frame_height):
+                    raise ValueError("stored WebP frame contradicts its VP8X canvas")
+                width, height = frame_width, frame_height
                 saw_image = True
-            elif kind == b"ANMF":
-                saw_image = True
-            elif kind not in (b"ALPH", b"ICCP", b"EXIF", b"XMP"):
-                raise ValueError("stored WebP has an unknown chunk")
+            else:
+                # Animations are refused as well: the fleet uploads a still
+                # thumbnail, and accepting an animation would mean validating
+                # the whole nested frame structure for no use case.
+                if kind not in (b"ALPH", b"ICCP", b"EXIF", b"XMP "):
+                    raise ValueError("stored WebP has an unknown chunk")
         position = end
     if position != payload_end:
         raise ValueError("stored WebP has a truncated chunk")

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -18,6 +18,8 @@ from urllib.parse import urlencode
 from app.settings import Settings, get_settings
 
 SIGNED_URL_TTL = 3600
+# Carries the dispatch token on a local upload (app/files.py, issue #247).
+UPLOAD_TOKEN_HEADER = "X-Upload-Token"
 PNG_CONTENT_TYPE = "image/png"
 WEBP_CONTENT_TYPE = "image/webp"
 DOWNLOAD_NAME_MAX_LENGTH = 96
@@ -134,8 +136,62 @@ def _png_dimensions(data: bytes) -> tuple[int, int]:
     return width, height
 
 
+def _webp_dimensions(data: bytes) -> tuple[int, int]:
+    """Dimensions of a stored WebP, or ValueError if it is not a usable one.
+
+    Thumbnails are the only WebP the fleet uploads, and until now nothing read
+    them: job_done created the thumbnail row on the worker's word alone. This
+    reads the RIFF container and the first chunk header, which is all three
+    WebP flavours need to state their canvas, and like the PNG walk above it
+    never decodes a pixel.
+    """
+    if len(data) < 30 or data[:4] != b"RIFF" or data[8:12] != b"WEBP":
+        raise ValueError("stored object is not a WebP")
+    # The RIFF length counts everything after it, so it must fit the object.
+    if struct.unpack_from("<I", data, 4)[0] + 8 > len(data):
+        raise ValueError("stored WebP is truncated")
+    kind = data[12:16]
+    if kind == b"VP8X":
+        width = int.from_bytes(data[24:27], "little") + 1
+        height = int.from_bytes(data[27:30], "little") + 1
+    elif kind == b"VP8 ":
+        if data[23:26] != b"\x9d\x01\x2a":
+            raise ValueError("stored WebP has no lossy keyframe")
+        width = struct.unpack_from("<H", data, 26)[0] & 0x3fff
+        height = struct.unpack_from("<H", data, 28)[0] & 0x3fff
+    elif kind == b"VP8L":
+        if data[20] != 0x2f:
+            raise ValueError("stored WebP has no lossless signature")
+        bits = int.from_bytes(data[21:25], "little")
+        width = (bits & 0x3fff) + 1
+        height = ((bits >> 14) & 0x3fff) + 1
+    else:
+        raise ValueError("stored WebP has an unknown first chunk")
+    if width == 0 or height == 0:
+        raise ValueError("stored WebP has empty dimensions")
+    if width > MAX_IMAGE_EDGE or height > MAX_IMAGE_EDGE:
+        raise ValueError("stored WebP dimensions are implausible")
+    return width, height
+
+
+def _inspect(data: bytes) -> tuple[int, int, str] | None:
+    """Dimensions and content type of stored bytes, or None if unusable.
+
+    The type is decided by the bytes, never by what the peer declared: an
+    uploader controls its own Content-Type header.
+    """
+    for parse, content_type in ((_png_dimensions, PNG_CONTENT_TYPE),
+                                (_webp_dimensions, WEBP_CONTENT_TYPE)):
+        try:
+            width, height = parse(data)
+        except ValueError:
+            continue
+        return width, height, content_type
+    return None
+
+
 class Storage(Protocol):
-    async def upload_target(self, key: str) -> UploadTarget: ...
+    async def upload_target(self, key: str, token: str | None = None) -> UploadTarget: ...
 
     async def image_info(self, key: str) -> ImageInfo | None: ...
 
@@ -160,11 +216,17 @@ class LocalStorage:
             raise ValueError("storage key escapes the storage root")
         return path
 
-    async def upload_target(self, key: str) -> UploadTarget:
+    async def upload_target(self, key: str, token: str | None = None) -> UploadTarget:
         content_type = PNG_CONTENT_TYPE if key.endswith(".png") else WEBP_CONTENT_TYPE
+        headers = {"Content-Type": content_type}
+        if token:
+            # The local route has no signature to check, so the dispatch token
+            # is what proves this upload belongs to the dispatch that minted
+            # the key rather than to anyone who can derive it (issue #247).
+            headers[UPLOAD_TOKEN_HEADER] = token
         return UploadTarget(
             url=f"{self.worker_url}/api/v1/files/{key}",
-            headers={"Content-Type": content_type},
+            headers=headers,
         )
 
     async def image_info(self, key: str) -> ImageInfo | None:
@@ -176,12 +238,12 @@ class LocalStorage:
                 data = path.read_bytes()
             except FileNotFoundError:
                 return None
-            try:
-                width, height = _png_dimensions(data)
-            except ValueError:
+            inspected = _inspect(data)
+            if inspected is None:
                 return None
+            width, height, content_type = inspected
             return ImageInfo(width=width, height=height, size=len(data),
-                             content_type=PNG_CONTENT_TYPE)
+                             content_type=content_type)
 
         # Off the loop: the read is up to MAX_VERIFY_BYTES of peer-supplied
         # bytes and every millisecond of it would otherwise stall every other
@@ -218,8 +280,9 @@ class S3Storage:
             config=Config(signature_version="s3v4"),  # MinIO requires SigV4
         )
 
-    async def upload_target(self, key: str) -> UploadTarget:
-        # Presigning is local computation, no network round trip.
+    async def upload_target(self, key: str, token: str | None = None) -> UploadTarget:
+        # Presigning is local computation, no network round trip. The token is
+        # the local backend's capability; here the signed URL is one already.
         content_type = PNG_CONTENT_TYPE if key.endswith(".png") else WEBP_CONTENT_TYPE
         url = self.client.generate_presigned_url(
             "put_object",
@@ -227,10 +290,16 @@ class S3Storage:
                 "Bucket": self.bucket,
                 "Key": key,
                 "ContentType": content_type,
+                # Signed so the bucket refuses a second write with 412: a
+                # presigned PUT stays valid for its whole TTL and would
+                # otherwise replace bytes the API has already verified
+                # (issue #249).
+                "IfNoneMatch": "*",
             },
             ExpiresIn=SIGNED_URL_TTL,
         )
-        return UploadTarget(url=url, headers={"Content-Type": content_type})
+        return UploadTarget(url=url, headers={"Content-Type": content_type,
+                                              "If-None-Match": "*"})
 
     async def image_info(self, key: str) -> ImageInfo | None:
         from botocore.exceptions import ClientError
@@ -266,15 +335,16 @@ class S3Storage:
             raise
         if len(data) > MAX_VERIFY_BYTES:
             return None
-        try:
-            width, height = _png_dimensions(data)
-        except ValueError:
+        inspected = _inspect(data)
+        if inspected is None:
             return None
+        width, height, content_type = inspected
         return ImageInfo(
             width=width,
             height=height,
             size=response.get("ContentLength", len(data)),
-            content_type=response.get("ContentType", PNG_CONTENT_TYPE),
+            # Not response ContentType: that is what the uploader declared.
+            content_type=content_type,
         )
 
     async def url(self, key: str, download_name: str | None = None) -> str:

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -2571,6 +2571,60 @@ def test_authorization_is_rechecked_after_the_body(monkeypatch):
 
 
 @pytest.mark.db
+def test_authorization_is_rechecked_between_write_and_link(monkeypatch):
+    """The write happens in a thread, and the re-check only counts if the
+    link follows it on the loop: a requeue that lands while the temporary is
+    being written must leave nothing behind and publish nothing."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-write-link")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "write-link"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            key = uuid.UUID(job_id)
+            current = jobs.inflight[key]
+            replacement = jobs.InFlight(
+                worker=current.worker, storage_key=current.storage_key,
+                thumb_storage_key=current.thumb_storage_key,
+                user_id=current.user_id, dispatch_token="replacement-token",
+                attempt=2,
+            )
+            real_to_thread = asyncio.to_thread
+
+            def superseding_to_thread(function):
+                def swap_after_write():
+                    try:
+                        return function()
+                    finally:
+                        # The requeue lands once the temporary exists, between
+                        # the off-thread write and the on-loop link.
+                        jobs.inflight[key] = replacement
+
+                return real_to_thread(swap_after_write)
+
+            monkeypatch.setattr(asyncio, "to_thread", superseding_to_thread)
+            response = client.put(urlsplit(dispatch["upload"]["url"]).path,
+                                  content=png_bytes(),
+                                  headers=dispatch["upload"]["headers"])
+            assert response.status_code == 403
+            storage = jobs.get_storage()
+            assert not storage.path(current.storage_key).exists()
+            leftovers = [
+                entry.name for entry in storage.path(current.storage_key).parent.iterdir()
+                if entry.name.startswith(".upload-")
+            ]
+            assert not leftovers, "a refused upload left its temporary behind"
+            assert jobs.inflight.get(key) is replacement
+
+            # Finish the job so it does not sit running in the shared database.
+            worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                              "width": 512, "height": 512})
+            poll_until(client, job_id, "failed")
+
+
+@pytest.mark.db
 def test_a_failed_write_leaves_no_partial_upload(monkeypatch):
     """Publishing is atomic: a write that fails partway must not leave a
     truncated object at the key, because nothing would replace it (uploads are
@@ -2613,7 +2667,7 @@ def test_a_failed_write_leaves_no_partial_upload(monkeypatch):
             assert not storage.path(key).exists(), "a failed write left a partial object"
             leftovers = [
                 entry.name for entry in storage.path(key).parent.iterdir()
-                if entry.name.startswith(storage.path(key).name)
+                if entry.name.startswith(".upload-")
             ]
             assert not leftovers, "a failed write left temporary files behind"
 
@@ -2624,3 +2678,30 @@ def test_a_failed_write_leaves_no_partial_upload(monkeypatch):
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
                               "width": 512, "height": 512})
             poll_until(client, job_id, "succeeded")
+
+
+@pytest.mark.db
+def test_upload_temporaries_carry_a_debris_prefix(monkeypatch):
+    """A process death between write and link leaves the temporary behind, so
+    its name must read as debris rather than content; the destination names
+    itself, and the directory is already per user and per job."""
+    import tempfile
+
+    real_mkstemp = tempfile.mkstemp
+    prefixes = []
+
+    def recording_mkstemp(*args, **kwargs):
+        prefixes.append(kwargs.get("prefix"))
+        return real_mkstemp(*args, **kwargs)
+
+    monkeypatch.setattr(tempfile, "mkstemp", recording_mkstemp)
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-temp-prefix")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "temp prefix"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+            assert prefixes == [".upload-"]

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -2,6 +2,7 @@
 real fleet WebSocket. Real inference is the worker's side (worker/tests)."""
 
 import asyncio
+import base64
 import struct
 import threading
 import time
@@ -47,11 +48,22 @@ MANIFEST_WITH_RT = {
 HOSTILE_PROMPT = 'A "lighthouse"\n; ../../ caf\u00e9'
 
 
-def webp_bytes(width=64, height=64):
-    """The extended (VP8X) form, which carries the canvas size in its header."""
-    body = (b"VP8X" + struct.pack("<I", 10) + b"\x00" * 4
-            + (width - 1).to_bytes(3, "little") + (height - 1).to_bytes(3, "little"))
-    return b"RIFF" + struct.pack("<I", 4 + len(body)) + b"WEBP" + body + b"\x00" * 10
+# A real lossless 320x200 WebP, encoded with
+# `ffmpeg -f lavfi -i color=c=red:s=320x200 -lossless 1` and embedded as
+# base64 so the module stays ASCII: CI has no ffmpeg, and a hand-built header
+# is a replica of the parser, so it proves nothing about real files.
+_WEBP_BYTES = base64.b64decode(
+    "UklGRiQAAABXRUJQVlA4TBcAAAAvP8ExAAcQ9Y/+BwAU6f9/iuh/6v+fAQA="
+)
+
+# The same red canvas at 400x300: past THUMBNAIL_MAX_EDGE on its longest edge.
+_WEBP_BIG_BYTES = base64.b64decode(
+    "UklGRiYAAABXRUJQVlA4TBoAAAAvj8FKAAcQ9Y/+BwQkSf//kxH9z/jPf/6fKQ=="
+)
+
+
+def webp_bytes():
+    return _WEBP_BYTES
 
 
 def dispatch_for(worker, job_id, limit=5):
@@ -379,6 +391,19 @@ def test_generation_end_to_end():
             assert client.get(urlsplit(asset["url"]).path).content == png_bytes(320, 240)
             assert client.get(urlsplit(asset["thumbnail_url"]).path).content == webp_bytes()
 
+            async def recorded_thumb_dimensions() -> tuple[int, int]:
+                assert db.session_factory is not None
+                async with db.session_factory() as session:
+                    row = await session.scalar(
+                        select(Asset).where(Asset.parent_asset_id == uuid.UUID(asset["id"]))
+                    )
+                    assert row is not None
+                    return row.width, row.height
+
+            # The thumbnail row carries the inspected dimensions, not a
+            # derivation from the master's: the object is the truth.
+            assert asyncio.run(recorded_thumb_dimensions()) == (320, 200)
+
             history = client.get("/api/v1/generations").json()
             assert any(entry["id"] == job_id for entry in history)
 
@@ -540,13 +565,18 @@ def test_stalled_job_requeues_once(monkeypatch):
                 job_id = client.post("/api/v1/generations",
                                      json={"model_id": "sd-test",
                                            "params": {"prompt": "stall"}}).json()["job_id"]
-                assert worker.receive_json()["job_id"] == job_id
+                first = worker.receive_json()
+                assert first["job_id"] == job_id
                 # Worker stays connected but sends no progress; stall requeues once
                 # and the retry is dispatched back to the same connected worker.
                 poll_until_attempt(client, job_id, 2, timeout=3.0)
                 redispatch = worker.receive_json()
                 assert redispatch["type"] == "dispatch_job"
                 assert redispatch["job_id"] == job_id
+                # A requeue that reused the token would let attempt one publish
+                # to attempt two's keys, so the token must be fresh per
+                # dispatch (issue #247).
+                assert redispatch["dispatch_token"] != first["dispatch_token"]
     finally:
         monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
         get_settings.cache_clear()
@@ -2422,3 +2452,175 @@ def test_a_thumbnail_that_is_not_a_webp_is_dropped_rather_than_served():
             assert job["assets"][0]["thumbnail_url"] is None
             # The rejected object is collected, not left addressable.
             assert client.get(urlsplit(dispatch["thumb_upload"]["url"]).path).status_code == 404
+
+
+@pytest.mark.db
+def test_an_oversized_thumbnail_is_dropped_rather_than_scaled_down():
+    """An oversized WebP used to pass inspection and was then recorded with
+    the master's dimensions scaled to the thumbnail cap, so a huge object was
+    served to gallery views as a small thumbnail."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-big-thumb")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "big thumb"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["thumb_upload"],
+                              _WEBP_BIG_BYTES).status_code == 200
+            worker.send_json({"type": "job_done", "job_id": job_id,
+                              "dispatch_token": dispatch["dispatch_token"],
+                              "gpu_ms": 4, "width": 512, "height": 512,
+                              "has_thumbnail": True})
+
+            job = poll_until(client, job_id, "succeeded")
+            assert len(job["assets"]) == 1
+            assert job["assets"][0]["thumbnail_url"] is None
+            assert client.get(urlsplit(dispatch["thumb_upload"]["url"]).path).status_code == 404
+
+
+def test_a_non_ascii_dispatch_token_is_ignored():
+    """compare_digest raises TypeError on a non-ASCII str, and TypeError is
+    not in the fleet handler's except tuple, so such a token used to raise out
+    of the socket; it is stale, not a crash."""
+    worker = realtime.Worker(id="w-non-ascii", ws=None, manifests=[], realtime_slots=1)
+    job_id = uuid.uuid4()
+    jobs.inflight[job_id] = jobs.InFlight(
+        worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
+        dispatch_token="token",
+    )
+    try:
+        asyncio.run(jobs.on_worker_message(worker, {
+            "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
+            "dispatch_token": "caf\u00e9",
+        }))
+        assert job_id in jobs.inflight
+        assert job_id not in jobs.live_progress
+    finally:
+        jobs.inflight.pop(job_id, None)
+        jobs.live_progress.pop(job_id, None)
+        jobs.last_progress_at.pop(job_id, None)
+
+
+def test_a_non_ascii_upload_token_fails_closed():
+    """compare_digest raises TypeError on a non-ASCII str, which used to make
+    the upload route answer 500; a token that cannot be compared is wrong, not
+    a bug (TestClient cannot even send such a header, so the guard itself is
+    exercised here)."""
+    worker = realtime.Worker(id="w-non-ascii-upload", ws=None, manifests=[],
+                             realtime_slots=1)
+    job_id = uuid.uuid4()
+    jobs.inflight[job_id] = jobs.InFlight(
+        worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
+        dispatch_token="token",
+    )
+    try:
+        assert not jobs.upload_authorized("k", "caf\u00e9")
+        # The ASCII token of its own dispatch is still believed.
+        assert jobs.upload_authorized("k", "token")
+    finally:
+        jobs.inflight.pop(job_id, None)
+
+
+@pytest.mark.db
+def test_authorization_is_rechecked_after_the_body(monkeypatch):
+    """The first check runs before the body arrives, and reading it can take
+    long enough for a retry to supersede this attempt; the second check must
+    stop the stale bytes from being published under the winning key."""
+    from starlette.requests import Request
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-recheck")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "recheck"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            key = uuid.UUID(job_id)
+            current = jobs.inflight[key]
+            replacement = jobs.InFlight(
+                worker=current.worker, storage_key=current.storage_key,
+                thumb_storage_key=current.thumb_storage_key,
+                user_id=current.user_id, dispatch_token="replacement-token",
+                attempt=2,
+            )
+            real_stream = Request.stream
+
+            def superseding_stream(self):
+                # The requeue lands while the body is being read, between the
+                # two checks.
+                jobs.inflight[key] = replacement
+                return real_stream(self)
+
+            monkeypatch.setattr(Request, "stream", superseding_stream)
+            response = client.put(urlsplit(dispatch["upload"]["url"]).path,
+                                  content=png_bytes(),
+                                  headers=dispatch["upload"]["headers"])
+            assert response.status_code == 403
+            storage = jobs.get_storage()
+            assert not storage.path(current.storage_key).exists()
+            assert jobs.inflight.get(key) is replacement
+
+            # Finish the job so it does not sit running in the shared database.
+            worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                              "width": 512, "height": 512})
+            poll_until(client, job_id, "failed")
+
+
+@pytest.mark.db
+def test_a_failed_write_leaves_no_partial_upload(monkeypatch):
+    """Publishing is atomic: a write that fails partway must not leave a
+    truncated object at the key, because nothing would replace it (uploads are
+    write-once) and the API could inspect and approve a prefix."""
+    import os
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-partial-write")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "partial"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            path = urlsplit(dispatch["upload"]["url"]).path
+            key = path.rsplit("/api/v1/files/", 1)[-1]
+            storage = jobs.get_storage()
+
+            real_fdopen = os.fdopen
+
+            def failing_fdopen(fd, mode):
+                handle = real_fdopen(fd, mode)
+
+                class Failing:
+                    def __enter__(self):
+                        return self
+
+                    def __exit__(self, *args):
+                        return handle.__exit__(*args)
+
+                    def write(self, data):
+                        handle.write(data[:16])
+                        raise OSError("simulated disk failure")
+
+                return Failing()
+
+            monkeypatch.setattr("app.files.os.fdopen", failing_fdopen)
+            assert client.put(path, content=png_bytes(),
+                              headers=dispatch["upload"]["headers"]).status_code == 500
+            assert not storage.path(key).exists(), "a failed write left a partial object"
+            leftovers = [
+                entry.name for entry in storage.path(key).parent.iterdir()
+                if entry.name.startswith(storage.path(key).name)
+            ]
+            assert not leftovers, "a failed write left temporary files behind"
+
+            monkeypatch.undo()
+            # The retry is a fresh attempt on the same key here, and it must
+            # not find a corpse from the failed write.
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+            worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
+                              "width": 512, "height": 512})
+            poll_until(client, job_id, "succeeded")

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -166,8 +166,8 @@ def test_generation_download_name_includes_batch_position():
     )
 
 
-def fleet_hello(ws, worker_id, manifest=MANIFEST):
-    ws.send_json({"type": "hello", "protocol_version": PROTOCOL_VERSION,
+def fleet_hello(ws, worker_id, manifest=MANIFEST, version=PROTOCOL_VERSION):
+    ws.send_json({"type": "hello", "protocol_version": version,
                   "worker_id": worker_id, "models": [manifest], "realtime_slots": 1})
     assert ws.receive_json()["type"] == "registered"
 
@@ -366,10 +366,13 @@ def test_generation_end_to_end():
             assert put_upload(client, dispatch["thumb_upload"],
                               webp_bytes()).status_code == 200
 
-            worker.send_json({"type": "job_progress", "job_id": job_id, "progress": 0.5})
+            worker.send_json({"type": "job_progress", "job_id": job_id,
+                              "progress": 0.5,
+                              "dispatch_token": dispatch["dispatch_token"]})
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 1234, "width": 512, "height": 512,
-                              "has_thumbnail": True})
+                              "has_thumbnail": True,
+                              "dispatch_token": dispatch["dispatch_token"]})
 
             job = poll_until(client, job_id, "succeeded")
             assert job["gpu_ms"] == 1234
@@ -498,7 +501,8 @@ def test_worker_loss_requeues_once():
             fleet_hello(worker, "w-heals")
             redispatch = worker.receive_json()
             assert redispatch["job_id"] == job_id
-            worker.send_json({"type": "job_failed", "job_id": job_id, "reason": "boom"})
+            worker.send_json({"type": "job_failed", "job_id": job_id, "reason": "boom",
+                              "dispatch_token": redispatch["dispatch_token"]})
             poll_until(client, job_id, "failed")
 
 
@@ -643,7 +647,8 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
                 assert put_upload(client, second["upload"],
                                   png_bytes()).status_code == 200
                 worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                                  "width": 512, "height": 512})
+                                  "width": 512, "height": 512,
+                                  "dispatch_token": second["dispatch_token"]})
                 poll_until(client, job_id, "succeeded")
 
                 assert asyncio.run(storage.image_info(first_key)) is None
@@ -676,7 +681,8 @@ def test_a_reported_failure_does_not_leave_its_upload_behind():
             assert storage.path(key).exists()
 
             worker.send_json({"type": "job_failed", "job_id": job_id,
-                              "reason": "worker said no"})
+                              "reason": "worker said no",
+                              "dispatch_token": dispatch["dispatch_token"]})
             poll_until(client, job_id, "failed")
             deadline = time.monotonic() + 3
             while time.monotonic() < deadline and storage.path(key).exists():
@@ -729,7 +735,8 @@ def test_a_late_verdict_does_not_fail_the_attempt_that_replaced_it(monkeypatch):
             inspected = threading.Event()
             monkeypatch.setattr(jobs, "get_storage", lambda: Replacing())
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                              "width": 512, "height": 512})
+                              "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
 
             # The stand-in gives a deterministic hook, so wait on the verdict
             # rather than polling a negative for two seconds on every run.
@@ -746,7 +753,8 @@ def test_a_late_verdict_does_not_fail_the_attempt_that_replaced_it(monkeypatch):
             monkeypatch.undo()
             jobs.inflight[key] = superseded
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                              "width": 512, "height": 512})
+                              "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
             poll_until(client, job_id, "succeeded")
 
 
@@ -774,7 +782,8 @@ def test_a_rejected_upload_is_not_left_in_storage():
             assert storage.path(key).exists()
 
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                              "width": 512, "height": 512})
+                              "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
             poll_until(client, job_id, "failed")
             assert not storage.path(key).exists(), "rejected upload was left behind"
 
@@ -820,7 +829,8 @@ def test_a_rejected_retry_collects_every_attempt(monkeypatch):
                 second_key = second_path.rsplit("/api/v1/files/", 1)[-1]
 
                 worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                                  "width": 512, "height": 512})
+                                  "width": 512, "height": 512,
+                                  "dispatch_token": second["dispatch_token"]})
                 poll_until(client, job_id, "failed")
                 deadline = time.monotonic() + 3
                 keys = (first_key, first_thumb_key, second_key)
@@ -859,10 +869,11 @@ def test_malformed_completion_is_recoverable_through_the_fleet_socket(monkeypatc
                 "/api/v1/generations",
                 json={"model_id": "sd-test", "params": {"prompt": "malformed"}},
             ).json()["job_id"]
-            worker.receive_json()
+            dispatch = worker.receive_json()
             worker.send_json({
                 "type": "job_done",
                 "job_id": job_id,
+                "dispatch_token": dispatch["dispatch_token"],
                 "gpu_ms": {"not": "a number"},
                 "width": 512,
                 "height": 512,
@@ -900,7 +911,8 @@ def test_recover_requeues_running_and_dispatches_queued():
                               webp_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": first_id,
                               "gpu_ms": 1, "width": 512, "height": 512,
-                              "has_thumbnail": True})
+                              "has_thumbnail": True,
+                              "dispatch_token": first["dispatch_token"]})
             poll_until(client, first_id, "succeeded")
 
             second = worker.receive_json()
@@ -924,7 +936,8 @@ def test_img2img_dispatch_includes_input_url():
             dispatch = worker.receive_json()
             assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
-                              "gpu_ms": 100, "width": 512, "height": 512})
+                              "gpu_ms": 100, "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
             source_job = poll_until(client, source_job_id, "succeeded")
             source_asset_id = source_job["assets"][0]["id"]
 
@@ -945,7 +958,8 @@ def test_img2img_dispatch_includes_input_url():
             assert put_upload(client, i2i_dispatch["upload"],
                               png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": edit_job_id,
-                              "gpu_ms": 200, "width": 512, "height": 512})
+                              "gpu_ms": 200, "width": 512, "height": 512,
+                              "dispatch_token": i2i_dispatch["dispatch_token"]})
             edit_job = poll_until(client, edit_job_id, "succeeded")
             assert edit_job["assets"][0]["url"].endswith(".png")
             assert edit_job["source_asset_id"] == source_asset_id
@@ -964,7 +978,8 @@ def test_img2img_rejects_model_without_capability():
             dispatch = worker.receive_json()
             assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": job_id,
-                              "gpu_ms": 1, "width": 512, "height": 512})
+                              "gpu_ms": 1, "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
             source_job = poll_until(client, job_id, "succeeded")
             source_asset_id = source_job["assets"][0]["id"]
 
@@ -1001,7 +1016,8 @@ def test_upscale_dispatch_includes_input_url():
             assert put_upload(client, dispatch["upload"],
                               png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
-                              "gpu_ms": 50, "width": 512, "height": 512})
+                              "gpu_ms": 50, "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
             source_asset_id = poll_until(client, source_job_id, "succeeded")["assets"][0]["id"]
 
         with client.websocket_connect("/api/v1/fleet") as worker:
@@ -1033,7 +1049,8 @@ def test_upscale_dispatch_includes_input_url():
             assert put_upload(client, up_dispatch["upload"],
                               png_bytes(1024, 1024)).status_code == 200
             worker.send_json({"type": "job_done", "job_id": upscale_job_id,
-                              "gpu_ms": 400, "width": 1024, "height": 1024})
+                              "gpu_ms": 400, "width": 1024, "height": 1024,
+                              "dispatch_token": up_dispatch["dispatch_token"]})
             done = poll_until(client, upscale_job_id, "succeeded")
             assert done["gpu_ms"] == 400
             assert done["assets"][0]["width"] == 1024
@@ -1135,7 +1152,8 @@ def test_job_phase_timings_persisted():
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 900, "input_fetch_ms": 50,
                               "load_ms": 1200, "postprocess_ms": 80,
-                              "width": 512, "height": 512})
+                              "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
 
             job = poll_until(client, job_id, "succeeded")
             assert job["gpu_ms"] == 900
@@ -1156,9 +1174,10 @@ def test_job_failure_reason_persisted():
                                   json={"model_id": "sd-test",
                                         "params": {"prompt": "fail"}})
             job_id = created.json()["job_id"]
-            worker.receive_json()
+            dispatch = worker.receive_json()
             worker.send_json({"type": "job_failed", "job_id": job_id,
-                              "reason": "CUDA OOM"})
+                              "reason": "CUDA OOM",
+                              "dispatch_token": dispatch["dispatch_token"]})
 
             job = poll_until(client, job_id, "failed")
             assert job["failure_reason"] == "CUDA OOM"
@@ -1201,7 +1220,8 @@ def _wait_for_dispatch(worker, expected: set[str], timeout=5.0) -> dict:
 def _finish_job(client, worker, dispatch: dict) -> None:
     assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
     worker.send_json({"type": "job_done", "job_id": dispatch["job_id"],
-                      "gpu_ms": 1, "width": 512, "height": 512})
+                      "gpu_ms": 1, "width": 512, "height": 512,
+                      "dispatch_token": dispatch["dispatch_token"]})
     poll_until(client, dispatch["job_id"], "succeeded")
 
 
@@ -1240,8 +1260,10 @@ def test_dispatch_depth_blocks_third_until_slot_frees(monkeypatch):
             time.sleep(0.35)
             d1 = _wait_for_dispatch(worker, expected)
             d2 = _wait_for_dispatch(worker, expected - {d1["job_id"]})
-            worker.send_json({"type": "job_progress", "job_id": d1["job_id"], "progress": 0.5})
-            worker.send_json({"type": "job_progress", "job_id": d2["job_id"], "progress": 0.5})
+            worker.send_json({"type": "job_progress", "job_id": d1["job_id"], "progress": 0.5,
+                              "dispatch_token": d1["dispatch_token"]})
+            worker.send_json({"type": "job_progress", "job_id": d2["job_id"], "progress": 0.5,
+                              "dispatch_token": d2["dispatch_token"]})
 
             third_id = _post_generation(client, "c")
             time.sleep(0.35)
@@ -2346,11 +2368,11 @@ def test_a_stale_dispatch_token_cannot_speak_for_the_current_attempt():
 
 @pytest.mark.db
 def test_a_worker_that_sends_no_dispatch_token_is_still_believed():
-    """The N-1 promise: an older worker echoes no token and must still be able
-    to finish a job (docs/connection-handling.md)."""
+    """The N-1 promise: a protocol 2 worker echoes no token and must still be
+    able to finish a job (docs/connection-handling.md)."""
     with TestClient(app) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
-            fleet_hello(worker, "w-no-token")
+            fleet_hello(worker, "w-no-token", version=PROTOCOL_VERSION - 1)
             job_id = client.post(
                 "/api/v1/generations",
                 json={"model_id": "sd-test", "params": {"prompt": "n-1"}},
@@ -2360,6 +2382,51 @@ def test_a_worker_that_sends_no_dispatch_token_is_still_believed():
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 7, "width": 512, "height": 512})
             assert poll_until(client, job_id, "succeeded")["gpu_ms"] == 7
+
+
+@pytest.mark.db
+def test_a_current_worker_that_omits_the_dispatch_token_is_ignored():
+    """The token is required from a protocol 3 worker, not merely echoed: an
+    omission is as stale as a wrong token, so the job must neither succeed
+    nor record an asset (issue #247)."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-missing-token")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "missing token"}},
+            ).json()["job_id"]
+            dispatch_for(worker, job_id)
+
+            key = uuid.UUID(job_id)
+            current = jobs.inflight[key]
+            asyncio.run(jobs.on_worker_message(current.worker, {
+                "type": "job_done", "job_id": job_id,
+                "gpu_ms": 7, "width": 512, "height": 512,
+            }))
+            assert jobs.inflight.get(key) is current
+            assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "running"
+
+            async def recorded_assets():
+                assert db.session_factory is not None
+                async with db.session_factory() as session:
+                    result = await session.execute(
+                        select(Asset).where(Asset.job_id == key)
+                    )
+                    return list(result.scalars())
+
+            assert asyncio.run(recorded_assets()) == []
+
+            # Finish the job with its own token, as the stale-token test
+            # does: a job left running is requeued when this socket closes.
+            assert client.put(
+                f"/api/v1/files/{current.storage_key}", content=png_bytes(),
+                headers={"X-Upload-Token": current.dispatch_token},
+            ).status_code == 200
+            worker.send_json({"type": "job_done", "job_id": job_id,
+                              "dispatch_token": current.dispatch_token,
+                              "gpu_ms": 8, "width": 512, "height": 512})
+            assert poll_until(client, job_id, "succeeded")["gpu_ms"] == 8
 
 
 @pytest.mark.db
@@ -2565,8 +2632,11 @@ def test_authorization_is_rechecked_after_the_body(monkeypatch):
             assert jobs.inflight.get(key) is replacement
 
             # Finish the job so it does not sit running in the shared database.
+            # The live entry is the replacement, so its token is the one that
+            # speaks; the missing object then fails the job.
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                              "width": 512, "height": 512})
+                              "width": 512, "height": 512,
+                              "dispatch_token": "replacement-token"})
             poll_until(client, job_id, "failed")
 
 
@@ -2619,8 +2689,11 @@ def test_authorization_is_rechecked_between_write_and_link(monkeypatch):
             assert jobs.inflight.get(key) is replacement
 
             # Finish the job so it does not sit running in the shared database.
+            # The live entry is the replacement, so its token is the one that
+            # speaks; the missing object then fails the job.
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                              "width": 512, "height": 512})
+                              "width": 512, "height": 512,
+                              "dispatch_token": "replacement-token"})
             poll_until(client, job_id, "failed")
 
 
@@ -2676,7 +2749,8 @@ def test_a_failed_write_leaves_no_partial_upload(monkeypatch):
             # not find a corpse from the failed write.
             assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
-                              "width": 512, "height": 512})
+                              "width": 512, "height": 512,
+                              "dispatch_token": dispatch["dispatch_token"]})
             poll_until(client, job_id, "succeeded")
 
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -47,6 +47,32 @@ MANIFEST_WITH_RT = {
 HOSTILE_PROMPT = 'A "lighthouse"\n; ../../ caf\u00e9'
 
 
+def webp_bytes(width=64, height=64):
+    """The extended (VP8X) form, which carries the canvas size in its header."""
+    body = (b"VP8X" + struct.pack("<I", 10) + b"\x00" * 4
+            + (width - 1).to_bytes(3, "little") + (height - 1).to_bytes(3, "little"))
+    return b"RIFF" + struct.pack("<I", 4 + len(body)) + b"WEBP" + body + b"\x00" * 10
+
+
+def dispatch_for(worker, job_id, limit=5):
+    """The dispatch for this job, skipping any the suite left requeued.
+
+    A job another test left running is requeued when its socket closes, so a
+    fresh socket can be handed that dispatch before this test's own.
+    """
+    for _ in range(limit):
+        message = worker.receive_json()
+        if message.get("type") == "dispatch_job" and message["job_id"] == job_id:
+            return message
+    raise AssertionError(f"no dispatch for job {job_id}")
+
+
+def put_upload(client, spec, content):
+    """PUT the way a worker does: the dispatch headers carry the upload token."""
+    return client.put(urlsplit(spec["url"]).path, content=content,
+                      headers=spec.get("headers") or {})
+
+
 def png_bytes(width=512, height=512):
     def chunk(kind, data):
         return (struct.pack(">I", len(data)) + kind + data
@@ -312,16 +338,21 @@ def test_generation_end_to_end():
             assert dispatch["job_id"] == job_id
             assert dispatch["params"] == {"prompt": HOSTILE_PROMPT}
             assert dispatch["upload"]["url"].endswith(f"/{job_id}-attempt-1.png")
-            assert dispatch["upload"]["headers"] == {"Content-Type": "image/png"}
+            assert dispatch["upload"]["headers"]["Content-Type"] == "image/png"
+            # The token authorises the PUT: the key alone is derivable by any
+            # worker that ever held this job (issue #247).
+            token = dispatch["upload"]["headers"]["X-Upload-Token"]
+            assert token and dispatch["thumb_upload"]["headers"]["X-Upload-Token"] == token
+            assert dispatch["dispatch_token"] == token
             assert dispatch["thumb_upload"]["url"].endswith(
                 f"/{job_id}-attempt-1-thumb.webp"
             )
-            assert dispatch["thumb_upload"]["headers"] == {"Content-Type": "image/webp"}
+            assert dispatch["thumb_upload"]["headers"]["Content-Type"] == "image/webp"
 
-            upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=png_bytes(320, 240)).status_code == 200
-            thumb_path = urlsplit(dispatch["thumb_upload"]["url"]).path
-            assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
+            assert put_upload(client, dispatch["upload"],
+                              png_bytes(320, 240)).status_code == 200
+            assert put_upload(client, dispatch["thumb_upload"],
+                              webp_bytes()).status_code == 200
 
             worker.send_json({"type": "job_progress", "job_id": job_id, "progress": 0.5})
             worker.send_json({"type": "job_done", "job_id": job_id,
@@ -346,7 +377,7 @@ def test_generation_end_to_end():
             )
             assert asset["thumbnail_url"] is not None
             assert client.get(urlsplit(asset["url"]).path).content == png_bytes(320, 240)
-            assert client.get(urlsplit(asset["thumbnail_url"]).path).content == b"thumb-bytes"
+            assert client.get(urlsplit(asset["thumbnail_url"]).path).content == webp_bytes()
 
             history = client.get("/api/v1/generations").json()
             assert any(entry["id"] == job_id for entry in history)
@@ -541,8 +572,9 @@ def test_retried_attempt_uses_a_new_upload_key_and_rejects_the_old_key(monkeypat
                 second = worker.receive_json()
                 second_path = urlsplit(second["upload"]["url"]).path
                 assert first_path != second_path
-                assert client.put(first_path, content=b"stale").status_code == 403
-                assert client.put(second_path, content=png_bytes()).status_code == 200
+                assert put_upload(client, first["upload"], b"stale").status_code == 403
+                assert put_upload(client, second["upload"],
+                                  png_bytes()).status_code == 200
     finally:
         monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
         get_settings.cache_clear()
@@ -578,8 +610,8 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
                 asyncio.run(_write_blob(storage, first_key, png_bytes()))
                 asyncio.run(_write_blob(storage, first_thumb_key, png_bytes()))
 
-                assert client.put(urlsplit(second["upload"]["url"]).path,
-                                  content=png_bytes()).status_code == 200
+                assert put_upload(client, second["upload"],
+                                  png_bytes()).status_code == 200
                 worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
                                   "width": 512, "height": 512})
                 poll_until(client, job_id, "succeeded")
@@ -609,7 +641,7 @@ def test_a_reported_failure_does_not_leave_its_upload_behind():
             dispatch = worker.receive_json()
             upload_path = urlsplit(dispatch["upload"]["url"]).path
             key = upload_path.rsplit("/api/v1/files/", 1)[-1]
-            assert client.put(upload_path, content=png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
             storage = jobs.get_storage()
             assert storage.path(key).exists()
 
@@ -639,14 +671,15 @@ def test_a_late_verdict_does_not_fail_the_attempt_that_replaced_it(monkeypatch):
                 json={"model_id": "sd-test", "params": {"prompt": "late"}},
             ).json()["job_id"]
             dispatch = worker.receive_json()
-            assert client.put(urlsplit(dispatch["upload"]["url"]).path,
-                              content=png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["upload"],
+                              png_bytes()).status_code == 200
             key = uuid.UUID(job_id)
             superseded = jobs.inflight[key]
             replacement = jobs.InFlight(
                 worker=superseded.worker, storage_key="replacement.png",
                 thumb_storage_key="replacement-thumb.webp",
-                user_id=superseded.user_id, attempt=2,
+                user_id=superseded.user_id, dispatch_token="replacement-token",
+                attempt=2,
             )
             real_storage = jobs.get_storage()
 
@@ -705,7 +738,8 @@ def test_a_rejected_upload_is_not_left_in_storage():
             dispatch = worker.receive_json()
             upload_path = urlsplit(dispatch["upload"]["url"]).path
             key = upload_path.rsplit("/api/v1/files/", 1)[-1]
-            assert client.put(upload_path, content=b"not a png at all").status_code == 200
+            assert put_upload(client, dispatch["upload"],
+                              b"not a png at all").status_code == 200
             storage = jobs.get_storage()
             assert storage.path(key).exists()
 
@@ -751,8 +785,8 @@ def test_a_rejected_retry_collects_every_attempt(monkeypatch):
                 # The retry's output is rejected: the key is still inflight so
                 # the PUT succeeds, and the invalid bytes fail verification.
                 second_path = urlsplit(second["upload"]["url"]).path
-                assert client.put(second_path,
-                                  content=b"not a png at all").status_code == 200
+                assert put_upload(client, second["upload"],
+                                  b"not a png at all").status_code == 200
                 second_key = second_path.rsplit("/api/v1/files/", 1)[-1]
 
                 worker.send_json({"type": "job_done", "job_id": job_id, "gpu_ms": 1,
@@ -831,10 +865,9 @@ def test_recover_requeues_running_and_dispatches_queued():
             assert first["type"] == "dispatch_job"
             first_id = first["job_id"]
 
-            upload_path = urlsplit(first["upload"]["url"]).path
-            assert client.put(upload_path, content=png_bytes()).status_code == 200
-            thumb_path = urlsplit(first["thumb_upload"]["url"]).path
-            assert client.put(thumb_path, content=b"thumb-bytes").status_code == 200
+            assert put_upload(client, first["upload"], png_bytes()).status_code == 200
+            assert put_upload(client, first["thumb_upload"],
+                              webp_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": first_id,
                               "gpu_ms": 1, "width": 512, "height": 512,
                               "has_thumbnail": True})
@@ -859,8 +892,7 @@ def test_img2img_dispatch_includes_input_url():
             source_job_id = created.json()["job_id"]
 
             dispatch = worker.receive_json()
-            upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
                               "gpu_ms": 100, "width": 512, "height": 512})
             source_job = poll_until(client, source_job_id, "succeeded")
@@ -880,8 +912,8 @@ def test_img2img_dispatch_includes_input_url():
             input_path = urlsplit(i2i_dispatch["input"]["url"]).path
             assert client.get(input_path).content == png_bytes()
 
-            assert client.put(urlsplit(i2i_dispatch["upload"]["url"]).path,
-                              content=png_bytes()).status_code == 200
+            assert put_upload(client, i2i_dispatch["upload"],
+                              png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": edit_job_id,
                               "gpu_ms": 200, "width": 512, "height": 512})
             edit_job = poll_until(client, edit_job_id, "succeeded")
@@ -900,8 +932,7 @@ def test_img2img_rejects_model_without_capability():
                                         "params": {"prompt": "seed"}})
             job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
-            upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 1, "width": 512, "height": 512})
             source_job = poll_until(client, job_id, "succeeded")
@@ -937,8 +968,8 @@ def test_upscale_dispatch_includes_input_url():
                                         "params": {"prompt": "seed"}})
             source_job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
-            assert client.put(urlsplit(dispatch["upload"]["url"]).path,
-                              content=png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["upload"],
+                              png_bytes()).status_code == 200
             worker.send_json({"type": "job_done", "job_id": source_job_id,
                               "gpu_ms": 50, "width": 512, "height": 512})
             source_asset_id = poll_until(client, source_job_id, "succeeded")["assets"][0]["id"]
@@ -969,8 +1000,8 @@ def test_upscale_dispatch_includes_input_url():
 
             # Upload the real upscaled image: the asset row takes its
             # dimensions from the object now, not from the worker's claim.
-            assert client.put(urlsplit(up_dispatch["upload"]["url"]).path,
-                              content=png_bytes(1024, 1024)).status_code == 200
+            assert put_upload(client, up_dispatch["upload"],
+                              png_bytes(1024, 1024)).status_code == 200
             worker.send_json({"type": "job_done", "job_id": upscale_job_id,
                               "gpu_ms": 400, "width": 1024, "height": 1024})
             done = poll_until(client, upscale_job_id, "succeeded")
@@ -1069,8 +1100,7 @@ def test_job_phase_timings_persisted():
                                         "params": {"prompt": "timing"}})
             job_id = created.json()["job_id"]
             dispatch = worker.receive_json()
-            upload_path = urlsplit(dispatch["upload"]["url"]).path
-            assert client.put(upload_path, content=png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
 
             worker.send_json({"type": "job_done", "job_id": job_id,
                               "gpu_ms": 900, "input_fetch_ms": 50,
@@ -1139,8 +1169,7 @@ def _wait_for_dispatch(worker, expected: set[str], timeout=5.0) -> dict:
 
 
 def _finish_job(client, worker, dispatch: dict) -> None:
-    upload_path = urlsplit(dispatch["upload"]["url"]).path
-    assert client.put(upload_path, content=png_bytes()).status_code == 200
+    assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
     worker.send_json({"type": "job_done", "job_id": dispatch["job_id"],
                       "gpu_ms": 1, "width": 512, "height": 512})
     poll_until(client, dispatch["job_id"], "succeeded")
@@ -2144,6 +2173,7 @@ def test_non_finite_progress_is_ignored():
     job_id = uuid.uuid4()
     jobs.inflight[job_id] = jobs.InFlight(
         worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
+        dispatch_token="token",
     )
     try:
         for unusable in (float("nan"), float("inf"), 10 ** 400, [1], {"a": 1}, None):
@@ -2193,6 +2223,7 @@ def test_job_done_with_unusable_numbers_leaves_the_job_recoverable():
         job_id = uuid.uuid4()
         jobs.inflight[job_id] = jobs.InFlight(
             worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
+            dispatch_token="token",
         )
         try:
             asyncio.run(jobs.on_worker_message(worker, {
@@ -2227,3 +2258,167 @@ def test_peer_uuid_rejects_a_non_string_id():
         except realtime.ProtocolError:
             continue
         raise AssertionError(f"{bad!r} was accepted as an id")
+
+
+@pytest.mark.db
+def test_a_stale_dispatch_token_cannot_speak_for_the_current_attempt():
+    """A stall requeue can hand a job back to the same Worker object, so the
+    `current.worker is worker` identity check cannot separate attempt one from
+    attempt two. Only the per-dispatch token can (issue #247).
+
+    The requeue itself is driven here rather than waited for: the sweeper's
+    window is milliseconds wide and the point of the test is the token, not
+    the timing. test_stalled_job_requeues_once covers the real requeue.
+    """
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-stale-token")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "token"}},
+            ).json()["job_id"]
+            dispatch_for(worker, job_id)
+
+            # What a requeue to the same worker leaves behind: a new entry,
+            # same Worker object, new key, new token.
+            key = uuid.UUID(job_id)
+            superseded = jobs.inflight[key]
+            second_keys = jobs.storage_keys_for_attempt(superseded.user_id, key, 2)
+            jobs.inflight[key] = jobs.InFlight(
+                worker=superseded.worker, storage_key=second_keys[0],
+                thumb_storage_key=second_keys[1], user_id=superseded.user_id,
+                dispatch_token="second-attempt-token", attempt=2,
+            )
+            current = jobs.inflight[key]
+            assert current.dispatch_token != superseded.dispatch_token
+
+            # The superseded attempt reports success. It knows the job id and
+            # holds the same socket, and must still not be believed.
+            asyncio.run(jobs.on_worker_message(current.worker, {
+                "type": "job_done", "job_id": job_id,
+                "dispatch_token": superseded.dispatch_token,
+                "gpu_ms": 1, "width": 512, "height": 512,
+            }))
+            assert jobs.inflight.get(key) is current
+            assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "running"
+
+            # The live attempt's own token is believed.
+            put = client.put(
+                f"/api/v1/files/{current.storage_key}", content=png_bytes(),
+                headers={"X-Upload-Token": current.dispatch_token},
+            )
+            assert put.status_code == 200
+            worker.send_json({"type": "job_done", "job_id": job_id,
+                              "dispatch_token": current.dispatch_token,
+                              "gpu_ms": 2, "width": 512, "height": 512})
+            assert poll_until(client, job_id, "succeeded")["gpu_ms"] == 2
+
+
+@pytest.mark.db
+def test_a_worker_that_sends_no_dispatch_token_is_still_believed():
+    """The N-1 promise: an older worker echoes no token and must still be able
+    to finish a job (docs/connection-handling.md)."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-no-token")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "n-1"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+            worker.send_json({"type": "job_done", "job_id": job_id,
+                              "gpu_ms": 7, "width": 512, "height": 512})
+            assert poll_until(client, job_id, "succeeded")["gpu_ms"] == 7
+
+
+@pytest.mark.db
+def test_an_upload_needs_the_token_of_its_own_dispatch():
+    """The key is derivable by anyone who was ever dispatched the job; the
+    token is not (issue #247)."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-upload-token")
+            first_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "one"}},
+            ).json()["job_id"]
+            first = dispatch_for(worker, first_id)
+            second_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "two"}},
+            ).json()["job_id"]
+            second = dispatch_for(worker, second_id)
+            assert first_id != second_id
+
+            path = urlsplit(first["upload"]["url"]).path
+            assert client.put(path, content=png_bytes()).status_code == 403
+            assert client.put(path, content=png_bytes(),
+                              headers={"X-Upload-Token": ""}).status_code == 403
+            # Another live dispatch's token does not carry to this key.
+            assert client.put(path, content=png_bytes(), headers={
+                "X-Upload-Token": second["upload"]["headers"]["X-Upload-Token"],
+            }).status_code == 403
+            assert put_upload(client, first["upload"], png_bytes()).status_code == 200
+
+            # Finish both: a job left running is requeued when this socket
+            # closes and its dispatch would arrive in the next test's socket.
+            for job, ident in ((first, first_id), (second, second_id)):
+                if job is second:
+                    assert put_upload(client, job["upload"],
+                                      png_bytes()).status_code == 200
+                worker.send_json({"type": "job_done", "job_id": ident,
+                                  "dispatch_token": job["dispatch_token"],
+                                  "gpu_ms": 1, "width": 512, "height": 512})
+                poll_until(client, ident, "succeeded")
+
+
+@pytest.mark.db
+def test_an_output_is_written_once():
+    """Verification proves what the object was at inspection time; a second
+    write would make that proof worthless (issue #249)."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-write-once")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "once"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            assert put_upload(client, dispatch["upload"],
+                              png_bytes(320, 240)).status_code == 200
+            assert put_upload(client, dispatch["upload"],
+                              png_bytes(64, 64)).status_code == 409
+            served = client.get(urlsplit(dispatch["upload"]["url"]).path)
+            assert served.content == png_bytes(320, 240)
+            worker.send_json({"type": "job_done", "job_id": dispatch["job_id"],
+                              "dispatch_token": dispatch["dispatch_token"],
+                              "gpu_ms": 1, "width": 320, "height": 240})
+            poll_until(client, dispatch["job_id"], "succeeded")
+
+
+@pytest.mark.db
+def test_a_thumbnail_that_is_not_a_webp_is_dropped_rather_than_served():
+    """has_thumbnail used to create the row on the worker's word alone, so a
+    worker could have the studio serve arbitrary bytes as an image."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-bad-thumb")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "thumb"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+            assert put_upload(client, dispatch["thumb_upload"],
+                              b"not a webp at all").status_code == 200
+            worker.send_json({"type": "job_done", "job_id": job_id,
+                              "dispatch_token": dispatch["dispatch_token"],
+                              "gpu_ms": 3, "width": 512, "height": 512,
+                              "has_thumbnail": True})
+
+            job = poll_until(client, job_id, "succeeded")
+            assert len(job["assets"]) == 1
+            assert job["assets"][0]["thumbnail_url"] is None
+            # The rejected object is collected, not left addressable.
+            assert client.get(urlsplit(dispatch["thumb_upload"]["url"]).path).status_code == 404

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -425,6 +425,7 @@ def test_job_dispatch_and_finish_timestamps():
             worker.send_json({
                 "type": "job_done",
                 "job_id": str(job_id),
+                "dispatch_token": dispatch["dispatch_token"],
                 "gpu_ms": 900,
                 "width": 512,
                 "height": 512,

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -410,6 +410,34 @@ _WEBP_BYTES = base64.b64decode(
     "UklGRiQAAABXRUJQVlA4TBcAAAAvP8ExAAcQ9Y/+BwAU6f9/iuh/6v+fAQA="
 )
 
+# A real extended 320x200 WebP with an alpha channel, ffmpeg output
+# (VP8X + ALPH + VP8): the only shape a real encoder here gives a VP8X
+# canvas, and the frame inside carries its own 320x200 header.
+_WEBP_EXTENDED_BYTES = base64.b64decode(
+    "UklGRpIEAABXRUJQVlA4WAoAAAAQAAAAPwEAxwAAQUxQSAACAAABGYBIan/0ASL6nxI4bNtGkuKyrv/e9pkdxxkbB0RMACQ1kiRJ1Kk3I81ggpx4wm95/8AzUgEeUoHeRL94PpPiMOQQpXo0BV8royn4BqKEwRVjJhR8qQX4DjPG4M7CLDqxhzBFOIa/JXgaI8bw8VHFBNeNgcPErHXSFHwD0b2D2+aa9XZsBhTzNrjBMP/BG1uI6MZ2rZqm4BuI7h3cPdesx2Mzp5jHwX2HaT84oaH7Nrbwh7WxFWfIlKEXQ2C+X5romnWfIa6Ye3/fYdoPzmuY243tncXhYJQZwn/wxhYuMqQWc+HvO0z7wekN07uxhQbG5pnuetaKiglOKNpGBjh4THZ3PXCRIb0Y8B2m/eBdGNpoYzt9TDkOTN+Gn4iqCM4ryp8BXICBsWG8tetZKgrDwxTfYS4y+A7zH7yxLe0H5xXlzwA2wKgITijqhv8S+ZPC1DDFd5j7M0YSs0jNPRvbuWPu/ZkwZtj1lPaD84ryZ4D0YBSPzdncLxtIqiI4n2jxHebxUXOKuT9jXDe2zH/Tx77rUTWgeUX5M4AbMO0HJxRVPDbbuV96CFN8h3l74hBiPlFL78a2UAQ/9l2PqgHNK8rfHdKDUTw2J32//FJ0XmPTfZiSW8zbE6d3Y1v2Dh6bXc9aGYYMEBvMPq/Hh4HZYMYY3FmYRQfPJ6Yox1A8BVZQOCBsAgAA8BYAnQEqQAHIAD6RSKFNJaQjIiAoALASCWdu4THVbG65TW/0CmA8fz/90/z/d35AFZu14uTkPfgCAe+2hFNEA5zIPCDXlNrYjorBpuVeTCYZdNVfzP2gTR/F11u/qUBYzLMiUoT3sD7ZO5F33uCuzFarQgjeeo34gOu1iJJV+fIo8SoYESwV2XnL2IQ4iiCDTiVAvI8+AVXCQpeGL9Vq68iq7ZpMvAHw6L9+Svfsh2CK+VbSogaif8nKYP81AZAAAP7b7X6ip5li//roH/66B/+ugf7aLHUQK5GBaGeY1jBB8/zlsKHAJMgi8V6jhupi6e0N1L6cHQx+DRDn4QgWC8Ji3ywdEprD7LhLfGS8q2QVh+YBI56Sfaad3u9ahXlAu384pO9QE2mDo5MJ1URn1RX1tnmWAOBoNglC7TvjeuHJZBp9LQZx0HHrfDchWI9H0s4h1gRLfPCi9WrwQrX3nsQQufyGx4wq0hkBcuqAsz+I8C83DjcfrLW7f9oVqismwoF8ebOkqNIEtYjogSfShoC7J5shYJlXSZaHyelTBWx8C+5GoOHFgkl8RV8vS1SUhxDsBazFUnMz+40CICNzCQFSsqLlwrsC9EtuLtB39+ykQ0OvHR2aoaGXw6QbAeHWn7FkIJwEl/UEcoEoPFBMlIRre9C59fnf7fmizmw0Vv2w9hVl3O2fRXT/oyIS88Msq3Jt0whWGwjnNQZeduLbcc6ECTlEw3D0qBIc+q5A+70nxoOhb3s3w1MhxLGU7N2rFwwaCizjFAAETx90qVLM0O4Rdiva6cjjCWJX+RbzZULLEU89ikXh2kTAAAA="
+)
+
+
+def _webp_chunk(kind, payload):
+    padded = payload + (b"\x00" if len(payload) & 1 else b"")
+    return kind + struct.pack("<I", len(payload)) + padded
+
+
+def _webp_container(*chunks):
+    body = b"".join(chunks)
+    return b"RIFF" + struct.pack("<I", 4 + len(body)) + b"WEBP" + body
+
+
+def _webp_payload(blob, kind):
+    """Payload of the first chunk of this kind in a real WebP blob."""
+    position = 12
+    while position + 8 <= len(blob):
+        if blob[position:position + 4] == kind:
+            length = struct.unpack_from("<I", blob, position + 4)[0]
+            return bytes(blob[position + 8:position + 8 + length])
+        position += 8 + struct.unpack_from("<I", blob, position + 4)[0]
+    raise AssertionError(f"{kind!r} missing from the fixture")
+
 
 def test_image_info_requires_a_complete_webp(tmp_path):
     """The WebP reader is a bounded chunk walk like the PNG one.
@@ -421,17 +449,9 @@ def test_image_info_requires_a_complete_webp(tmp_path):
     """
     storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
 
-    def chunk(kind, payload):
-        padded = payload + (b"\x00" if len(payload) & 1 else b"")
-        return kind + struct.pack("<I", len(payload)) + padded
-
-    def container(*chunks):
-        body = b"".join(chunks)
-        return b"RIFF" + struct.pack("<I", 4 + len(body)) + b"WEBP" + body
-
-    vp8x = chunk(b"VP8X", b"\x00" * 4 + (319).to_bytes(3, "little")
-                 + (199).to_bytes(3, "little"))
-    (tmp_path / "vp8x-only.webp").write_bytes(container(vp8x))
+    vp8x = _webp_chunk(b"VP8X", b"\x00" * 4 + (319).to_bytes(3, "little")
+                       + (199).to_bytes(3, "little"))
+    (tmp_path / "vp8x-only.webp").write_bytes(_webp_container(vp8x))
     assert asyncio.run(storage.image_info("vp8x-only.webp")) is None
 
     # The real file's VP8L chunk declares 23 bytes; a declared 100 runs past
@@ -448,6 +468,69 @@ def test_image_info_requires_a_complete_webp(tmp_path):
     bad_version[24] |= 0x80
     (tmp_path / "bad-version.webp").write_bytes(bad_version)
     assert asyncio.run(storage.image_info("bad-version.webp")) is None
+
+
+def test_image_info_refuses_an_animated_webp(tmp_path):
+    """An ANMF chunk is refused, not treated as image data.
+
+    What the fleet uploads is a still thumbnail; accepting an animation would
+    mean validating the whole nested frame structure for no use case, and an
+    empty frame must not count as the one image a container needs.
+    """
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    vp8x = _webp_chunk(b"VP8X", b"\x00" * 4 + (319).to_bytes(3, "little")
+                       + (199).to_bytes(3, "little"))
+    (tmp_path / "animated.webp").write_bytes(
+        _webp_container(vp8x, _webp_chunk(b"ANMF", b""))
+    )
+    assert asyncio.run(storage.image_info("animated.webp")) is None
+
+
+def test_image_info_requires_the_frame_to_match_the_canvas(tmp_path):
+    """The VP8X canvas is a claim, not the object.
+
+    The frame carries its own dimensions, and a canvas edited down to 1x1
+    over a real 320x200 frame would otherwise be recorded as 1x1 and dodge
+    the thumbnail edge check that trusts these numbers.
+    """
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    lying_canvas = bytearray(_WEBP_EXTENDED_BYTES)
+    # The canvas is the four flags plus width-1 and height-1, three
+    # little-endian bytes each, in the VP8X payload.
+    lying_canvas[24:27] = b"\x00\x00\x00"
+    lying_canvas[27:30] = b"\x00\x00\x00"
+    (tmp_path / "lying-canvas.webp").write_bytes(lying_canvas)
+    assert asyncio.run(storage.image_info("lying-canvas.webp")) is None
+
+
+def test_image_info_refuses_a_second_bitstream(tmp_path):
+    """A static WebP carries exactly one frame chunk.
+
+    A second bitstream in an extended container is not a thumbnail the fleet
+    can produce, so it is a fabricated file rather than one to keep.
+    """
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    frame = _webp_chunk(b"VP8 ", _webp_payload(_WEBP_EXTENDED_BYTES, b"VP8 "))
+    vp8x = _webp_chunk(b"VP8X", _webp_payload(_WEBP_EXTENDED_BYTES, b"VP8X"))
+    (tmp_path / "two-frames.webp").write_bytes(
+        _webp_container(vp8x, frame, frame)
+    )
+    assert asyncio.run(storage.image_info("two-frames.webp")) is None
+
+
+def test_image_info_accepts_a_real_webp_with_xmp(tmp_path):
+    """The XMP whitelist entry is the four-byte kind: the trailing space is
+    part of the chunk code, so a real XMP chunk must not fall into the
+    unknown-chunk branch."""
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    frame = _webp_chunk(b"VP8 ", _webp_payload(_WEBP_EXTENDED_BYTES, b"VP8 "))
+    vp8x = _webp_chunk(b"VP8X", _webp_payload(_WEBP_EXTENDED_BYTES, b"VP8X"))
+    xmp = _webp_chunk(b"XMP ", b'<x:xmpmeta xmlns:x="adobe:ns:meta/">')
+    (tmp_path / "with-xmp.webp").write_bytes(
+        _webp_container(vp8x, frame, xmp)
+    )
+    info = asyncio.run(storage.image_info("with-xmp.webp"))
+    assert (info.width, info.height) == (320, 200)
 
 
 def test_s3_delete_removes_every_version_of_exactly_that_key():

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -43,8 +43,9 @@ def test_local_storage_urls(tmp_path):
     target = asyncio.run(storage.upload_target("u/j.png"))
     assert target.url == "http://worker/api/v1/files/u/j.png"
     assert target.headers == {"Content-Type": "image/png"}
-    thumb_target = asyncio.run(storage.upload_target("u/j-thumb.webp"))
-    assert thumb_target.headers == {"Content-Type": "image/webp"}
+    # The dispatch token rides in the headers the worker echoes (issue #247).
+    tokened = asyncio.run(storage.upload_target("u/j.png", "tok"))
+    assert tokened.headers == {"Content-Type": "image/png", "X-Upload-Token": "tok"}
     assert asyncio.run(storage.url("u/j.webp")) == "http://browser/api/v1/files/u/j.webp"
     download_url = asyncio.run(
         storage.url("u/j.png", download_name="potocolom-20260729-142530-castle.png")
@@ -154,9 +155,14 @@ def test_s3_storage_presigns_offline():
     assert target.url.startswith("http://localhost:9100/")
     assert "u/j.png" in target.url
     assert "X-Amz-Signature" in target.url
-    assert target.headers == {"Content-Type": "image/png"}
+    # If-None-Match is signed as well as sent: the bucket refuses a second
+    # write with 412, so a presigned PUT cannot be replayed over an object the
+    # API has already verified (issue #249).
+    assert target.headers == {"Content-Type": "image/png", "If-None-Match": "*"}
+    signed = parse_qs(urlsplit(target.url).query)["X-Amz-SignedHeaders"][0]
+    assert "if-none-match" in signed
     thumb_target = asyncio.run(storage.upload_target("u/j-thumb.webp"))
-    assert thumb_target.headers == {"Content-Type": "image/webp"}
+    assert thumb_target.headers == {"Content-Type": "image/webp", "If-None-Match": "*"}
     # Browser-facing image URL (SPA <img src>), not the worker upload target.
     view = asyncio.run(storage.url("u/j.png"))
     assert view.startswith("http://localhost:9100/")

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import struct
 import zlib
 from urllib.parse import parse_qs, urlsplit
@@ -121,7 +122,11 @@ class _FakeS3Client:
         return {
             "Body": _FakeBody(self.data),
             "ContentLength": len(self.data),
-            "ContentType": "image/png",
+            # Deliberately not the type of the bytes: an uploader declares its
+            # own Content-Type on a presigned PUT, so image_info must report
+            # what the bytes are, and a fake that agreed with them could not
+            # tell the difference.
+            "ContentType": "text/plain",
         }
 
     def get_paginator(self, name):
@@ -396,6 +401,53 @@ def test_max_image_edge_matches_the_largest_real_output():
     # A factor-4 upscale of the largest shipped generation size. Anything more
     # only moves the memory question to whatever decodes the file later.
     assert MAX_IMAGE_EDGE == 4096
+
+
+# The real lossless 320x200 WebP from test_jobs, embedded here too so the
+# rejections below are mutations of real encoded bytes rather than headers
+# built to please the reader.
+_WEBP_BYTES = base64.b64decode(
+    "UklGRiQAAABXRUJQVlA4TBcAAAAvP8ExAAcQ9Y/+BwAU6f9/iuh/6v+fAQA="
+)
+
+
+def test_image_info_requires_a_complete_webp(tmp_path):
+    """The WebP reader is a bounded chunk walk like the PNG one.
+
+    Reading the RIFF header and the first chunk header let a fabricated VP8X
+    prefix pass as a thumbnail no matter what followed it, so the walk must
+    demand an image chunk after VP8X, keep every chunk inside the RIFF payload
+    and reject a lossless frame that claims an unknown version.
+    """
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+
+    def chunk(kind, payload):
+        padded = payload + (b"\x00" if len(payload) & 1 else b"")
+        return kind + struct.pack("<I", len(payload)) + padded
+
+    def container(*chunks):
+        body = b"".join(chunks)
+        return b"RIFF" + struct.pack("<I", 4 + len(body)) + b"WEBP" + body
+
+    vp8x = chunk(b"VP8X", b"\x00" * 4 + (319).to_bytes(3, "little")
+                 + (199).to_bytes(3, "little"))
+    (tmp_path / "vp8x-only.webp").write_bytes(container(vp8x))
+    assert asyncio.run(storage.image_info("vp8x-only.webp")) is None
+
+    # The real file's VP8L chunk declares 23 bytes; a declared 100 runs past
+    # the RIFF payload even though all 44 bytes are present.
+    overlong = bytearray(_WEBP_BYTES)
+    struct.pack_into("<I", overlong, 16, 100)
+    (tmp_path / "overlong.webp").write_bytes(overlong)
+    assert asyncio.run(storage.image_info("overlong.webp")) is None
+
+    # The top three bits of the fourth byte after the 0x2f signature are the
+    # version; the encoder emitted zero there and a nonzero one is a frame
+    # this walk does not understand.
+    bad_version = bytearray(_WEBP_BYTES)
+    bad_version[24] |= 0x80
+    (tmp_path / "bad-version.webp").write_bytes(bad_version)
+    assert asyncio.run(storage.image_info("bad-version.webp")) is None
 
 
 def test_s3_delete_removes_every_version_of_exactly_that_key():

--- a/docs/api.md
+++ b/docs/api.md
@@ -226,6 +226,9 @@ GET  /api/v1/telemetry/preview        admin only; 403 for viewer or user; 200 ex
                                         503 when the database is unavailable
 PUT  /api/v1/files/{key}               local-storage upload target (self-hosted, non-S3); a PUT is
                                         authorized only for a storage key the API minted in-flight
+                                        AND an X-Upload-Token header matching that dispatch, which
+                                        the worker echoes from upload.headers; 403 otherwise, and
+                                        409 on a second write, since outputs are write-once
 GET  /api/v1/files/{key}               serve a stored object (self-hosted, non-S3)
 ```
 

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -34,9 +34,11 @@ Fleet connection, worker to API:
 | `heartbeat` | `slots_in_use`, `loaded_models`, `gpu` (device, util, VRAM, temperature, power) | every 30 seconds. Corrected 2026-07-23: the wire also carries `loaded_models` and a `gpu` sample. An N-1 worker may still send `memory_mode` here |
 | `session_ready` | `session_id` | slot acquired, model warm |
 | `session_closed` | `session_id`, `frames`, `gpu_ms`, `duration_ms`, `category`, optional `category_score` | worker side accounting and completion-side usage event |
-| `job_progress` | `job_id`, `progress` | fraction of denoising steps done |
-| `job_done` | `job_id`, `gpu_ms`, `duration_ms`, `category`, optional `category_score`, `width`, `height`, `input_fetch_ms` (optional), `load_ms` (optional), `postprocess_ms` (optional) | sent after the result uploaded to the dispatch target |
-| `job_failed` | `job_id`, `reason` | the job fails visibly; only worker death triggers the one retry |
+| `job_progress` | `job_id`, `progress`, `dispatch_token` | fraction of denoising steps done |
+| `job_done` | `job_id`, `dispatch_token`, `gpu_ms`, `duration_ms`, `category`, optional `category_score`, `width`, `height`, `input_fetch_ms` (optional), `load_ms` (optional), `postprocess_ms` (optional) | sent after the result uploaded to the dispatch target |
+| `job_failed` | `job_id`, `dispatch_token`, `reason` | the job fails visibly; only worker death triggers the one retry |
+
+`dispatch_token` is the value the API sent in `dispatch_job`, echoed back on every message about that job. A message carrying the wrong token is ignored: a stall requeue can hand a job back to the same worker, and without the token attempt one's late `job_done` is indistinguishable from attempt two's. A message that omits the field is accepted, because an N-1 worker does not send it; that acceptance goes away when the compatibility floor next moves.
 
 Fleet connection, API to worker:
 
@@ -46,7 +48,7 @@ Fleet connection, API to worker:
 | `rejected` | `reason`, `min_supported_version` | hello refused; the API closes after sending |
 | `open_session` | `session_id`, `model_id`, `params` | acquire a slot and warm the model |
 | `close_session` | `session_id` | release the slot |
-| `dispatch_job` | `job_id`, `model_id`, `params`, `upload`, `thumb_upload` (optional), `input` (optional) | `upload.url` and `upload.headers`: where the worker PUTs the full result; `thumb_upload` is the same shape for a WebP thumbnail. `input.url`: presigned GET for the source image on image_to_image jobs. Older workers ignore the optional fields (N-1 safe). |
+| `dispatch_job` | `job_id`, `model_id`, `params`, `dispatch_token`, `upload`, `thumb_upload` (optional), `input` (optional) | `upload.url` and `upload.headers`: where the worker PUTs the full result; `thumb_upload` is the same shape for a WebP thumbnail. `input.url`: presigned GET for the source image on image_to_image jobs. `dispatch_token` identifies this dispatch: it is echoed on the messages below and, on the local storage backend, rides in `upload.headers` as `X-Upload-Token` because the key alone is derivable by any worker that ever held the job. Older workers ignore the optional fields (N-1 safe). |
 
 Realtime connection, browser to API:
 

--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -38,7 +38,7 @@ Fleet connection, worker to API:
 | `job_done` | `job_id`, `dispatch_token`, `gpu_ms`, `duration_ms`, `category`, optional `category_score`, `width`, `height`, `input_fetch_ms` (optional), `load_ms` (optional), `postprocess_ms` (optional) | sent after the result uploaded to the dispatch target |
 | `job_failed` | `job_id`, `dispatch_token`, `reason` | the job fails visibly; only worker death triggers the one retry |
 
-`dispatch_token` is the value the API sent in `dispatch_job`, echoed back on every message about that job. A message carrying the wrong token is ignored: a stall requeue can hand a job back to the same worker, and without the token attempt one's late `job_done` is indistinguishable from attempt two's. A message that omits the field is accepted, because an N-1 worker does not send it; that acceptance goes away when the compatibility floor next moves.
+`dispatch_token` is the value the API sent in `dispatch_job`, echoed back on every message about that job. A message carrying the wrong token is ignored: a stall requeue can hand a job back to the same worker, and without the token attempt one's late `job_done` is indistinguishable from attempt two's. The field is required from a protocol 3 worker, which is believed only with a matching token: a message that omits it is ignored exactly like one carrying a wrong token. A protocol 2 (N-1) worker is the one exception, accepted without it because that version does not send the field; the acceptance disappears when the compatibility floor moves to 3.
 
 Fleet connection, API to worker:
 

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -98,6 +98,10 @@ def test_hello_carries_manifests():
     assert "source" not in manifest  # weight locations stay worker side
     assert hello["device"] == "cpu"
     assert hello["memory_mode"] == "auto"
+    # A version 3 API requires the dispatch token on every job message and
+    # ignores one that omits it, so announcing the wrong version here would
+    # have this worker's results silently dropped.
+    assert hello["protocol_version"] == 3
 
 
 def test_rejected_registration_raises_cleanly():
@@ -214,6 +218,7 @@ def dispatch_control():
             "url": "http://api/api/v1/files/u/j-1-thumb.webp",
             "headers": {"Content-Type": "image/webp"},
         },
+        "dispatch_token": "dispatch-token",
     }
 
 
@@ -248,6 +253,9 @@ def test_run_job_generates_uploads_and_reports(monkeypatch):
     assert done["category"] == "other"
     assert "category_score" not in done
     assert done["has_thumbnail"] is True
+    # Every message about this job carries the token back, or a version 3 API
+    # treats it as a report from a superseded attempt and ignores it.
+    assert all(r["dispatch_token"] == "dispatch-token" for r in reports)
 
 
 def test_run_job_delivers_without_thumbnail_when_thumb_upload_fails(monkeypatch):
@@ -301,3 +309,34 @@ def test_run_job_downloads_input_image(monkeypatch):
     assert len(FakeUpload.puts) == 2
     reports = [json.loads(m) for m in socket.sent]
     assert any(r["type"] == "job_done" for r in reports)
+
+
+def test_job_failure_carries_the_dispatch_token(monkeypatch):
+    """job_failed is the one report a worker sends without having uploaded, so
+    it is the easiest to forget to stamp."""
+    monkeypatch.setattr("worker.client.httpx.AsyncClient", FakeUpload)
+    FakeUpload.puts = []
+    FakeUpload.fail = True
+    socket = FakeSocket()
+    try:
+        asyncio.run(run_job(socket, SimulatedEngine(0.01), SIMULATED_MANIFEST,
+                            dispatch_control()))
+    finally:
+        FakeUpload.fail = False
+
+    failed = [json.loads(m) for m in socket.sent if json.loads(m)["type"] == "job_failed"]
+    assert len(failed) == 1
+    assert failed[0]["dispatch_token"] == "dispatch-token"
+
+
+def test_an_api_that_sends_no_dispatch_token_gets_none_back():
+    """The N-1 direction: a version 2 API sends no token, and stamping an empty
+    one would be a field it does not know."""
+    control = dispatch_control()
+    del control["dispatch_token"]
+    socket = FakeSocket()
+    asyncio.run(run_job(socket, SimulatedEngine(0.01), SIMULATED_MANIFEST, control))
+
+    reports = [json.loads(m) for m in socket.sent]
+    assert reports
+    assert not any("dispatch_token" in r for r in reports)

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -154,6 +154,11 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
     """One queued job: generate, upload to the given target, report the result.
     Failures are reported, never raised: the connection outlives the job."""
     job_id = control["job_id"]
+    # Echoed on every message about this job so the API can tell this dispatch
+    # from an earlier attempt of the same job that reached the same worker
+    # (docs/connection-handling.md). An older API sends none, so send none.
+    token = control.get("dispatch_token")
+    stamp = {"dispatch_token": token} if isinstance(token, str) and token else {}
     job_started = time.monotonic()
     progress_tasks: list[asyncio.Task[None]] = []
     last_fraction = 0.0
@@ -166,7 +171,7 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
     async def send_progress(fraction: float) -> None:
         with suppress(websockets.WebSocketException):
             await ws.send(json.dumps({"type": "job_progress", "job_id": job_id,
-                                      "progress": round(fraction, 4)}))
+                                      "progress": round(fraction, 4), **stamp}))
 
     async def progress_keepalive() -> None:
         while True:
@@ -219,7 +224,7 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
                     logger.exception("job %s thumbnail failed; delivering without one",
                                      job_id)
         postprocess_ms = int((time.monotonic() - post_start) * 1000)
-        done_msg: dict = {"type": "job_done", "job_id": job_id,
+        done_msg: dict = {"type": "job_done", "job_id": job_id, **stamp,
                           "gpu_ms": result.gpu_ms,
                           "input_fetch_ms": input_fetch_ms,
                           "load_ms": result.load_ms,
@@ -244,7 +249,7 @@ async def run_job(ws, engine: Engine, manifest: Manifest, control: dict) -> None
         logger.exception("job %s failed", job_id)
         with suppress(websockets.WebSocketException):
             await ws.send(json.dumps({"type": "job_failed", "job_id": job_id,
-                                      "reason": str(error)}))
+                                      "reason": str(error), **stamp}))
     finally:
         keepalive_task.cancel()
         with suppress(asyncio.CancelledError):

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -26,7 +26,7 @@ from worker.settings import Settings, get_settings
 logger = logging.getLogger("potocolom.worker")
 
 # Wire constants; keep in sync with backend/app/realtime.py.
-PROTOCOL_VERSION = 2
+PROTOCOL_VERSION = 3
 GENERATED_FRAME = 0x02
 FRAME_HEADER_BYTES = 17
 CLOSE_PROTOCOL_VIOLATION = 4000


### PR DESCRIPTION
Closes #247. Closes #249. Both land together because both add a field to the wire.

A dispatch was identified by the job id alone. Three things followed:

- **Upload authority was derivable.** The key is built from the user id, job id and attempt, all of which a previously dispatched worker knows, and `files.py` authorised a PUT for any key that belonged to *some* inflight entry. Attempt one could overwrite what attempt two uploaded.
- **A same-worker retry was not bound to an attempt.** A stall requeue can hand the job back to the same `Worker` object, so `current.worker is worker` cannot tell attempt one's late `job_done` from attempt two's. `test_stalled_job_requeues_once` redispatches to the same worker deliberately, so this was the ordinary path.
- **Verified output stayed writable.** Locally the PUT truncated; on S3 a presigned PUT is replayable for its full hour.

## What changed

Each dispatch mints a token. It goes out in `dispatch_job`, the worker echoes it on `job_progress`, `job_done` and `job_failed`, and a message carrying the wrong one is ignored. A message with no token is still accepted, because an N-1 worker sends none; that acceptance ends when the floor moves. `docs/connection-handling.md` carries the field.

The same token authorises the local upload, riding in the `upload.headers` the worker already echoes verbatim, so the worker needed no change for that half. The route requires the key and the token to name the same inflight entry.

Uploads are write-once: `O_EXCL` locally with 409 on a second write, and a signed `If-None-Match: *` on the S3 target so the bucket answers 412. A retry writes to a different key, so nothing legitimate needs a second write.

`has_thumbnail` created an asset row on the worker's word alone, which let a worker have the studio serve arbitrary bytes as an image. The thumbnail is inspected like the master now. Storage gained a WebP reader for it, in the shape of the PNG one: a RIFF and first-chunk walk, no decoding. Content type comes from the bytes on both backends rather than from what the uploader declared. A failed thumbnail costs the row and the object, never the job.

## Guards proved by breaking them

| Guard | Mutation | Result |
|---|---|---|
| Token checked on worker messages | read of `dispatch_token` forced to `None` | test fails |
| Absent token still accepted (N-1) | `if presented is not None` forced true | test fails |
| Upload needs its own dispatch token | authority back to key-only | test fails |
| Output written once | `open(path, "xb")` back to `"wb"` | test fails |
| Thumbnail inspected | rejection branch forced false | test fails |

`make verify` green: 243 backend, 91 worker, frontend build and CSP. The WebP reader was checked against real encoder output (ffmpeg lossy and lossless), not only handcrafted bytes.

Two of the new tests were flaky at first and are now deterministic: one depended on which dispatch a fresh socket received (jobs another test left running are requeued into it) and one on a 50 ms stall window. The first reads until it sees its own job; the second drives the requeue directly, since `test_stalled_job_requeues_once` already covers the real sweeper.

Reviewers are out of quota (codex until Aug 18, the Claude reviewer until this evening), so this carries my own gate only. It should get an independent pass before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure, dispatch-specific authorization for file uploads.
  - Upload targets now include required authorization tokens.
  - Added write-once protection; duplicate uploads return HTTP 409.
  - Added validation for thumbnail content, dimensions, size, and WebP format.
  - Updated worker messaging to carry dispatch authorization while supporting older workers.

- **Bug Fixes**
  - Prevented unauthorized or stale uploads and improved cleanup of invalid artifacts.

- **Documentation**
  - Updated API and connection documentation with upload-token and dispatch-message requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->