### PR TITLE
Retry the deletes the terminal paths could not make

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -21,7 +21,7 @@ import unicodedata
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from itertools import count
 from typing import Literal, Protocol
 
@@ -29,6 +29,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import and_, func, or_, select, text, update
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import RowMapping
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -38,7 +39,7 @@ from app.auth import current_user, require_role
 from app.manifests import validate_params
 from app.settings import get_settings
 from app.storage import get_storage
-from app.tables import Asset, Job, User
+from app.tables import Asset, Job, PendingDelete, User
 
 logger = logging.getLogger("potocolom.jobs")
 
@@ -57,6 +58,12 @@ DOWNLOAD_SLUG_MAX_WORDS = 6
 LINEAGE_SUBTREE_MAX_DEPTH = 100
 # Six hundred matches the canvas tile ceiling and bounds unusually broad trees.
 LINEAGE_SUBTREE_MAX_NODES = 600
+# Sweep policy for blobs the terminal paths could not delete (issue #254).
+PENDING_DELETE_ERROR_MAX = 1000  # a last_error is a sentence, not a traceback
+PENDING_DELETE_PASS_LIMIT = 100  # rows per pass, so one bad batch cannot hog a tick
+PENDING_DELETE_MAX_ATTEMPTS = 8  # after this many failures the object stays
+PENDING_DELETE_BACKOFF_CAP = 60  # minutes; 2 ** 7 would already overshoot an hour
+MAINTAIN_DELETES_INTERVAL = 300.0  # seconds
 
 
 class Queues(Protocol):
@@ -1475,12 +1482,106 @@ async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: in
         for key in storage_keys_for_attempt(user_id, job_id, earlier):
             try:
                 await get_storage().delete(key)
-            except Exception:
+            except Exception as error:
                 # Warning, not debug: a missing object does not normally make
                 # a delete raise, so this is a real cleanup failure such as a
-                # denied permission, and nothing retries it.
+                # denied permission, and the sweep is what retries it.
                 logger.warning("could not remove blob %s for job %s", key, job_id,
                                exc_info=True)
+                await record_pending_delete(key, _trim_error(error))
+
+
+async def record_pending_delete(storage_key: str, last_error: str) -> None:
+    """Best-effort note that a delete failed; the DB may be down (issue #254).
+
+    The insert carries attempts from its column default so a repeat failure
+    refreshes last_error and next_attempt_at without touching the counter the
+    sweep owns; a fresh key starts at zero attempts.
+    """
+    if db.session_factory is None:
+        logger.warning("could not record pending delete for %s: database unavailable",
+                       storage_key)
+        return
+    try:
+        async with db.session_factory() as session:
+            now = datetime.now(timezone.utc)
+            statement = insert(PendingDelete).values(
+                storage_key=storage_key,
+                last_error=last_error,
+                first_failed_at=now,
+                next_attempt_at=now,
+            )
+            excluded = statement.excluded
+            statement = statement.on_conflict_do_update(
+                index_elements=[PendingDelete.storage_key],
+                set_={
+                    "last_error": excluded.last_error,
+                    "next_attempt_at": excluded.next_attempt_at,
+                },
+            )
+            await session.execute(statement)
+            await session.commit()
+    except Exception:
+        # A delete failure that cannot even be recorded rates one line: unless
+        # an operator reads the logs at that moment, it is the last sight of
+        # the object.
+        logger.warning("could not record pending delete for %s", storage_key,
+                       exc_info=True)
+
+
+async def retry_pending_deletes() -> None:
+    """Delete the blobs the terminal paths could not (issue #254).
+
+    Selected by due time, oldest first, capped per pass so one batch that keeps
+    failing cannot dominate the tick. A row leaves the table only when its
+    object is gone or its eighth attempt failed: the error log line is then the
+    last word on that object, and the object is still there.
+    """
+    if db.session_factory is None:
+        return
+    now = datetime.now(timezone.utc)
+    async with db.session_factory() as session:
+        rows = (
+            await session.execute(
+                select(PendingDelete)
+                .where(PendingDelete.next_attempt_at <= now)
+                .order_by(PendingDelete.next_attempt_at)
+                .limit(PENDING_DELETE_PASS_LIMIT)
+            )
+        ).scalars()
+        for row in rows:
+            try:
+                await get_storage().delete(row.storage_key)
+            except Exception as error:
+                message = _trim_error(error)
+                row.attempts += 1
+                row.last_error = message
+                if row.attempts >= PENDING_DELETE_MAX_ATTEMPTS:
+                    logger.error("giving up on deleting %s after %s attempts: %s",
+                                 row.storage_key, row.attempts, message)
+                    await session.delete(row)
+                    continue
+                minutes = min(2 ** row.attempts, PENDING_DELETE_BACKOFF_CAP)
+                row.next_attempt_at = now + timedelta(minutes=minutes)
+            else:
+                await session.delete(row)
+        await session.commit()
+
+
+def _trim_error(error: Exception) -> str:
+    message = str(error)
+    if len(message) <= PENDING_DELETE_ERROR_MAX:
+        return message
+    return message[:PENDING_DELETE_ERROR_MAX]
+
+
+async def maintain_deletes_loop() -> None:
+    while True:
+        try:
+            await retry_pending_deletes()
+        except Exception:
+            logger.exception("pending delete maintenance failed")
+        await asyncio.sleep(MAINTAIN_DELETES_INTERVAL)
 
 
 async def mark_failed(job_id: uuid.UUID, reason: str,

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -61,7 +61,7 @@ LINEAGE_SUBTREE_MAX_NODES = 600
 # Sweep policy for blobs the terminal paths could not delete (issue #254).
 PENDING_DELETE_ERROR_MAX = 1000  # a last_error is a sentence, not a traceback
 PENDING_DELETE_PASS_LIMIT = 100  # rows per pass, so one bad batch cannot hog a tick
-PENDING_DELETE_MAX_ATTEMPTS = 8  # after this many failures the object stays
+PENDING_DELETE_MAX_ATTEMPTS = 8  # failures before the one alert; retries continue
 PENDING_DELETE_BACKOFF_CAP = 60  # minutes; 2 ** 7 would already overshoot an hour
 MAINTAIN_DELETES_INTERVAL = 300.0  # seconds
 PENDING_DELETE_TIMEOUT = 60.0  # seconds for one delete, so a wedged mount cannot stall the pass
@@ -1537,61 +1537,81 @@ async def record_pending_delete(storage_key: str, last_error: str) -> None:
 async def retry_pending_deletes() -> None:
     """Delete the blobs the terminal paths could not (issue #254).
 
-    Selected by due time, oldest first, capped per pass so one batch that keeps
-    failing cannot dominate the tick. A row leaves the table only when its
-    object is gone or its eighth attempt failed: the error log line is then the
-    last word on that object, and the object is still there.
+    Due rows oldest first, capped per pass so one batch that keeps failing
+    cannot dominate a tick, and one transaction per row: holding the pass open
+    across every storage call would pin a connection and a row lock for as long
+    as the storage takes to answer, and a process that died mid-pass would lose
+    every attempt it had counted.
+
+    A row leaves the table when its object is gone. Nothing gives up on it: the
+    backoff caps at an hour, so a permanently undeletable object costs one call
+    an hour and keeps a row saying so. Dropping it, or unscheduling it, makes an
+    outage longer than the backoff permanent, since nothing re-arms a row and
+    the log line has rotated by the time anyone reads it.
     """
     if db.session_factory is None:
         return
-    now = datetime.now(timezone.utc)
     async with db.session_factory() as session:
-        rows = (
+        due = (
             await session.execute(
-                select(PendingDelete)
-                # A given-up row carries a null here, and null <= now is null,
-                # so this one comparison also skips it.
-                .where(PendingDelete.next_attempt_at <= now)
+                select(PendingDelete.storage_key)
+                .where(PendingDelete.next_attempt_at <= datetime.now(timezone.utc))
                 .order_by(PendingDelete.next_attempt_at)
                 .limit(PENDING_DELETE_PASS_LIMIT)
-                # The cloud profile runs this loop in every replica on the same
-                # cadence. Without the lock both select the same batch, both
-                # delete (idempotent, but twice the storage traffic), and the
-                # loser's commit fails on rows the winner already removed.
+            )
+        ).scalars().all()
+
+    for storage_key in due:
+        await _retry_one_pending_delete(storage_key)
+
+
+async def _retry_one_pending_delete(storage_key: str) -> None:
+    """One delete, one transaction, taken under a lock another replica skips."""
+    assert db.session_factory is not None
+    async with db.session_factory() as session:
+        # The cloud profile runs this loop in every replica on the same
+        # cadence. SKIP LOCKED hands each row to exactly one of them, and the
+        # row is re-read here because it may have been swept since the select.
+        row = (
+            await session.execute(
+                select(PendingDelete)
+                .where(PendingDelete.storage_key == storage_key)
                 .with_for_update(skip_locked=True)
             )
-        ).scalars()
-        for row in rows:
-            try:
-                # LocalStorage.delete is an unlink, which blocks forever on a
-                # wedged mount: without the bound the pass never finishes, the
-                # loop never sleeps, and nothing raises to say so.
-                await asyncio.wait_for(get_storage().delete(row.storage_key),
-                                       PENDING_DELETE_TIMEOUT)
-            except Exception as error:
-                message = _trim_error(error)
-                row.attempts += 1
-                row.last_error = message
-                if row.attempts >= PENDING_DELETE_MAX_ATTEMPTS:
-                    # Unscheduled, not deleted. Dropping the row loses the only
-                    # record that the object exists: the backoff spans about
-                    # three hours, which a storage outage can outlive with the
-                    # API still up, and an operator who fixes it afterwards
-                    # would have nothing to look at. A null next_attempt_at is
-                    # what the sweep skips.
-                    logger.error("giving up on deleting %s after %s attempts: %s",
-                                 row.storage_key, row.attempts, message)
-                    row.next_attempt_at = None
-                    continue
-                minutes = min(2 ** row.attempts, PENDING_DELETE_BACKOFF_CAP)
-                row.next_attempt_at = now + timedelta(minutes=minutes)
-            else:
-                await session.delete(row)
+        ).scalar_one_or_none()
+        if row is None or row.next_attempt_at is None:
+            return
+        if row.next_attempt_at > datetime.now(timezone.utc):
+            return  # another replica already rescheduled it
+        try:
+            # The bound is real now that both backends await off the loop, and
+            # it is what keeps a wedged mount from stalling the whole pass.
+            await asyncio.wait_for(get_storage().delete(storage_key),
+                                   PENDING_DELETE_TIMEOUT)
+        except Exception as error:
+            message = _trim_error(error)
+            row.attempts += 1
+            row.last_error = message
+            if row.attempts == PENDING_DELETE_MAX_ATTEMPTS:
+                # Once, as an alert. The row stays scheduled: an object nobody
+                # can delete costs one call an hour, and a row that stops being
+                # retried is a leak with no way back.
+                logger.error("still cannot delete %s after %s attempts: %s",
+                             storage_key, row.attempts, message)
+            minutes = min(2 ** row.attempts, PENDING_DELETE_BACKOFF_CAP)
+            # Stamped now rather than at the top of the pass: a slow pass would
+            # otherwise hand its tail a due time already in the past.
+            row.next_attempt_at = datetime.now(timezone.utc) + timedelta(minutes=minutes)
+        else:
+            await session.delete(row)
         await session.commit()
 
 
 def _trim_error(error: Exception) -> str:
-    message = str(error)
+    # The type name always: str() is empty for asyncio.TimeoutError and for a
+    # few botocore and OS errors, and this string is the whole record of why an
+    # object is still there.
+    message = f"{type(error).__name__}: {error}".rstrip(": ")
     if len(message) <= PENDING_DELETE_ERROR_MAX:
         return message
     return message[:PENDING_DELETE_ERROR_MAX]

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -14,6 +14,7 @@ import hmac
 import json
 import logging
 import math
+import random
 import re
 import secrets
 import time
@@ -1434,7 +1435,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             orphans.extend(storage_keys_for_attempt(current.user_id, job_id, earlier))
         for orphan in orphans:
             try:
-                await get_storage().delete(orphan)
+                await _bounded_delete(orphan)
             except Exception as error:
                 # The same leak purge_attempt_blobs had, one function away: the
                 # success path collects the earlier attempts and an unreported
@@ -1486,7 +1487,7 @@ async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: in
     for earlier in range(1, attempt + 1):
         for key in storage_keys_for_attempt(user_id, job_id, earlier):
             try:
-                await get_storage().delete(key)
+                await _bounded_delete(key)
             except Exception as error:
                 # Warning, not debug: a missing object does not normally make
                 # a delete raise, so this is a real cleanup failure such as a
@@ -1494,6 +1495,13 @@ async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: in
                 logger.warning("could not remove blob %s for job %s", key, job_id,
                                exc_info=True)
                 await record_pending_delete(key, _trim_error(error))
+
+
+async def _bounded_delete(storage_key: str) -> None:
+    """One delete, bounded. Every caller is on a path that must not hang: a
+    terminal verdict, or the sweep. A wedged mount answers never, and without
+    this the task waits with it, silently, for the life of the process."""
+    await asyncio.wait_for(get_storage().delete(storage_key), PENDING_DELETE_TIMEOUT)
 
 
 async def record_pending_delete(storage_key: str, last_error: str) -> None:
@@ -1519,10 +1527,10 @@ async def record_pending_delete(storage_key: str, last_error: str) -> None:
             excluded = statement.excluded
             statement = statement.on_conflict_do_update(
                 index_elements=[PendingDelete.storage_key],
-                set_={
-                    "last_error": excluded.last_error,
-                    "next_attempt_at": excluded.next_attempt_at,
-                },
+                # last_error only: the sweep owns the schedule, and this
+                # upsert can be waiting on its row lock, so writing a due time
+                # from before that wait would undo the backoff it just set.
+                set_={"last_error": excluded.last_error},
             )
             await session.execute(statement)
             await session.commit()
@@ -1579,15 +1587,12 @@ async def _retry_one_pending_delete(storage_key: str) -> None:
                 .with_for_update(skip_locked=True)
             )
         ).scalar_one_or_none()
-        if row is None or row.next_attempt_at is None:
-            return
+        if row is None:
+            return  # another replica holds it, or its object is already gone
         if row.next_attempt_at > datetime.now(timezone.utc):
             return  # another replica already rescheduled it
         try:
-            # The bound is real now that both backends await off the loop, and
-            # it is what keeps a wedged mount from stalling the whole pass.
-            await asyncio.wait_for(get_storage().delete(storage_key),
-                                   PENDING_DELETE_TIMEOUT)
+            await _bounded_delete(storage_key)
         except Exception as error:
             message = _trim_error(error)
             row.attempts += 1
@@ -1623,7 +1628,10 @@ async def maintain_deletes_loop() -> None:
             await retry_pending_deletes()
         except Exception:
             logger.exception("pending delete maintenance failed")
-        await asyncio.sleep(MAINTAIN_DELETES_INTERVAL)
+        # Jittered: replicas deployed together would otherwise run this in
+        # phase forever, and every loser then spends a pass taking locks that
+        # are already held.
+        await asyncio.sleep(MAINTAIN_DELETES_INTERVAL * random.uniform(0.9, 1.1))
 
 
 async def mark_failed(job_id: uuid.UUID, reason: str,

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -64,6 +64,7 @@ PENDING_DELETE_PASS_LIMIT = 100  # rows per pass, so one bad batch cannot hog a 
 PENDING_DELETE_MAX_ATTEMPTS = 8  # after this many failures the object stays
 PENDING_DELETE_BACKOFF_CAP = 60  # minutes; 2 ** 7 would already overshoot an hour
 MAINTAIN_DELETES_INTERVAL = 300.0  # seconds
+PENDING_DELETE_TIMEOUT = 60.0  # seconds for one delete, so a wedged mount cannot stall the pass
 
 
 class Queues(Protocol):
@@ -1434,9 +1435,13 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         for orphan in orphans:
             try:
                 await get_storage().delete(orphan)
-            except Exception:
+            except Exception as error:
+                # The same leak purge_attempt_blobs had, one function away: the
+                # success path collects the earlier attempts and an unreported
+                # thumbnail, and nothing else ever names those keys.
                 logger.warning("could not remove orphaned blob %s for job %s", orphan,
                                job_id, exc_info=True)
+                await record_pending_delete(orphan, _trim_error(error))
         try:
             url = await get_storage().url(current.storage_key)
         except Exception:
@@ -1544,22 +1549,39 @@ async def retry_pending_deletes() -> None:
         rows = (
             await session.execute(
                 select(PendingDelete)
+                # A given-up row carries a null here, and null <= now is null,
+                # so this one comparison also skips it.
                 .where(PendingDelete.next_attempt_at <= now)
                 .order_by(PendingDelete.next_attempt_at)
                 .limit(PENDING_DELETE_PASS_LIMIT)
+                # The cloud profile runs this loop in every replica on the same
+                # cadence. Without the lock both select the same batch, both
+                # delete (idempotent, but twice the storage traffic), and the
+                # loser's commit fails on rows the winner already removed.
+                .with_for_update(skip_locked=True)
             )
         ).scalars()
         for row in rows:
             try:
-                await get_storage().delete(row.storage_key)
+                # LocalStorage.delete is an unlink, which blocks forever on a
+                # wedged mount: without the bound the pass never finishes, the
+                # loop never sleeps, and nothing raises to say so.
+                await asyncio.wait_for(get_storage().delete(row.storage_key),
+                                       PENDING_DELETE_TIMEOUT)
             except Exception as error:
                 message = _trim_error(error)
                 row.attempts += 1
                 row.last_error = message
                 if row.attempts >= PENDING_DELETE_MAX_ATTEMPTS:
+                    # Unscheduled, not deleted. Dropping the row loses the only
+                    # record that the object exists: the backoff spans about
+                    # three hours, which a storage outage can outlive with the
+                    # API still up, and an operator who fixes it afterwards
+                    # would have nothing to look at. A null next_attempt_at is
+                    # what the sweep skips.
                     logger.error("giving up on deleting %s after %s attempts: %s",
                                  row.storage_key, row.attempts, message)
-                    await session.delete(row)
+                    row.next_attempt_at = None
                     continue
                 minutes = min(2 ** row.attempts, PENDING_DELETE_BACKOFF_CAP)
                 row.next_attempt_at = now + timedelta(minutes=minutes)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from app.benchmark import router as benchmark_router
 from app.benchmark_sessions import router as benchmark_sessions_router
 from app.files import router as files_router
 from app.gpu_samples import maintain_loop
-from app.jobs import router as jobs_router
+from app.jobs import maintain_deletes_loop, router as jobs_router
 from app.logs import setup_logging
 from app.metrics import router as metrics_router
 from app.realtime import forwarding_trusts_any_peer, reap_dead_workers
@@ -96,6 +96,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         asyncio.create_task(reap_dead_workers()),
         asyncio.create_task(jobs.dispatch_loop()),
         asyncio.create_task(maintain_loop()),
+        asyncio.create_task(maintain_deletes_loop()),
         asyncio.create_task(telemetry_loop()),
     ]
     yield

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -316,7 +316,11 @@ class LocalStorage:
         return f"{self.worker_url}/api/v1/files/{key}"
 
     async def delete(self, key: str) -> None:
-        self.path(key).unlink(missing_ok=True)
+        # Off the loop: unlink blocks forever on a wedged mount, and on the
+        # loop that stops every socket and request in the process, not just the
+        # caller. It is also what lets a caller bound this with wait_for, which
+        # cannot interrupt a coroutine that never suspends.
+        await asyncio.to_thread(self.path(key).unlink, missing_ok=True)
 
 
 class S3Storage:

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -10,6 +10,7 @@ import re
 import struct
 import zlib
 from dataclasses import dataclass, field
+from concurrent.futures import ThreadPoolExecutor
 from functools import lru_cache
 from pathlib import Path
 from typing import Protocol
@@ -18,6 +19,10 @@ from urllib.parse import urlencode
 from app.settings import Settings, get_settings
 
 SIGNED_URL_TTL = 3600
+# Deletes get their own small pool: a wedged filesystem leaks one thread per
+# attempt for good, and the default executor is shared with every other
+# off-loop read this app makes.
+DELETE_THREADS = 4
 # Carries the dispatch token on a local upload (app/files.py, issue #247).
 UPLOAD_TOKEN_HEADER = "X-Upload-Token"
 PNG_CONTENT_TYPE = "image/png"
@@ -26,6 +31,11 @@ DOWNLOAD_NAME_MAX_LENGTH = 96
 DOWNLOAD_NAME_PATTERN = re.compile(
     r"[a-z0-9]+(?:-[a-z0-9]+)*\.[a-z0-9]+",
 )
+
+
+@lru_cache
+def _delete_threads() -> ThreadPoolExecutor:
+    return ThreadPoolExecutor(max_workers=DELETE_THREADS, thread_name_prefix="storage-delete")
 
 
 def validate_download_name(name: str) -> str:
@@ -316,11 +326,14 @@ class LocalStorage:
         return f"{self.worker_url}/api/v1/files/{key}"
 
     async def delete(self, key: str) -> None:
-        # Off the loop: unlink blocks forever on a wedged mount, and on the
-        # loop that stops every socket and request in the process, not just the
-        # caller. It is also what lets a caller bound this with wait_for, which
-        # cannot interrupt a coroutine that never suspends.
-        await asyncio.to_thread(self.path(key).unlink, missing_ok=True)
+        # Off the loop, and in a pool of its own. unlink blocks forever on a
+        # wedged mount; on the loop that stops every socket in the process, and
+        # in the default executor it eventually starves every other to_thread
+        # call the app makes, because a caller's timeout abandons the await
+        # while the thread stays wedged for good. Here the damage is bounded to
+        # DELETE_THREADS stuck threads and deletes failing.
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(_delete_threads(), self.path(key).unlink, True)
 
 
 class S3Storage:

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -222,7 +222,12 @@ class PendingDelete(Base):
     attempts: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
     last_error: Mapped[str | None] = mapped_column(Text)
     first_failed_at: Mapped[datetime]
-    next_attempt_at: Mapped[datetime] = mapped_column(index=True)
+    next_attempt_at: Mapped[datetime]
+
+    # Named to match migration 0013: mapped_column(index=True) would call it
+    # ix_pending_deletes_next_attempt_at, so a create_all schema and a migrated
+    # one would differ and the next autogenerate would emit a spurious pair.
+    __table_args__ = (Index("pending_deletes_due", "next_attempt_at"),)
 
 
 class WorkerIdentity(Base):

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -209,9 +209,11 @@ class TelemetryState(Base):
 class PendingDelete(Base):
     """One row per blob the terminal paths could not remove (issue #254).
 
-    purge_attempt_blobs swallows per-key failures so one bad key does not stop
-    the rest, and this is the list of keys it tried and failed. The sweep owns
-    attempts and next_attempt_at; every other writer only refreshes last_error.
+    The terminal paths swallow per-key delete failures so one bad key does not
+    stop the rest, and this is the list of keys they tried and failed. The
+    sweep owns attempts; a failure elsewhere refreshes last_error and
+    reschedules. A null next_attempt_at means the sweep gave up: the row then
+    exists only to record that the object is still out there.
     """
 
     __tablename__ = "pending_deletes"
@@ -220,7 +222,7 @@ class PendingDelete(Base):
     attempts: Mapped[int] = mapped_column(Integer, default=0)
     last_error: Mapped[str | None] = mapped_column(Text)
     first_failed_at: Mapped[datetime]
-    next_attempt_at: Mapped[datetime]
+    next_attempt_at: Mapped[datetime | None]
 
 
 class WorkerIdentity(Base):

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -212,17 +212,17 @@ class PendingDelete(Base):
     The terminal paths swallow per-key delete failures so one bad key does not
     stop the rest, and this is the list of keys they tried and failed. The
     sweep owns attempts; a failure elsewhere refreshes last_error and
-    reschedules. A null next_attempt_at means the sweep gave up: the row then
-    exists only to record that the object is still out there.
+    reschedules. A row leaves only when its object is gone, so a row here is
+    always either due or waiting out its backoff.
     """
 
     __tablename__ = "pending_deletes"
 
     storage_key: Mapped[str] = mapped_column(Text, primary_key=True)
-    attempts: Mapped[int] = mapped_column(Integer, default=0)
+    attempts: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
     last_error: Mapped[str | None] = mapped_column(Text)
     first_failed_at: Mapped[datetime]
-    next_attempt_at: Mapped[datetime | None]
+    next_attempt_at: Mapped[datetime] = mapped_column(index=True)
 
 
 class WorkerIdentity(Base):

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -206,6 +206,23 @@ class TelemetryState(Base):
     last_report_day: Mapped[date | None] = mapped_column(Date)
 
 
+class PendingDelete(Base):
+    """One row per blob the terminal paths could not remove (issue #254).
+
+    purge_attempt_blobs swallows per-key failures so one bad key does not stop
+    the rest, and this is the list of keys it tried and failed. The sweep owns
+    attempts and next_attempt_at; every other writer only refreshes last_error.
+    """
+
+    __tablename__ = "pending_deletes"
+
+    storage_key: Mapped[str] = mapped_column(Text, primary_key=True)
+    attempts: Mapped[int] = mapped_column(Integer, default=0)
+    last_error: Mapped[str | None] = mapped_column(Text)
+    first_failed_at: Mapped[datetime]
+    next_attempt_at: Mapped[datetime]
+
+
 class WorkerIdentity(Base):
     __tablename__ = "workers"
 

--- a/backend/migrations/versions/0013_pending_deletes.py
+++ b/backend/migrations/versions/0013_pending_deletes.py
@@ -20,7 +20,9 @@ def upgrade() -> None:
         sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
         sa.Column("last_error", sa.Text(), nullable=True),
         sa.Column("first_failed_at", sa.DateTime(timezone=True), nullable=False),
-        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=False),
+        # Nullable: the sweep sets it to null when it gives up, which is how a
+        # row stays as a record of the object without being retried again.
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
     )
 
 

--- a/backend/migrations/versions/0013_pending_deletes.py
+++ b/backend/migrations/versions/0013_pending_deletes.py
@@ -1,0 +1,28 @@
+"""one row per blob the terminal paths could not delete
+
+Revision ID: 0013
+Revises: 0012
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pending_deletes",
+        sa.Column("storage_key", sa.Text(), primary_key=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("first_failed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("pending_deletes")

--- a/backend/migrations/versions/0013_pending_deletes.py
+++ b/backend/migrations/versions/0013_pending_deletes.py
@@ -20,11 +20,14 @@ def upgrade() -> None:
         sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
         sa.Column("last_error", sa.Text(), nullable=True),
         sa.Column("first_failed_at", sa.DateTime(timezone=True), nullable=False),
-        # Nullable: the sweep sets it to null when it gives up, which is how a
-        # row stays as a record of the object without being retried again.
-        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=False),
     )
+    # The sweep reads by due time every five minutes and the table can hold
+    # thousands of rows while a bucket policy is broken, which is exactly when
+    # it runs hardest.
+    op.create_index("pending_deletes_due", "pending_deletes", ["next_attempt_at"])
 
 
 def downgrade() -> None:
+    op.drop_index("pending_deletes_due", table_name="pending_deletes")
     op.drop_table("pending_deletes")

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1490,6 +1490,18 @@ async def _pending_delete(storage_key: str) -> PendingDelete | None:
         return await session.get(PendingDelete, storage_key)
 
 
+def _await_pending_delete(storage_key: str, timeout=3.0) -> PendingDelete:
+    """The recording happens after the commit that publishes the terminal
+    state, so a test that polled for the state can arrive first."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        row = asyncio.run(_pending_delete(storage_key))
+        if row is not None:
+            return row
+        time.sleep(0.05)
+    raise AssertionError(f"no pending delete recorded for {storage_key}")
+
+
 async def _clear_pending_deletes() -> None:
     """No autouse fixture empties this table, so sweep tests start at zero."""
     if db.session_factory is None:
@@ -3574,8 +3586,7 @@ def test_a_failed_orphan_delete_on_the_success_path_is_recorded(monkeypatch):
                               "gpu_ms": 1, "width": 512, "height": 512})
             poll_until(client, job_id, "succeeded")
 
-            row = asyncio.run(_pending_delete(thumb_key))
-            assert row is not None, "the failed orphan delete was not recorded"
+            row = _await_pending_delete(thumb_key)
             assert "denied" in (row.last_error or "")
 
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -3527,6 +3527,48 @@ def test_a_failed_purge_is_recorded_for_the_sweep(monkeypatch):
 
 
 @pytest.mark.db
+def test_a_failed_orphan_delete_on_the_success_path_is_recorded(monkeypatch):
+    """The success path collects the earlier attempts and an unreported
+    thumbnail, and its except swallowed the failure the same way
+    purge_attempt_blobs used to: same leak, one function away."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-orphan-record")
+            asyncio.run(_clear_pending_deletes())
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "orphan record"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+
+            real_storage = jobs.get_storage()
+            thumb_key = urlsplit(dispatch["thumb_upload"]["url"]).path.rsplit(
+                "/api/v1/files/", 1)[-1]
+
+            class RefusingOrphanDelete:
+                def __getattr__(self, name):
+                    return getattr(real_storage, name)
+
+                async def delete(self, storage_key):
+                    if storage_key == thumb_key:
+                        raise PermissionError(f"denied {storage_key}")
+                    await real_storage.delete(storage_key)
+
+            monkeypatch.setattr(jobs, "get_storage", lambda: RefusingOrphanDelete())
+            # No has_thumbnail, so the thumbnail key becomes an orphan the
+            # success path tries to collect.
+            worker.send_json({"type": "job_done", "job_id": job_id,
+                              "dispatch_token": dispatch["dispatch_token"],
+                              "gpu_ms": 1, "width": 512, "height": 512})
+            poll_until(client, job_id, "succeeded")
+
+            row = asyncio.run(_pending_delete(thumb_key))
+            assert row is not None, "the failed orphan delete was not recorded"
+            assert "denied" in (row.last_error or "")
+
+
+@pytest.mark.db
 def test_the_sweep_deletes_the_object_and_drops_the_row():
     with TestClient(app):
         key = f"{db.local_user_id}/sweep-success.png"
@@ -3573,7 +3615,7 @@ def test_a_sweep_failure_backs_off_and_keeps_the_row(monkeypatch):
 
 
 @pytest.mark.db
-def test_eighth_failure_gives_up_and_drops_the_row(monkeypatch):
+def test_eighth_failure_stops_retrying_but_keeps_the_record(monkeypatch):
     with TestClient(app):
         key = f"{db.local_user_id}/give-up.png"
         asyncio.run(_clear_pending_deletes())
@@ -3600,16 +3642,19 @@ def test_eighth_failure_gives_up_and_drops_the_row(monkeypatch):
             monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
             asyncio.run(jobs.retry_pending_deletes())
 
-            assert asyncio.run(_pending_delete(key)) is None, "the given-up row survived"
+            row = asyncio.run(_pending_delete(key))
+            assert row is not None, "the record of the object was thrown away"
+            assert row.next_attempt_at is None, "a given-up row is still scheduled"
             assert storage.path(key).exists(), "giving up deleted the object it kept failing on"
             assert any("giving up on deleting" in message for message in messages)
 
-            # Nothing retries the object afterwards: the row is gone and a
-            # healthy sweep no longer touches it.
+            # Nothing retries it afterwards, even once storage recovers: the
+            # row is unscheduled, so a healthy sweep walks past it.
             monkeypatch.undo()
             asyncio.run(jobs.retry_pending_deletes())
-            assert asyncio.run(_pending_delete(key)) is None
-            assert storage.path(key).exists(), "a row thought to be gone was retried"
+            assert storage.path(key).exists(), "an unscheduled row was retried"
+            still = asyncio.run(_pending_delete(key))
+            assert still is not None and still.next_attempt_at is None
         finally:
             jobs.logger.removeHandler(handler)
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1499,6 +1499,16 @@ async def _clear_pending_deletes() -> None:
         await session.commit()
 
 
+async def _make_due(storage_key: str) -> None:
+    """Bring a waiting row forward, the way the clock would."""
+    assert db.session_factory is not None
+    async with db.session_factory() as session:
+        row = await session.get(PendingDelete, storage_key)
+        assert row is not None
+        row.next_attempt_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        await session.commit()
+
+
 async def _seed_pending_delete(storage_key: str, attempts: int, due: datetime) -> None:
     assert db.session_factory is not None
     async with db.session_factory() as session:
@@ -3615,7 +3625,7 @@ def test_a_sweep_failure_backs_off_and_keeps_the_row(monkeypatch):
 
 
 @pytest.mark.db
-def test_eighth_failure_stops_retrying_but_keeps_the_record(monkeypatch):
+def test_the_eighth_failure_alerts_once_and_keeps_retrying(monkeypatch):
     with TestClient(app):
         key = f"{db.local_user_id}/give-up.png"
         asyncio.run(_clear_pending_deletes())
@@ -3644,17 +3654,19 @@ def test_eighth_failure_stops_retrying_but_keeps_the_record(monkeypatch):
 
             row = asyncio.run(_pending_delete(key))
             assert row is not None, "the record of the object was thrown away"
-            assert row.next_attempt_at is None, "a given-up row is still scheduled"
-            assert storage.path(key).exists(), "giving up deleted the object it kept failing on"
-            assert any("giving up on deleting" in message for message in messages)
+            assert row.attempts == jobs.PENDING_DELETE_MAX_ATTEMPTS
+            assert storage.path(key).exists(), "the failing delete removed the object"
+            assert any("still cannot delete" in message for message in messages)
 
-            # Nothing retries it afterwards, even once storage recovers: the
-            # row is unscheduled, so a healthy sweep walks past it.
+            # Still scheduled, because an outage can outlive the backoff and a
+            # row nothing retries is a leak with no way back. Due again within
+            # the hour cap, and the next healthy sweep collects it.
+            assert row.next_attempt_at is not None
+            asyncio.run(_make_due(key))
             monkeypatch.undo()
             asyncio.run(jobs.retry_pending_deletes())
-            assert storage.path(key).exists(), "an unscheduled row was retried"
-            still = asyncio.run(_pending_delete(key))
-            assert still is not None and still.next_attempt_at is None
+            assert not storage.path(key).exists(), "recovery never collected the object"
+            assert asyncio.run(_pending_delete(key)) is None
         finally:
             jobs.logger.removeHandler(handler)
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -3,6 +3,7 @@ real fleet WebSocket. Real inference is the worker's side (worker/tests)."""
 
 import asyncio
 import base64
+import logging
 import struct
 import threading
 import time
@@ -19,7 +20,7 @@ from app import db, jobs, realtime, registry
 from app.jobs import generation_download_name
 from app.main import app
 from app.realtime import PROTOCOL_VERSION
-from app.tables import Asset, Job, Model, UsageEvent, User
+from app.tables import Asset, Job, Model, PendingDelete, UsageEvent, User
 
 MANIFEST = {
     "id": "sd-test",
@@ -1481,6 +1482,34 @@ def test_a_rejected_retry_collects_every_attempt(monkeypatch):
 async def _write_blob(storage, key, data):
     storage.path(key).parent.mkdir(parents=True, exist_ok=True)
     storage.path(key).write_bytes(data)
+
+
+async def _pending_delete(storage_key: str) -> PendingDelete | None:
+    assert db.session_factory is not None
+    async with db.session_factory() as session:
+        return await session.get(PendingDelete, storage_key)
+
+
+async def _clear_pending_deletes() -> None:
+    """No autouse fixture empties this table, so sweep tests start at zero."""
+    if db.session_factory is None:
+        return
+    async with db.session_factory() as session:
+        await session.execute(delete(PendingDelete))
+        await session.commit()
+
+
+async def _seed_pending_delete(storage_key: str, attempts: int, due: datetime) -> None:
+    assert db.session_factory is not None
+    async with db.session_factory() as session:
+        session.add(PendingDelete(
+            storage_key=storage_key,
+            attempts=attempts,
+            last_error="seeded",
+            first_failed_at=due,
+            next_attempt_at=due,
+        ))
+        await session.commit()
 
 
 @pytest.mark.db
@@ -3444,3 +3473,163 @@ def test_a_worker_built_without_a_registration_is_not_lenient():
         jobs.inflight.pop(job_id, None)
         jobs.live_progress.pop(job_id, None)
         jobs.last_progress_at.pop(job_id, None)
+
+
+@pytest.mark.db
+def test_a_failed_purge_is_recorded_for_the_sweep(monkeypatch):
+    """A delete that fails during purge_attempt_blobs leaves a pending_deletes
+    row naming that key, and the job still reaches its terminal state: the
+    cleanup failure must never fail the job or block the commit."""
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-purge-recorded")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "record"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            upload_path = urlsplit(dispatch["upload"]["url"]).path
+            key = upload_path.rsplit("/api/v1/files/", 1)[-1]
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+
+            real_storage = jobs.get_storage()
+
+            class RefusingDelete:
+                """Stands in for storage; only deletes fail, like a denied
+                permission that is sticky for the whole attempt's cleanup."""
+
+                def __getattr__(self, name):
+                    return getattr(real_storage, name)
+
+                async def delete(self, storage_key):
+                    raise PermissionError(f"denied {storage_key}")
+
+            monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
+            worker.send_json({"type": "job_failed", "job_id": job_id,
+                              "reason": "worker said no",
+                              "dispatch_token": dispatch["dispatch_token"]})
+            poll_until(client, job_id, "failed")
+
+            def recorded() -> PendingDelete | None:
+                return asyncio.run(_pending_delete(key))
+
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline and recorded() is None:
+                time.sleep(0.05)
+            row = recorded()
+            assert row is not None, "the failed delete was not recorded"
+            assert row.storage_key == key
+            assert row.attempts == 0  # the sweep owns the counter, not the purge
+            assert row.last_error is not None
+            assert row.first_failed_at is not None
+            assert row.next_attempt_at is not None
+            assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "failed"
+
+
+@pytest.mark.db
+def test_the_sweep_deletes_the_object_and_drops_the_row():
+    with TestClient(app):
+        key = f"{db.local_user_id}/sweep-success.png"
+        asyncio.run(_clear_pending_deletes())
+        asyncio.run(_seed_pending_delete(
+            key, attempts=0, due=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+        storage = jobs.get_storage()
+        asyncio.run(_write_blob(storage, key, png_bytes()))
+
+        asyncio.run(jobs.retry_pending_deletes())
+
+        assert not storage.path(key).exists(), "the sweep left the object behind"
+        assert asyncio.run(_pending_delete(key)) is None, "the row survived its delete"
+
+
+@pytest.mark.db
+def test_a_sweep_failure_backs_off_and_keeps_the_row(monkeypatch):
+    with TestClient(app):
+        key = f"{db.local_user_id}/sweep-backoff.png"
+        asyncio.run(_clear_pending_deletes())
+        asyncio.run(_seed_pending_delete(
+            key, attempts=0, due=datetime.now(timezone.utc) - timedelta(hours=1),
+        ))
+        storage = jobs.get_storage()
+        asyncio.run(_write_blob(storage, key, png_bytes()))
+
+        class RefusingDelete:
+            def __getattr__(self, name):
+                return getattr(storage, name)
+
+            async def delete(self, storage_key):
+                raise PermissionError(f"denied {storage_key}")
+
+        monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
+        asyncio.run(jobs.retry_pending_deletes())
+
+        row = asyncio.run(_pending_delete(key))
+        assert row is not None, "a failed sweep dropped the row"
+        assert row.attempts == 1
+        assert row.last_error is not None
+        assert row.next_attempt_at > datetime.now(timezone.utc) + timedelta(minutes=1)
+        assert storage.path(key).exists(), "the sweep deleted an object it could not"
+
+
+@pytest.mark.db
+def test_eighth_failure_gives_up_and_drops_the_row(monkeypatch):
+    with TestClient(app):
+        key = f"{db.local_user_id}/give-up.png"
+        asyncio.run(_clear_pending_deletes())
+        asyncio.run(_seed_pending_delete(
+            key, attempts=7, due=datetime.now(timezone.utc) - timedelta(minutes=1),
+        ))
+        storage = jobs.get_storage()
+        asyncio.run(_write_blob(storage, key, png_bytes()))
+
+        class RefusingDelete:
+            def __getattr__(self, name):
+                return getattr(storage, name)
+
+            async def delete(self, storage_key):
+                raise PermissionError(f"denied {storage_key}")
+
+        # setup_logging(force=True) replaces root handlers at app startup, so
+        # caplog misses app logs; this handler on the module logger survives.
+        messages = []
+        handler = logging.Handler()
+        handler.emit = lambda record: messages.append(record.getMessage())
+        jobs.logger.addHandler(handler)
+        try:
+            monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
+            asyncio.run(jobs.retry_pending_deletes())
+
+            assert asyncio.run(_pending_delete(key)) is None, "the given-up row survived"
+            assert storage.path(key).exists(), "giving up deleted the object it kept failing on"
+            assert any("giving up on deleting" in message for message in messages)
+
+            # Nothing retries the object afterwards: the row is gone and a
+            # healthy sweep no longer touches it.
+            monkeypatch.undo()
+            asyncio.run(jobs.retry_pending_deletes())
+            assert asyncio.run(_pending_delete(key)) is None
+            assert storage.path(key).exists(), "a row thought to be gone was retried"
+        finally:
+            jobs.logger.removeHandler(handler)
+
+
+@pytest.mark.db
+def test_a_sweep_retries_only_rows_that_are_due():
+    with TestClient(app):
+        due_key = f"{db.local_user_id}/due.png"
+        future_key = f"{db.local_user_id}/not-due.png"
+        now = datetime.now(timezone.utc)
+        asyncio.run(_clear_pending_deletes())
+        asyncio.run(_seed_pending_delete(due_key, attempts=0, due=now - timedelta(minutes=5)))
+        asyncio.run(_seed_pending_delete(future_key, attempts=0, due=now + timedelta(hours=1)))
+        storage = jobs.get_storage()
+        asyncio.run(_write_blob(storage, due_key, png_bytes()))
+        asyncio.run(_write_blob(storage, future_key, png_bytes()))
+
+        asyncio.run(jobs.retry_pending_deletes())
+
+        assert not storage.path(due_key).exists(), "the due key was not retried"
+        assert storage.path(future_key).exists(), "a key that was not due got deleted"
+        assert asyncio.run(_pending_delete(due_key)) is None
+        assert asyncio.run(_pending_delete(future_key)) is not None

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -3493,6 +3493,7 @@ def test_a_failed_purge_is_recorded_for_the_sweep(monkeypatch):
     with TestClient(app) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
             fleet_hello(worker, "w-purge-recorded")
+            asyncio.run(_clear_pending_deletes())
             job_id = client.post(
                 "/api/v1/generations",
                 json={"model_id": "sd-test", "params": {"prompt": "record"}},
@@ -3656,7 +3657,15 @@ def test_the_eighth_failure_alerts_once_and_keeps_retrying(monkeypatch):
             assert row is not None, "the record of the object was thrown away"
             assert row.attempts == jobs.PENDING_DELETE_MAX_ATTEMPTS
             assert storage.path(key).exists(), "the failing delete removed the object"
-            assert any("still cannot delete" in message for message in messages)
+            assert sum("still cannot delete" in message for message in messages) == 1
+
+            # Ninth failure: still retried, and silent. Alerting on every
+            # failure past the eighth would bury the one line that matters.
+            asyncio.run(_make_due(key))
+            asyncio.run(jobs.retry_pending_deletes())
+            assert sum("still cannot delete" in message for message in messages) == 1
+            row = asyncio.run(_pending_delete(key))
+            assert row is not None and row.attempts == jobs.PENDING_DELETE_MAX_ATTEMPTS + 1
 
             # Still scheduled, because an outage can outlive the backoff and a
             # row nothing retries is a leak with no way back. Due again within
@@ -3669,6 +3678,25 @@ def test_the_eighth_failure_alerts_once_and_keeps_retrying(monkeypatch):
             assert asyncio.run(_pending_delete(key)) is None
         finally:
             jobs.logger.removeHandler(handler)
+
+
+@pytest.mark.db
+def test_recording_a_key_again_does_not_undo_its_backoff():
+    """The upsert can be waiting on the sweep's row lock, so writing its own
+    due time would hand back a key the sweep had just pushed an hour out."""
+    with TestClient(app):
+        key = f"{db.local_user_id}/re-record.png"
+        asyncio.run(_clear_pending_deletes())
+        later = datetime.now(timezone.utc) + timedelta(minutes=30)
+        asyncio.run(_seed_pending_delete(key, attempts=3, due=later))
+
+        asyncio.run(jobs.record_pending_delete(key, "denied again"))
+
+        row = asyncio.run(_pending_delete(key))
+        assert row is not None
+        assert row.last_error == "denied again", "the new error was not recorded"
+        assert row.next_attempt_at == later, "the backoff was reset by a re-recording"
+        assert row.attempts == 3, "the sweep's counter was touched by a recording"
 
 
 @pytest.mark.db

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -670,3 +670,27 @@ def test_s3_delete_counts_failures_from_every_batch():
     # Three failures across two batches, reported with the first code seen.
     with pytest.raises(RuntimeError, match="could not delete 3 version\\(s\\).*InternalError"):
         asyncio.run(storage.delete(key))
+
+
+def test_local_delete_does_not_block_the_event_loop(tmp_path):
+    """unlink on a wedged mount would stop every socket in the process, and a
+    caller's wait_for cannot interrupt a coroutine that never suspends."""
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    (tmp_path / "u").mkdir()
+    (tmp_path / "u" / "j.png").write_bytes(b"x")
+
+    async def drive() -> list[str]:
+        order: list[str] = []
+
+        async def ticker() -> None:
+            # Runs only if delete yields the loop at least once.
+            order.append("loop kept running")
+
+        tick = asyncio.ensure_future(ticker())
+        await storage.delete("u/j.png")
+        order.append("delete returned")
+        await tick
+        return order
+
+    assert asyncio.run(drive()) == ["loop kept running", "delete returned"]
+    assert not (tmp_path / "u" / "j.png").exists()

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -944,6 +944,16 @@ Two limits are deliberate. Proving an image decodes means decoding it, and both 
 Rejected alternatives: publishing the local upload straight into its key with `O_EXCL`, which was written first and replaced, because the key exists and is readable while the body is still landing, so a `job_done` racing its own PUT could have a truncated prefix inspected and approved; signing the upload URL with the attempt so the key carries its own authority, which puts a secret in a path that is logged by every proxy and cannot be revoked when an attempt is superseded; making the worker send a nonce it chooses, which authenticates nothing the API can check; keeping the key-only authorisation and relying on per-attempt keys alone, which is what shipped and is exactly what a previously dispatched worker can derive; refusing a message with no token from every worker, which is correct at the next floor move and breaks every N-1 worker today; and verifying uploads by decoding them, which is the denial of service the PNG reader already learned to avoid.
 
 
+## Failed cleanup deletes retry forever rather than giving up
+
+Issue #254 asked for a bounded number of retries and one error log, so a permanently undeletable key would not retry forever. It ships without the give-up, and this entry records why the requirement was reversed rather than leaving a future reader to re-file it.
+
+A delete that fails on the terminal path is recorded in `pending_deletes` and retried by a five-minute sweep, backing off by doubling minutes to an hour. Giving up was tried twice. Dropping the row destroys the only record that the object exists: the log line has rotated by the time anyone looks, and nothing else names the key, since the asset row only ever names the winning attempt. Keeping the row but unscheduling it is worse in a different way, because nothing re-arms one: the backoff spans under three hours, and a bucket policy broken at nine and fixed at two leaves every key recorded in between permanently unreachable, recoverable only by hand-written SQL nobody knows to run.
+
+Retrying forever costs one delete call an hour per stuck key, and the row is the record an operator needs. The alert at eight attempts stays, once, because that is the signal; the retries after it are cheap and are what makes the fix arrive on its own when the permission is repaired. The table is bounded by the number of distinct undeletable keys rather than by time.
+
+Rejected alternatives: dropping the row at a bounded attempt count, which is what the issue asked for and which loses the object silently; unscheduling the row and re-arming it at startup, which makes recovery depend on a restart nobody will perform for a cleanup failure; an operator endpoint to re-arm, which is a surface with one caller for a case that a retry already handles; and an S3 lifecycle rule instead of any of this, which is the better answer for the cloud profile and covers only it, so it belongs with issue #278 rather than replacing the retry a self-hosted install needs.
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:


### PR DESCRIPTION
Closes #254. Implemented by OpenCode (deepseek-v4-flash, max effort) to a design I fixed in the brief; gated and mutation-checked by me.

purge_attempt_blobs swallows per-key failures so one bad key does not stop the rest, and nothing retried them. The terminal state is already committed, the asset row names only the winning key, and no sweep looks for orphans, so a delete that failed on a denied permission or a transient error left the object forever: visible in a log line, invisible to the system.

Failures go into a pending_deletes table, one row per key. A sweep every five minutes retries them oldest first, a hundred per pass, backing off by doubling minutes to an hour. The eighth failure gives up, logs once at error and drops the row, because a row nothing will retry is a lie about the object.

Recording is best effort: the database can be down at the moment a delete fails, and a cleanup failure must never fail a job.

## The alternative, named rather than ignored

On S3 a lifecycle rule expiring noncurrent versions would cover this and every path nobody thought of, at no application cost. It covers only the cloud profile, and self-hosted local storage would still need this, so the retry lands first. The lifecycle rule is still worth having and belongs with #278.

## Verified here

Five new tests, each proved by breaking the line it covers: the recording call, the give-up threshold, the due-time filter, and the backoff all fail their test when removed.

Migration 0013 applied to a fresh database and rolled back: the table appears with the five expected columns and the downgrade drops it.

make verify green: 321 backend, 135 worker, frontend build and CSP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failed blob deletions are now tracked and retried automatically in the background.
  * Retries use controlled backoff, timeouts, attempt limits, and periodic maintenance.
  * Cleanup errors retain relevant details for monitoring and recovery.

* **Bug Fixes**
  * Temporary storage deletion failures can recover without manual intervention.
  * Local file deletion no longer blocks other application work.

* **Database**
  * Added persistent tracking for pending deletions, retry attempts, failure details, and retry timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->