### PR TITLE
Warm the model the studio opens, not a hardcoded one

### DIFF
--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -615,12 +615,21 @@ class WarmupEngine:
 
     torch_compile = False
 
-    def __init__(self):
+    def __init__(self, strip_realtime: tuple[str, ...] = ()):
         self._calibrated_slots = None
         self.calibrated: list[str] = []
+        self.strip_realtime = set(strip_realtime)
 
     def measured_manifests(self, manifests):
-        return [{"id": m.id, "capabilities": m.capabilities} for m in manifests]
+        # What the memory ladder does on a card that cannot hold a model: the
+        # capability is stripped from the wire copy while the manifest itself
+        # still declares it (capabilities_for_rung in memory_ladder.py).
+        return [
+            {"id": m.id,
+             "capabilities": [c for c in m.capabilities
+                              if not (c == "realtime" and m.id in self.strip_realtime)]}
+            for m in manifests
+        ]
 
     async def calibrate_realtime(self, manifest, configured):
         self.calibrated.append(manifest.id)
@@ -650,21 +659,51 @@ def test_warmup_calibrates_the_manifest_declaring_default(order):
 
 
 def test_warmup_without_a_declared_default_picks_the_first_candidate():
+    """Deterministic when nothing declares default, and vega-rt is not special.
+
+    vega-rt is present precisely because the code this replaced named it: if
+    that hardcoding came back, this would calibrate vega-rt instead of the
+    first candidate, so the test fails rather than passing either way.
+    """
     engine = WarmupEngine()
     asyncio.run(warmup_realtime(engine, [realtime_manifest("first"),
-                                         realtime_manifest("second")], 1))
+                                         realtime_manifest("vega-rt")], 1))
     assert engine.calibrated == ["first"]
 
 
-def test_warmup_ignores_a_default_that_cannot_serve_realtime():
-    """capabilities come from measured_manifests, which the memory ladder may
-    have stripped realtime from, so a default the card cannot hold is not a
-    candidate and the realtime model that can is warmed instead."""
-    engine = WarmupEngine()
-    too_big = Manifest(id="too-big", name="too-big",
-                       capabilities=["text_to_image"], default=True, parameters={})
-    asyncio.run(warmup_realtime(engine, [too_big, realtime_manifest("fits")], 1))
+def test_warmup_ignores_a_default_the_card_cannot_hold():
+    """A default whose realtime capability the memory ladder stripped is not a
+    candidate, so the model the card can actually serve is warmed instead.
+
+    The manifest still declares realtime; only the measured wire copy does not,
+    which is what a card too small for it produces.
+    """
+    engine = WarmupEngine(strip_realtime=("too-big",))
+    asyncio.run(warmup_realtime(engine, [realtime_manifest("too-big", default=True),
+                                         realtime_manifest("fits")], 1))
     assert engine.calibrated == ["fits"]
+
+
+def test_warmup_skips_a_benchmark_only_default():
+    """The studio never offers a benchmark_only model, so warming one would
+    leave whatever the picker does open cold and unlabelled."""
+    engine = WarmupEngine()
+    anchor = Manifest(id="anchor", name="anchor", capabilities=["realtime"],
+                      default=True, benchmark_only=True, parameters={})
+    asyncio.run(warmup_realtime(engine, [anchor, realtime_manifest("offered")], 1))
+    assert engine.calibrated == ["offered"]
+
+
+def test_warmup_warns_when_several_models_declare_default(caplog):
+    """Warmup orders manifests by filename and the picker by model id, so with
+    one default they agree and with several they can disagree: say so."""
+    engine = WarmupEngine()
+    with caplog.at_level("WARNING"):
+        asyncio.run(warmup_realtime(engine, [realtime_manifest("zeta", default=True),
+                                             realtime_manifest("alpha", default=True)], 1))
+    assert engine.calibrated == ["zeta"]
+    assert "several realtime models declare default" in caplog.text
+    assert "alpha, zeta" in caplog.text
 
 
 def test_rejected_registration_raises_cleanly():

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -16,6 +16,7 @@ from worker.client import (
     run,
     run_job,
     serve_connection,
+    warmup_realtime,
 )
 from worker.engine import GeneratedFrame, SimulatedEngine
 from worker.manifests import SIMULATED_MANIFEST, Manifest
@@ -605,6 +606,65 @@ def test_heartbeat_advertises_only_frames_at_default_steps():
     # Only the default-steps session was observed, and only it is advertised.
     assert engine.observed == [("sdxl-turbo", 200), ("sdxl-turbo", 200)]
     assert frame_p95_payload(engine) == {"sdxl-turbo": 200}
+
+
+
+class WarmupEngine:
+    """Enough engine for warmup_realtime: it gates on torch_compile existing
+    and on _calibrated_slots being unset, then calibrates one model."""
+
+    torch_compile = False
+
+    def __init__(self):
+        self._calibrated_slots = None
+        self.calibrated: list[str] = []
+
+    def measured_manifests(self, manifests):
+        return [{"id": m.id, "capabilities": m.capabilities} for m in manifests]
+
+    async def calibrate_realtime(self, manifest, configured):
+        self.calibrated.append(manifest.id)
+        self._calibrated_slots = 1
+        return 1
+
+
+def realtime_manifest(model_id, *, default=False):
+    return Manifest(id=model_id, name=model_id, capabilities=["realtime"],
+                    default=default, parameters={})
+
+
+@pytest.mark.parametrize("order", [("plain", "chosen"), ("chosen", "plain")])
+def test_warmup_calibrates_the_manifest_declaring_default(order):
+    """Warm what the studio opens, whatever order the manifests arrive in.
+
+    The picker preselects the manifest declaring `default`, so warming another
+    leaves the first session on a fresh worker paying a cold load while a model
+    nobody selected sits ready (issue #283). This used to name vega-rt, which
+    was right until it was not, and nothing caught the change.
+    """
+    manifests = [realtime_manifest(name, default=(name == "chosen"))
+                 for name in order]
+    engine = WarmupEngine()
+    asyncio.run(warmup_realtime(engine, manifests, 1))
+    assert engine.calibrated == ["chosen"]
+
+
+def test_warmup_without_a_declared_default_picks_the_first_candidate():
+    engine = WarmupEngine()
+    asyncio.run(warmup_realtime(engine, [realtime_manifest("first"),
+                                         realtime_manifest("second")], 1))
+    assert engine.calibrated == ["first"]
+
+
+def test_warmup_ignores_a_default_that_cannot_serve_realtime():
+    """capabilities come from measured_manifests, which the memory ladder may
+    have stripped realtime from, so a default the card cannot hold is not a
+    candidate and the realtime model that can is warmed instead."""
+    engine = WarmupEngine()
+    too_big = Manifest(id="too-big", name="too-big",
+                       capabilities=["text_to_image"], default=True, parameters={})
+    asyncio.run(warmup_realtime(engine, [too_big, realtime_manifest("fits")], 1))
+    assert engine.calibrated == ["fits"]
 
 
 def test_rejected_registration_raises_cleanly():

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -176,8 +176,15 @@ async def warmup_realtime(engine: Engine, manifests: list[Manifest],
     candidates = [manifest for manifest in manifests if manifest.id in live_ids]
     if not candidates:
         return
-    # Prefer the dedicated realtime draft model when present.
-    pick = next((m for m in candidates if m.id == "vega-rt"), candidates[0])
+    # Warm what the studio opens: the manifest declaring `default` is the one
+    # its picker preselects (fallbackModelId in studio.svelte.ts), so warming
+    # anything else leaves the first session on a fresh worker paying a cold
+    # load, measured at 15.4 s against 0.3 s warm, while a model nobody
+    # selected sits ready. This named vega-rt, which was right while it was the
+    # only realtime model and then became wrong in silence (issue #283). The
+    # choice also decides what calibrate_realtime measures, so the p95 the
+    # picker labels a model with is now the default model's own.
+    pick = next((m for m in candidates if m.default), candidates[0])
     slots = await engine.calibrate_realtime(pick, configured_slots)
     logger.info("warmup realtime model=%s slots=%d", pick.id, slots)
 

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -173,9 +173,21 @@ async def warmup_realtime(engine: Engine, manifests: list[Manifest],
     live_ids = {
         item["id"] for item in wire if "realtime" in item.get("capabilities", [])
     }
-    candidates = [manifest for manifest in manifests if manifest.id in live_ids]
+    candidates = [manifest for manifest in manifests
+                  if manifest.id in live_ids and not manifest.benchmark_only]
     if not candidates:
         return
+    declared = [manifest for manifest in candidates if manifest.default]
+    if len(declared) > 1:
+        # The studio's picker takes the first default in ITS order, which is by
+        # model id, while manifests arrive here in filename order. With one
+        # default the two agree; with several they can disagree and the warm
+        # model is not the opened one. Say so rather than pick silently.
+        logger.warning(
+            "several realtime models declare default (%s); warming %s, which the "
+            "studio may not be the one it preselects",
+            ", ".join(sorted(m.id for m in declared)), declared[0].id,
+        )
     # Warm what the studio opens: the manifest declaring `default` is the one
     # its picker preselects (fallbackModelId in studio.svelte.ts), so warming
     # anything else leaves the first session on a fresh worker paying a cold
@@ -184,7 +196,9 @@ async def warmup_realtime(engine: Engine, manifests: list[Manifest],
     # only realtime model and then became wrong in silence (issue #283). The
     # choice also decides what calibrate_realtime measures, so the p95 the
     # picker labels a model with is now the default model's own.
-    pick = next((m for m in candidates if m.default), candidates[0])
+    # benchmark_only models are excluded above: the studio never offers one, so
+    # warming it would leave whatever the picker does open cold and unlabelled.
+    pick = declared[0] if declared else candidates[0]
     slots = await engine.calibrate_realtime(pick, configured_slots)
     logger.info("warmup realtime model=%s slots=%d", pick.id, slots)
 


### PR DESCRIPTION
# Description

The worker preloaded and calibrated a hardcoded `vega-rt` at boot instead of the model the studio actually opens, so since #274 made `sdxl-turbo` the default, a fresh worker warmed a model nobody selects and the first session paid a cold load.

Closes #283.

# Motivation

Measured on the reference RX 7600 XT, opening the default model exactly as the studio does:

| | before | after |
|---|---|---|
| first frame | 15384 ms | 327 ms |
| warm p50 | 296 ms | 301 ms |
| picker label for the default | null | 278 ms |

Fifteen seconds of an active session rendering nothing is the first thing a new user meets, and every frame after it was already inside 330 ms. The same choice decides what `calibrate_realtime` measures, so the picker advertised a number for a model it does not preselect and none for the one it does.

A hardcoded model id was also the kind of thing that rots quietly: correct when `vega-rt` was the only realtime model, wrong afterwards, and nothing failed when it changed.

# Functionality

- Warmup takes the manifest declaring `default`, which is what the studio's picker preselects through `fallbackModelId`, and falls back to the first candidate when none declares it.
- Two consequences are deliberate rather than inherited: boot costs the default model's cold load rather than `vega-rt`'s, and the advertised slot count comes from the default's frame time.
- A default the memory ladder stripped `realtime` from is not a candidate, so a card too small for it still warms a model it can serve.

# Details

`warmup_realtime` is in worker/worker/client.py. Nothing covered it before, which is how the hardcoded id survived becoming wrong, so this adds the first three tests: the declared default wins whatever order the manifests arrive in, a set with no default picks deterministically, and a default without the realtime capability is skipped. Reintroducing the hardcoded id fails the first of those, verified.

`make verify` passes: backend 301, worker 132, frontend 53. The seven upload-test failures that appear under a concurrently running suite are #280, reproduce on main, and are not this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Realtime warmup now uses the studio-selected default model when available.
  * Added a fallback to the first eligible realtime-capable model when no valid default is configured.
  * Benchmark-only and non-realtime models are no longer selected for warmup.
  * Added a warning when multiple models are marked as the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->