### PR TITLE
Leave no job behind for the next test to inherit

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -220,7 +220,14 @@ def _no_inherited_jobs(request):
     if "db" not in request.keywords or not DATABASE_AVAILABLE:
         return
     from app import db, jobs, realtime
+    from app.settings import get_settings
 
+    # monkeypatch puts the environment back, and the settings cache still holds
+    # what was read from it: a test that lowered JOB_STALL_SECONDS to force a
+    # requeue leaves every later test with a sweeper that fires in 50 ms, which
+    # requeues their jobs under them. Undoing the variable is not undoing the
+    # setting until this is cleared.
+    get_settings.cache_clear()
     # A worker whose socket is gone stays in this registry, and the scheduler
     # will hand it the next test's job and wait for a reply that cannot come.
     realtime.workers.clear()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -39,6 +39,7 @@ import tempfile
 from urllib.parse import urlsplit
 
 import pytest
+from sqlalchemy import text
 
 _CHECKOUT = pathlib.Path(__file__).resolve().parents[2]
 _VERSIONS = _CHECKOUT / "backend" / "migrations" / "versions"
@@ -199,6 +200,56 @@ DATABASE_AVAILABLE = _prepare_database()
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "db: needs the development PostgreSQL")
+
+
+@pytest.fixture(autouse=True)
+def _no_inherited_jobs(request):
+    """Leave no job behind for the next test to be handed.
+
+    A job left running is requeued when its socket closes, so the next test to
+    open a fleet socket receives that dispatch before its own and waits for a
+    message that already went somewhere else. Tests used to work around it by
+    reading until they saw their own job id, which kept the leak and hid it
+    (issue #279).
+
+    Cleared after each test rather than before, so a failure leaves the state
+    that produced it visible to whoever is debugging, and the test that comes
+    after still starts clean.
+    """
+    yield
+    if "db" not in request.keywords or not DATABASE_AVAILABLE:
+        return
+    from app import db, jobs, realtime
+
+    # A worker whose socket is gone stays in this registry, and the scheduler
+    # will hand it the next test's job and wait for a reply that cannot come.
+    realtime.workers.clear()
+    jobs.inflight.clear()
+    jobs.live_progress.clear()
+    jobs.last_progress_at.clear()
+    jobs.lost_jobs.clear()
+    jobs.subscribers.clear()
+
+    async def drain() -> None:
+        # The queue holds ids, not rows, so truncating the table does not empty
+        # it. A leftover id is dispatched to whichever worker is registered
+        # when the loop next runs, which is the next test's, and that test then
+        # reads a dispatch belonging to a job it never created.
+        while await jobs.queues.pop(jobs.JOB_QUEUE) is not None:
+            pass
+        if db.session_factory is None:
+            return  # the app never started here, so no rows of its making
+        async with db.session_factory() as session:
+            # DELETE rather than TRUNCATE: TRUNCATE takes an ACCESS EXCLUSIVE
+            # lock and waits behind any connection a finished test left open,
+            # which hangs the run instead of cleaning it. These tables hold a
+            # handful of rows, so the row-level path costs nothing, and the
+            # lock timeout keeps a stuck connection from stalling the suite.
+            await session.execute(text("SET LOCAL lock_timeout = '5s'"))
+            await session.execute(text("DELETE FROM jobs"))
+            await session.commit()
+
+    asyncio.run(drain())
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -78,10 +78,14 @@ def webp_bytes():
 
 
 def dispatch_for(worker, job_id, limit=5):
-    """The dispatch for this job, skipping any the suite left requeued.
+    """The dispatch for this job, skipping any that belongs to another test.
 
-    A job another test left running is requeued when its socket closes, so a
-    fresh socket can be handed that dispatch before this test's own.
+    The conftest fixture clears the job rows and the in-process dispatch state
+    after every db test, which removes the leak this used to paper over. What
+    survives is a dispatch already in flight when the fixture runs: the loop
+    picked the row before the delete and delivers it to whichever worker is
+    registered when it wakes, which is the next test's. Measured, removing this
+    helper fails about one run in four, all in the same cluster (issue #279).
     """
     for _ in range(limit):
         message = worker.receive_json()


### PR DESCRIPTION
Addresses #279. The issue stays open for the part I did not close, which is stated below rather than glossed.

A job left running is requeued when its socket closes, so the next test to open a fleet socket was handed that dispatch before its own. The tests worked around it with `dispatch_for`, reading until they saw their own job id, which kept the leak and hid it.

An autouse fixture now clears what one test can leave another: the job rows, the in-process dispatch state, **the queue**, and **the worker registry**. The last two are the ones that are easy to miss. The queue holds ids rather than rows, so emptying the table does not empty it, and a leftover id is dispatched to whoever is registered when the loop next wakes. A worker whose socket is gone stays in the registry and still gets picked by the scheduler, and then nothing answers.

## The part that took the longest, because it looked like flakiness

My first version used `TRUNCATE jobs CASCADE`. That takes an ACCESS EXCLUSIVE lock and waits behind any connection a finished test left open, so the suite **hung** rather than cleaned, and the hangs surfaced as failures scattered across the jobs tests. It cost several rounds of measuring before I stopped believing the symptom and looked at the lock. `DELETE` plus a `lock_timeout` is the fix; these tables hold a handful of rows, so the row-level path costs nothing.

## Measured

| | Before | After |
|---|---|---|
| Suite time | ~145s | ~42s |
| Consecutive clean runs | flaky | 8 of 8, then 3 more after the final edit |

The speedup is not incidental: tests were waiting on each other's leftovers.

## What I did not close, honestly

`dispatch_for` stays. I removed it, measured, and it fails about **one run in four**, always the same cluster: a dispatch already in flight when the fixture runs is delivered to the next test's worker, because the loop picked the row before the delete. That is a narrower coupling than the leak, and closing it means either draining the loop at teardown or making dispatch check that its worker is still the one that asked. Its docstring now describes that, instead of describing the leak this PR removes.

`make verify` green: 307 backend, 135 worker, frontend build and CSP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved database test isolation by automatically cleaning up queued, active, and persisted job state between tests.
  - Prevented leftover dispatch activity from affecting subsequent job-processing tests.
  - Updated test documentation to clarify cleanup behavior and reduce cross-test failures.
  - Improved test reliability when database sessions or services are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->