### PR TITLE
Say what eviction does, and pin it

### DIFF
--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -275,6 +275,35 @@ def test_canvas_to_sketch_map_inverts_stroke_polarity():
     assert sketch.getpixel((REALTIME_SIZE // 2, REALTIME_SIZE // 4)) == (0, 0, 0)
 
 
+def test_eviction_releases_every_entry_a_model_shares_weights_across():
+    """A model's realtime and t2i entries share their UNet, text encoders and
+    VAE, so freeing its memory means dropping both.
+
+    Eviction works per model rather than per cache key, which is what makes
+    that true: _evict_cold collects model ids and _evict_model drops every key
+    for the one it picks. Pinned here because the sharing is deliberate and a
+    future per-key eviction would free nothing while reporting that it had.
+    """
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    shared = object()
+
+    class Pipe:
+        def __init__(self):
+            self.unet = shared
+
+    engine._pipelines = {("rt", "t2i"): Pipe(), ("rt", "realtime"): Pipe(),
+                         ("other", "t2i"): Pipe()}
+    engine._rungs = {"rt": "full", "other": "full"}
+    engine._last_used = {"rt": 1.0, "other": 2.0}
+    with patch.object(DiffusersEngine, "_free_gpu_cache", lambda self: None), \
+         patch.object(DiffusersEngine, "_free_vram_bytes", lambda self: 0):
+        engine._evict_cold(except_model_id="other")
+
+    assert not [key for key in engine._pipelines if key[0] == "rt"]
+    assert "rt" not in engine._rungs  # nothing resident, so the rung goes too
+    assert ("other", "t2i") in engine._pipelines
+
+
 def test_load_realtime_registers_the_base_under_the_t2i_key():
     """The realtime pipeline's base must be visible to the cache.
 

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -782,13 +782,17 @@ class DiffusersEngine:
             # Registered directly rather than through _pipeline, which would
             # re-enter the loader's own eviction and demotion logic from
             # inside a load; the rung for this model has already been chosen
-            # by the caller. This does not make eviction free: the two cache
-            # entries share their UNet, text encoders and VAE, so evicting
-            # one of them frees nothing while the other is alive. Eviction
-            # accounting does not model shared components; this at least
-            # makes the base visible to the cache rather than invisible to
-            # it, so a later text-to-image job reuses it instead of loading
-            # a second copy.
+            # by the caller. Registering makes the base visible to the cache
+            # rather than invisible to it, so a later text-to-image job reuses
+            # it instead of loading a second complete copy.
+            #
+            # Two entries for one model share their UNet, text encoders and
+            # VAE, and eviction handles that because it works per model:
+            # _evict_cold collects model ids and _evict_model drops every key
+            # for the one it picks, so the shared weights are released
+            # together and no path removes a single entry. Measured with a
+            # two-entry model beside another: both entries went, the cached
+            # rung was forgotten, the other model stayed.
             self._pipelines[(manifest.id, "t2i")] = base
         # T2IAdapter computes its conditioning features once before the
         # denoising loop, so the conditioned path's cost is roughly constant


### PR DESCRIPTION
# Description

Closes #275, which I filed from inference and which is not a defect.

# Motivation

The comment beside the base pipeline registration claimed eviction cannot free a model whose two cache entries share weights, and that its accounting does not model sharing. Both claims are false, and a comment that invents a hazard is worse than no comment, because the next person may go and fix it.

Eviction works per model: `_evict_cold` collects model ids and `_evict_model` drops every key for the one it picks, so a model's shared UNet, text encoders and VAE are released together, and no path removes a single entry.

Measured on a two-entry model beside another:

    entries left          : [('sdxl-fast', 't2i')]
    both vega entries gone: True
    rung forgotten        : True
    other model kept      : True

# Functionality

- The comment now describes what the code does and why the sharing is safe.
- A test pins it, because the sharing is deliberate and a future per-key eviction would free nothing while reporting that it had. Making `_evict_model` drop one key instead of all of them fails that test.

# Details

Nothing about behaviour changes here; this is a comment and a test. `make verify` passes at backend 301, worker 135, frontend 53.

Worth recording: this is the third issue I filed from reading rather than measuring that turned out not to exist, after the slot leak in #264 and the upload-test flake in #273. All three were written from a symptom or an inference and none from a reproduction, which is the habit rather than the individual mistakes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage confirming that model-level cache eviction removes all related pipeline entries and cached rung data.
  * Verified that excluded models remain unaffected.

* **Documentation**
  * Clarified cache eviction behavior for shared realtime and text-to-image pipeline entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->