### PR TITLE
Read an unregistered worker as current, not as ancient

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1227,8 +1227,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
     # believed (docs/connection-handling.md), which is the compatibility
     # floor; that acceptance disappears when the floor moves to 3.
     presented = control.get("dispatch_token")
-    if (presented is None and worker.protocol_version is not None
-            and worker.protocol_version >= 3):
+    if presented is None and worker.protocol_version >= 3:
         # A current worker omitting the token is as stale as one presenting a
         # wrong token, and gets the same warning.
         logger.warning("worker %s sent a stale dispatch token for job %s; ignored",

--- a/backend/app/realtime.py
+++ b/backend/app/realtime.py
@@ -305,11 +305,15 @@ class Worker:
     realtime_slots: int
     device: str | None = None
     memory_mode: str | None = None
-    # Advertised in hello. The update_params handler compares it against
-    # UPDATE_SESSION_PROTOCOL_VERSION to refuse an update an N-1 worker would
-    # silently drop. None for a Worker built without a registration, which is
-    # read as predating every version.
-    protocol_version: int | None = None
+    # Advertised in hello, and read by two gates: the update_params handler
+    # compares it against UPDATE_SESSION_PROTOCOL_VERSION to refuse an update
+    # an N-1 worker would silently drop, and the dispatch-token check in
+    # jobs.py requires the token from a worker at 3 or newer. A registration
+    # always sets it; the default covers a Worker built without one, and it is
+    # the current version rather than None so that gate fails closed rather
+    # than granting the leniency that exists only for an older worker
+    # (issue #282).
+    protocol_version: int = PROTOCOL_VERSION
     slots_in_use: int = 0
     jobs_in_flight: int = 0  # queued jobs; capped at JOB_DISPATCH_DEPTH in jobs.py
     last_seen: float = field(default_factory=time.monotonic)
@@ -822,10 +826,8 @@ async def realtime(ws: WebSocket) -> None:
                                     "message": invalid,
                                 }))
                                 continue
-                        # None means no registration recorded a version, which
-                        # is read as predating every one of them.
                         if (session.worker is not None
-                                and (session.worker.protocol_version or 0)
+                                and session.worker.protocol_version
                                 < UPDATE_SESSION_PROTOCOL_VERSION):
                             # The assigned worker predates update_session (an
                             # N-1 worker is deliberately welcome) and would

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -2290,10 +2290,12 @@ def test_non_finite_progress_is_ignored():
         for unusable in (float("nan"), float("inf"), 10 ** 400, [1], {"a": 1}, None):
             asyncio.run(jobs.on_worker_message(worker, {
                 "type": "job_progress", "job_id": str(job_id), "progress": unusable,
+                "dispatch_token": "token",
             }))
             assert job_id not in jobs.live_progress, f"{unusable!r} was stored"
         asyncio.run(jobs.on_worker_message(worker, {
             "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
+            "dispatch_token": "token",
         }))
         assert jobs.live_progress[job_id] == 0.5
     finally:
@@ -2340,6 +2342,9 @@ def test_job_done_with_unusable_numbers_leaves_the_job_recoverable():
             asyncio.run(jobs.on_worker_message(worker, {
                 "type": "job_done", "job_id": str(job_id), "gpu_ms": unusable,
                 "width": unusable, "height": unusable,
+                # Without the token this worker is at the current protocol and
+                # the message is ignored, which would test nothing.
+                "dispatch_token": "token",
             }))
         except Exception as error:  # noqa: BLE001 - the point is that none escape
             raise AssertionError(f"gpu_ms={unusable!r} escaped as {type(error).__name__}")
@@ -2838,3 +2843,29 @@ def test_upload_temporaries_carry_a_debris_prefix(monkeypatch):
             dispatch = dispatch_for(worker, job_id)
             assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
             assert prefixes == [".upload-"]
+
+
+def test_a_worker_built_without_a_registration_is_not_lenient():
+    """protocol_version defaults to the current protocol, not to None.
+
+    Both gates that read it (the dispatch token here, update_session in
+    realtime.py) must refuse rather than grant an unregistered worker the
+    leniency that exists only for an older one (issue #282).
+    """
+    worker = realtime.Worker(id="w-default", ws=None, manifests=[], realtime_slots=1)
+    assert worker.protocol_version == realtime.PROTOCOL_VERSION
+
+    job_id = uuid.uuid4()
+    jobs.inflight[job_id] = jobs.InFlight(
+        worker=worker, storage_key="k", thumb_storage_key="t", user_id=uuid.uuid4(),
+        dispatch_token="token",
+    )
+    try:
+        asyncio.run(jobs.on_worker_message(worker, {
+            "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
+        }))
+        assert job_id not in jobs.live_progress
+    finally:
+        jobs.inflight.pop(job_id, None)
+        jobs.live_progress.pop(job_id, None)
+        jobs.last_progress_at.pop(job_id, None)

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -2848,9 +2848,12 @@ def test_upload_temporaries_carry_a_debris_prefix(monkeypatch):
 def test_a_worker_built_without_a_registration_is_not_lenient():
     """protocol_version defaults to the current protocol, not to None.
 
-    Both gates that read it (the dispatch token here, update_session in
-    realtime.py) must refuse rather than grant an unregistered worker the
-    leniency that exists only for an older one (issue #282).
+    Two gates read it. This one requires the token from a worker at 3 or
+    newer, so an unregistered worker must be held to it rather than handed
+    the leniency that exists only for an older one (issue #282). The
+    update_session gate in realtime.py reads the same field the other way
+    round, and the same default is right there: it sends the update rather
+    than withholding it, which is what a current worker should get.
     """
     worker = realtime.Worker(id="w-default", ws=None, manifests=[], realtime_slots=1)
     assert worker.protocol_version == realtime.PROTOCOL_VERSION


### PR DESCRIPTION
Closes #282.

`Worker.protocol_version` defaulted to `None`, and two gates read it: the dispatch-token check in `jobs.py` requires the token from a worker at 3 or newer, and `update_params` in `realtime.py` refuses an update an N-1 worker would silently drop. `None` meant "predates every version" for both, so the security gate handed an unset version exactly the leniency that exists only for an older worker.

Registration always sets the field, so nothing in production reached this. A security gate that reads an unset field as the permissive value is the wrong default regardless. It defaults to the current protocol now and both consumers compare it directly, which also drops the `(x or 0)` at the `update_session` call site.

The tests that build a `Worker` without a registration were leaning on that leniency to send job messages with no token, so they were exercising the acceptance rather than the numeric conversion they were written for. They carry a token now, and a new test pins the default: with `protocol_version` forced to `0`, it fails.

## Scope note

Full `make verify` deliberately not run: another process on this machine holds the GPU and the CPU is contended. What I ran is `tests/test_realtime.py` (113 tests), the affected `tests/test_jobs.py` selections, `ruff` and `mypy`, all green, plus the mutation check above. CI runs the full gate here, and I will run it locally before this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved worker protocol compatibility checks for dispatch tokens and live parameter updates.
  - Unregistered workers now use the current protocol version by default.
  - Tokenless progress messages from workers requiring tokens are rejected consistently.

- **Tests**
  - Updated worker-message handling tests to include dispatch tokens.
  - Added coverage for default protocol-version behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->