### PR TITLE
Delete the assets before the jobs they belong to

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -255,7 +255,14 @@ def _no_inherited_jobs(request):
             # which hangs the run instead of cleaning it. These tables hold a
             # handful of rows, so the row-level path costs nothing, and the
             # lock timeout keeps a stuck connection from stalling the suite.
+            #
+            # Assets first: they carry the job_id foreign key, which TRUNCATE
+            # CASCADE used to absorb and DELETE does not. Nulling the other
+            # direction first (jobs.source_asset_id) is what lets the assets go
+            # while a job still points at one.
             await session.execute(text("SET LOCAL lock_timeout = '5s'"))
+            await session.execute(text("UPDATE jobs SET source_asset_id = NULL"))
+            await session.execute(text("DELETE FROM assets"))
             await session.execute(text("DELETE FROM jobs"))
             await session.commit()
 


### PR DESCRIPTION
Follow-up to #306, which CI caught on the branch behind it.

The cleanup fixture swapped TRUNCATE ... CASCADE for DELETE, because TRUNCATE takes an ACCESS EXCLUSIVE lock and waits behind any connection a finished test left open, which hung the suite rather than cleaning it. DELETE does not absorb what CASCADE did: assets.job_id references jobs, so deleting the jobs first raises ForeignKeyViolationError.

Assets go first now, and jobs.source_asset_id is nulled before them, since the two tables reference each other and a job still holding a source asset would block its deletion.

Worth noting how it surfaced: the local suite never hit it, because most tests clean up their own rows; the failure needed a test that leaves an asset behind, which is exactly the case the fixture exists for. make verify green, and five consecutive runs of the backend suite pass (314 tests, about 45s).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup reliability by removing asset records in the correct order.
  * Prevented foreign-key conflicts during test data deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->