### PR TITLE
Say when a tree's derivatives could not be loaded

### DIFF
--- a/frontend/src/lib/components/lineage-canvas.svelte
+++ b/frontend/src/lib/components/lineage-canvas.svelte
@@ -40,6 +40,7 @@
 	import MoveIcon from '@lucide/svelte/icons/move';
 	import PencilIcon from '@lucide/svelte/icons/pencil';
 	import PlusIcon from '@lucide/svelte/icons/plus';
+	import RefreshCwIcon from '@lucide/svelte/icons/refresh-cw';
 	import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
 	import ScanLineIcon from '@lucide/svelte/icons/scan-line';
 	import StarIcon from '@lucide/svelte/icons/star';
@@ -1617,7 +1618,7 @@
 									scheduleTreeLoad(root, true);
 								}}
 							>
-								<RotateCcwIcon />
+								<RefreshCwIcon />
 							</button>
 						{/if}
 					{/if}

--- a/frontend/src/lib/components/lineage-canvas.svelte
+++ b/frontend/src/lib/components/lineage-canvas.svelte
@@ -1503,7 +1503,7 @@
 						class:is-missing={data.entry.missing || shownImage === null}
 						class:is-starred={starred}
 						style={`--tile-pull: ${proximityScale(item)}`}
-						aria-label={`${actionLabel(data.entry.action)}: ${promptLabel(data)}${starred ? `. ${t('app.images.starred')}` : ''}${item.isRoot ? `. ${t('app.images.drag_tree')}` : ''}${item.treeStatus === 'loading' ? `. ${t('app.images.tree_loading')}` : ''}`}
+						aria-label={`${actionLabel(data.entry.action)}: ${promptLabel(data)}${starred ? `. ${t('app.images.starred')}` : ''}${item.isRoot ? `. ${t('app.images.drag_tree')}` : ''}${item.treeStatus === 'loading' ? `. ${t('app.images.tree_loading')}` : ''}${item.treeStatus === 'error' ? `. ${t('app.images.tree_load_failed')}` : ''}`}
 						title={promptLabel(data)}
 						onfocus={() => (focusedNodeId = item.node.id)}
 						onblur={() => (focusedNodeId = null)}
@@ -1602,6 +1602,24 @@
 						>
 							<RotateCcwIcon />
 						</button>
+					{/if}
+					{#if item.isRoot && item.treeStatus === 'error'}
+						{@const root = persistedRoots.find((entry) => entry.id === item.rootId)}
+						{#if root}
+							<button
+								type="button"
+								class="retry-tree-load"
+								title={t('app.images.retry_tree_load')}
+								aria-label={t('app.images.retry_tree_load')}
+								onpointerdown={(event) => event.stopPropagation()}
+								onclick={(event) => {
+									event.stopPropagation();
+									scheduleTreeLoad(root, true);
+								}}
+							>
+								<RotateCcwIcon />
+							</button>
+						{/if}
 					{/if}
 					{#if item.isRoot && item.remainingCountLowerBound > 0}
 						<span class="truncated-count">
@@ -1953,6 +1971,38 @@
 		height: 13px;
 	}
 
+	.retry-tree-load {
+		position: absolute;
+		top: calc(50% - var(--visible-tile-half-height) - 10px);
+		right: calc(50% + var(--visible-tile-half-width) - 10px);
+		z-index: 2;
+		display: grid;
+		width: 24px;
+		height: 24px;
+		padding: 0;
+		place-items: center;
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		color: var(--foreground);
+		background: var(--card);
+		box-shadow: 0 2px 8px color-mix(in oklch, var(--foreground) 14%, transparent);
+		pointer-events: auto;
+	}
+
+	.retry-tree-load:hover {
+		background: var(--accent);
+	}
+
+	.retry-tree-load:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 2px;
+	}
+
+	.retry-tree-load :global(svg) {
+		width: 13px;
+		height: 13px;
+	}
+
 	.truncated-count {
 		position: absolute;
 		top: calc(50% + var(--visible-tile-half-height) + 6px);
@@ -2007,6 +2057,10 @@
 		width: 100%;
 		height: 100%;
 		place-items: center;
+	}
+
+	.lod-constellation .retry-tree-load {
+		display: none;
 	}
 
 	.micro-content img,

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -369,6 +369,8 @@
 	"app.images.load_failed": "Image history could not be loaded.",
 	"app.images.retry": "Retry",
 	"app.images.tree_loading": "Loading derivatives",
+	"app.images.tree_load_failed": "Derivatives could not be loaded",
+	"app.images.retry_tree_load": "Load this tree's derivatives again",
 	"app.images.truncated_more": "At least {count} more not loaded",
 	"app.images.drag_tree": "Drag to move this tree. Use arrow keys when focused.",
 	"app.images.reset_tree_position": "Reset this tree position",

--- a/frontend/src/lib/i18n/es.json
+++ b/frontend/src/lib/i18n/es.json
@@ -369,6 +369,8 @@
 	"app.images.load_failed": "No se pudo cargar el historial de imagenes.",
 	"app.images.retry": "Reintentar",
 	"app.images.tree_loading": "Cargando derivadas",
+	"app.images.tree_load_failed": "No se pudieron cargar las derivadas",
+	"app.images.retry_tree_load": "Cargar de nuevo las derivadas de este árbol",
 	"app.images.truncated_more": "Al menos {count} mas sin cargar",
 	"app.images.drag_tree": "Arrastra para mover este arbol. Usa las flechas al enfocarlo.",
 	"app.images.reset_tree_position": "Restablecer la posicion de este arbol",


### PR DESCRIPTION
# Description

Closes #235. A subtree that failed permanently collapsed to its root tile, which is visually
identical to a root that never had derivatives.

# Details

Confirmed in a browser when the issue was filed: with `/subtree` forced to 500, a root with five
real children rendered as a lone tile and the canvas contained no text matching failure, error or
retry. It was also unrecoverable within the session, because the one automatic retry is spent,
`decideLineageTreeLoad` then returns `skip` for the rest of the section's life, and a failed entry
is never written to `sessionTreeCache`, so only leaving the section and returning cleared it.

A failed root now carries a retry control that forces a load, which grants a fresh budget through
`retainedRetryBudget`.

Three details worth stating, because each was a constraint rather than a preference:

- The control is a **sibling** of the tile, not a child. The tile is itself a `<button>`, so
  nesting one inside it would be invalid, and the decorative `root-affordance` span already there
  takes no pointer events. This is the same shape `reset-tree-position` uses.
- It sits opposite `reset-tree-position` so a tree that was dragged and then failed shows both.
  They are mirrored about the tile centre and do not overlap: 196px apart at the card band, 84px
  at trees.
- It is hidden at the constellation band, where a 24px control would swamp a tile whose
  half-width is 18px.

The tile's `aria-label` gains the failure phrase too, so a screen reader is not told a tree is
complete when its derivatives are missing.

The retry budget itself is unchanged and was already correct. This issue was only ever about the
absence of feedback.

# Verification

`npm run lint`, `npm run check` clean across 1247 files, 54 unit tests, and `npm run build` with
CSP verification all pass. The `en.json` and `es.json` key sets are identical.

No unit test: the change is markup, CSS and an accessible name, and the state it keys off,
`treeStatus === 'error'`, is already covered. A test that rendered a fake component to assert on a
CSS class would be the theatre this repo has rejected before.