### PR TITLE
Say when the studio drops a model instead of dropping it in silence

### DIFF
--- a/backend/app/registry.py
+++ b/backend/app/registry.py
@@ -17,6 +17,13 @@ from app.tables import Model
 
 logger = logging.getLogger("potocolom.registry")
 
+# public() runs on every /api/v1/models request and on every for_jobs()
+# call, so a drop logged naively would repeat for every poll of the studio.
+# Remembering the last-logged drop per model id logs a given drop once, and
+# only again when the reason changes or a recovery ends and the drop
+# returns; otherwise a pure function would not hold state.
+_last_dropped_reason: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {}
+
 router = APIRouter()
 
 
@@ -48,6 +55,7 @@ def public() -> dict[str, Manifest]:
     public_models: dict[str, Manifest] = {}
     for model_id, manifest in published.items():
         if manifest.studio_capabilities is None:
+            _last_dropped_reason.pop(model_id, None)
             public_models[model_id] = manifest
             continue
         # The studio pickers filter on capabilities, so narrowing them here is
@@ -60,7 +68,16 @@ def public() -> dict[str, Manifest]:
             # studio would list it while no picker could ever offer it, which
             # reads as a removal the user never made. available() still serves
             # it to the benchmark page and the realtime session path.
+            reason = (tuple(manifest.capabilities), tuple(manifest.studio_capabilities))
+            if _last_dropped_reason.get(model_id) != reason:
+                logger.warning(
+                    "model %s dropped from the studio: advertised capabilities %s "
+                    "narrow to nothing against studio_capabilities %s",
+                    manifest.id, manifest.capabilities, manifest.studio_capabilities,
+                )
+                _last_dropped_reason[model_id] = reason
             continue
+        _last_dropped_reason.pop(model_id, None)
         public_models[model_id] = manifest.model_copy(update={"capabilities": narrowed})
     return public_models
 

--- a/backend/tests/test_registry.py
+++ b/backend/tests/test_registry.py
@@ -1,5 +1,7 @@
 """Model registry merge rules across concurrent workers."""
 
+import logging
+
 import pytest
 from unittest.mock import MagicMock
 
@@ -266,6 +268,107 @@ def test_public_omits_a_manifest_narrowed_to_nothing():
     finally:
         realtime.workers.clear()
         realtime.workers.update(saved)
+
+
+def test_public_logs_a_narrowed_to_nothing_drop_once(caplog):
+    # A model whose studio set intersects nothing vanishes from the studio,
+    # so the drop must be said out loud: the model id and both capability
+    # sets in one line an operator can grep for (issue #269).
+    worker = realtime.Worker(
+        id="w-drop", ws=None, realtime_slots=1,
+        manifests=[Manifest(id="m-drop", name="Drop",
+                            capabilities=["text_to_image"],
+                            studio_capabilities=["upscale"])],
+    )
+    saved = dict(realtime.workers)
+    try:
+        realtime.workers.clear()
+        realtime.workers["w-drop"] = worker
+        with caplog.at_level(logging.WARNING, logger="potocolom.registry"):
+            assert "m-drop" not in registry.public()
+        assert "m-drop" in registry.available()
+    finally:
+        realtime.workers.clear()
+        realtime.workers.update(saved)
+    records = [r for r in caplog.records if r.name == "potocolom.registry"]
+    assert len(records) == 1
+    assert records[0].message == (
+        "model m-drop dropped from the studio: advertised capabilities "
+        "['text_to_image'] narrow to nothing against studio_capabilities ['upscale']"
+    )
+
+
+def test_public_does_not_repeat_the_drop_log(caplog):
+    # public() runs on every /api/v1/models request and for_jobs() call, so
+    # a drop must be logged once, not once per poll of the studio.
+    worker = realtime.Worker(
+        id="w-repeat", ws=None, realtime_slots=1,
+        manifests=[Manifest(id="m-repeat", name="Repeat",
+                            capabilities=["text_to_image"],
+                            studio_capabilities=["upscale"])],
+    )
+    saved = dict(realtime.workers)
+    try:
+        realtime.workers.clear()
+        realtime.workers["w-repeat"] = worker
+        with caplog.at_level(logging.WARNING, logger="potocolom.registry"):
+            for _ in range(3):
+                assert "m-repeat" not in registry.public()
+    finally:
+        realtime.workers.clear()
+        realtime.workers.update(saved)
+    records = [r for r in caplog.records if r.name == "potocolom.registry"]
+    assert len(records) == 1
+
+
+def test_public_relogs_a_drop_after_the_model_recovers(caplog):
+    # The suppression is per state, not permanent: a model that recovers and
+    # then drops again is a second event an operator needs to see.
+    worker = realtime.Worker(
+        id="w-again", ws=None, realtime_slots=1,
+        manifests=[Manifest(id="m-again", name="Again",
+                            capabilities=["text_to_image", "realtime"],
+                            studio_capabilities=["upscale"])],
+    )
+    saved = dict(realtime.workers)
+    try:
+        realtime.workers.clear()
+        realtime.workers["w-again"] = worker
+        with caplog.at_level(logging.WARNING, logger="potocolom.registry"):
+            assert "m-again" not in registry.public()
+            worker.manifests[0].studio_capabilities = ["realtime"]
+            assert "m-again" in registry.public()
+            worker.manifests[0].studio_capabilities = ["upscale"]
+            assert "m-again" not in registry.public()
+    finally:
+        realtime.workers.clear()
+        realtime.workers.update(saved)
+    records = [r for r in caplog.records if r.name == "potocolom.registry"]
+    assert len(records) == 2
+
+
+def test_public_does_not_log_a_benchmark_only_model(caplog):
+    # benchmark_only is the field doing its job, not a drop: a model absent
+    # for that reason must stay silent even when its studio set would narrow
+    # to nothing.
+    worker = realtime.Worker(
+        id="w-bench", ws=None, realtime_slots=0,
+        manifests=[Manifest(id="m-bench", name="Bench",
+                            capabilities=["text_to_image"],
+                            benchmark_only=True,
+                            studio_capabilities=["upscale"])],
+    )
+    saved = dict(realtime.workers)
+    try:
+        realtime.workers.clear()
+        realtime.workers["w-bench"] = worker
+        with caplog.at_level(logging.WARNING, logger="potocolom.registry"):
+            assert "m-bench" not in registry.public()
+    finally:
+        realtime.workers.clear()
+        realtime.workers.update(saved)
+    records = [r for r in caplog.records if r.name == "potocolom.registry"]
+    assert not records
 
 
 @pytest.mark.db


### PR DESCRIPTION
# Description

A manifest whose `studio_capabilities` narrow to nothing is omitted from `/api/v1/models` entirely. That is intended, and it was silent.

# Motivation

Reproduced on the shipped `sdxl-turbo`, whose `studio_capabilities` is `["realtime"]`, by driving it through `measured_wire_manifest` at each rung:

    rung=full           wire caps=['text_to_image', 'image_to_image', 'realtime']
                        public: present as ['realtime']

    rung=model_offload  wire caps=['text_to_image', 'image_to_image']
                        public: ABSENT from /api/v1/models

So a rung below full strips `realtime`, the intersection empties, and the model vanishes: not in the realtime picker, not in the queued pickers, not in the models screen, with nothing on any surface saying why. `available()` still carries it for the benchmark page and the realtime session path, which is the asymmetry that makes it confusing to diagnose from the studio alone.

# Functionality

- A drop logs at warning level, naming the model, the capabilities the worker advertised, and the `studio_capabilities` they narrowed against.
- `public()` runs on every models request and every `for_jobs()` call, so the line is remembered per model and repeated only when the reason changes, or when a recovery ends and the drop returns.
- A `benchmark_only` model logs nothing: that is the field doing its job, not a drop.
- The model is still omitted. Advertising one with no offerable capability would read as a removal nobody made.

# Details

Issue #269 stays open for the other half, which is whether the studio should show such a model as present but unavailable; that needs somewhere in the studio to say so, and it is a product decision rather than a log line.

Four tests cover it: the drop logs once with both capability sets, repeated calls do not repeat it, a model that recovers and empties again logs the second time, and a `benchmark_only` model logs nothing. Removing the logging call fails two of them.

`make verify` passes at backend 305, worker 134, frontend 53.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of models removed from Studio when no capabilities remain.
  * Prevented repeated warnings for the same model and removal reason.
  * Warnings now reappear when a model recovers and is later removed again.
  * Benchmark-only models continue to be excluded from public availability.
  * Preserved existing model availability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->