### PR TITLE
Make a realtime model resident before its session renders

### DIFF
--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -994,3 +994,34 @@ def test_an_api_that_sends_no_dispatch_token_gets_none_back():
     reports = [json.loads(m) for m in socket.sent]
     assert reports
     assert not any("dispatch_token" in r for r in reports)
+
+
+def test_session_runner_survives_a_residency_load_failure(caplog):
+    # A load that fails outside the rung ladder, missing weights or a bad
+    # import, must not take the session task with it. Dying here would leave
+    # the session open with no runner behind it and nothing logged after that
+    # point, which is quieter than the per-frame refusal it replaced. The task
+    # has to reach the frame loop so the frame guard still speaks.
+    socket = FakeSocket()
+    engine = RecordingEngine()
+
+    async def boom(_manifest):
+        raise RuntimeError("weights missing")
+
+    engine.ensure_realtime_resident = boom
+    manifest = _realtime_manifest("vega-rt", steps_default=4)
+    session_id = uuid.uuid4()
+
+    async def scenario():
+        runner = SessionRunner(session_id, socket, engine, manifest,
+                               ensure_seed(manifest.with_defaults({"prompt": "x"})))
+        runner.submit(b"first")
+        await asyncio.sleep(0.03)
+        runner.close()
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(scenario())
+
+    # Reached the frame loop rather than dying at the residency call.
+    assert len(socket.sent) == 1
+    assert "could not make model vega-rt resident" in caplog.text

--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -579,6 +579,58 @@ def test_session_runner_observes_each_rendered_frame_for_its_model():
     assert len(socket.sent) == 2
 
 
+def test_session_runner_logs_a_non_resident_model_once_and_keeps_rendering(caplog):
+    # The residency decision happens once, before the frame loop, and a False
+    # answer is logged once: the frames that follow would log an exception on
+    # every draw, and the per-frame noise buried the cause. The session stays
+    # up either way, so the frame fallback still renders here.
+    socket = FakeSocket()
+    engine = RecordingEngine()
+
+    async def not_resident(_manifest):
+        return False
+
+    engine.ensure_realtime_resident = not_resident
+    manifest = _realtime_manifest("vega-rt", steps_default=4)
+    session_id = uuid.uuid4()
+
+    async def scenario():
+        runner = SessionRunner(session_id, socket, engine, manifest,
+                               ensure_seed(manifest.with_defaults({"prompt": "x"})))
+        runner.submit(b"first")
+        await asyncio.sleep(0.03)
+        runner.submit(b"second")
+        await asyncio.sleep(0.03)
+        runner.close()
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(scenario())
+
+    assert len(socket.sent) == 2
+    assert f"session {session_id} cannot render" in caplog.text
+    assert "model vega-rt is not fully resident" in caplog.text
+    assert caplog.text.count("not fully resident") == 1
+
+
+def test_session_runner_renders_without_warning_when_resident(caplog):
+    socket = FakeSocket()
+    engine = RecordingEngine()
+    manifest = _realtime_manifest("vega-rt", steps_default=4)
+
+    async def scenario():
+        runner = SessionRunner(uuid.uuid4(), socket, engine, manifest,
+                               ensure_seed(manifest.with_defaults({"prompt": "x"})))
+        runner.submit(b"first")
+        await asyncio.sleep(0.03)
+        runner.close()
+
+    with caplog.at_level("WARNING"):
+        asyncio.run(scenario())
+
+    assert len(socket.sent) == 1
+    assert "not fully resident" not in caplog.text
+
+
 def test_heartbeat_advertises_only_frames_at_default_steps():
     # The advertised number claims the model's cost at its declared defaults,
     # so a session at other settings must not supersede it: frames rendered

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -1153,6 +1153,101 @@ def test_a_cached_rung_survives_while_another_pipeline_entry_is_resident():
     assert engine.model_rung("m") is None
 
 
+def test_ensure_realtime_resident_returns_true_without_evicting_when_full():
+    """The common path must stay cheap: a full-resident model is answered
+    from the cached rung and the load path, which is what evicts, runs."""
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine._rungs = {"vega-rt": "full"}
+    resident = object()
+    engine._pipelines = {("vega-rt", "t2i"): resident}
+    engine.load_model = MagicMock()
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "realtime"],
+        min_vram_gb=8,
+    )
+
+    result = asyncio.run(engine.ensure_realtime_resident(manifest))
+
+    assert result is True
+    engine.load_model.assert_not_called()
+    assert engine._pipelines[("vega-rt", "t2i")] is resident
+    assert engine.model_rung("vega-rt") == "full"
+
+
+def test_ensure_realtime_resident_reloads_full_when_the_rung_was_cached_offload():
+    """A queued job on another model can consume VRAM between sessions and
+    leave a stale "model_offload" cached answer behind (issue #270). Resident
+    means deciding against the VRAM that exists once that job is evicted,
+    which is the load path, not re-reading the stale cache."""
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    torch_stub = MagicMock()
+    torch_stub.OutOfMemoryError = type("OutOfMemoryError", (Exception,), {})
+    engine.torch = torch_stub
+    engine.device = "cuda"
+    engine.memory_mode = "auto"
+    engine.models_dir = ""
+    engine.torch_compile = False
+    engine.attention_backend = ""
+    engine._pipelines = {("other", "t2i"): object()}
+    engine._rungs = {"vega-rt": "model_offload", "other": "full"}
+    engine._last_used = {}
+    engine._free_gpu_cache = MagicMock()
+    engine._gpu = asyncio.Lock()
+    engine._from_pretrained = MagicMock(return_value=MagicMock())
+
+    def free_vram():
+        # Before the load path evicts the job, the card cannot hold full
+        # residency for the session's model; afterwards it can.
+        return 1 if ("other", "t2i") in engine._pipelines else 64 * 1024**3
+
+    engine._free_vram_bytes = MagicMock(side_effect=free_vram)
+
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "realtime"],
+        min_vram_gb=8,
+    )
+    diffusers = ModuleType("diffusers")
+    diffusers.AutoPipelineForText2Image = object()
+    diffusers.AutoPipelineForImage2Image = object()
+
+    async def scenario():
+        with patch.dict(sys.modules, {"diffusers": diffusers}):
+            return await engine.ensure_realtime_resident(manifest)
+
+    assert asyncio.run(scenario()) is True
+    assert engine.model_rung("vega-rt") == "full"
+    assert ("other", "t2i") not in engine._pipelines
+    assert ("vega-rt", "t2i") in engine._pipelines
+
+
+def test_ensure_realtime_resident_leaves_a_pinned_mode_alone():
+    """A pinned memory mode is an operator choice; the load path, which
+    evicts everyone, is not entered for it. The session gets the per-frame
+    fallback instead and nothing resident is dropped."""
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.memory_mode = "model_offload"
+    engine._rungs = {"vega-rt": "model_offload"}
+    resident = object()
+    engine._pipelines = {("vega-rt", "t2i"): resident}
+    engine.load_model = MagicMock()
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "realtime"],
+        min_vram_gb=8,
+    )
+
+    result = asyncio.run(engine.ensure_realtime_resident(manifest))
+
+    assert result is False
+    engine.load_model.assert_not_called()
+    assert engine._pipelines[("vega-rt", "t2i")] is resident
+
+
 def _load_oom_engine(failing_rungs: set[str]) -> tuple[DiffusersEngine, list[str]]:
     torch_stub = MagicMock()
     torch_stub.OutOfMemoryError = type("OutOfMemoryError", (Exception,), {})

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -233,7 +233,24 @@ class SessionRunner:
         # socket until the load finished. A False answer is logged once, not
         # per frame: what follows would raise and log on every frame for the
         # non-resident model, and the per-frame noise buried the cause.
-        if not await engine.ensure_realtime_resident(manifest):
+        try:
+            resident = await engine.ensure_realtime_resident(manifest)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # A load that fails for a reason the rung ladder does not cover,
+            # missing weights or a bad import, must not take this task with
+            # it. Dying here would leave the session open with no runner
+            # behind it and nothing logged after this line, which is quieter
+            # than the per-frame refusal it replaced. Fall through instead:
+            # frame still refuses a non-resident model, and the operator sees
+            # the load failure here.
+            logger.exception(
+                "session %s could not make model %s resident",
+                self.session_id, manifest.id,
+            )
+            resident = False
+        if not resident:
             logger.warning(
                 "session %s cannot render: model %s is not fully resident",
                 self.session_id, manifest.id,

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -226,6 +226,18 @@ class SessionRunner:
         self.arrived.set()
 
     async def _run(self, ws, engine: Engine, manifest: Manifest) -> None:
+        # Residency is decided once, before any frame waits on a stale rung
+        # answer. This cannot live in the open_session handler in the control
+        # loop: that loop also reads every heartbeat and every frame from
+        # every session, and awaiting a model load there would stall the
+        # socket until the load finished. A False answer is logged once, not
+        # per frame: what follows would raise and log on every frame for the
+        # non-resident model, and the per-frame noise buried the cause.
+        if not await engine.ensure_realtime_resident(manifest):
+            logger.warning(
+                "session %s cannot render: model %s is not fully resident",
+                self.session_id, manifest.id,
+            )
         steps_default = default_steps(manifest)
         while True:
             await self.arrived.wait()

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -101,6 +101,8 @@ class Engine(Protocol):
 
     async def load_model(self, manifest: Manifest) -> int: ...
 
+    async def ensure_realtime_resident(self, manifest: Manifest) -> bool: ...
+
     async def unload_model(self, model_id: str) -> None: ...
 
     async def unload_all(self) -> None: ...
@@ -209,6 +211,10 @@ class SimulatedEngine:
         await asyncio.sleep(self.inference_seconds / 4)
         self._loaded = {manifest.id}
         return int((time.monotonic() - start) * 1000)
+
+    async def ensure_realtime_resident(self, manifest: Manifest) -> bool:
+        # The simulated engine renders without residency; nothing to make resident.
+        return True
 
     async def unload_model(self, model_id: str) -> None:
         self._loaded.discard(model_id)
@@ -939,6 +945,32 @@ class DiffusersEngine:
             mode = "t2i"
         self._pipeline(manifest, mode)
         return int((time.monotonic() - start) * 1000)
+
+    async def ensure_realtime_resident(self, manifest: Manifest) -> bool:
+        """Make the model fully resident if realtime needs it, and say whether
+        it is.
+
+        A realtime frame runs against a 500 ms bar, so a model on an offload
+        rung cannot serve one: frame refuses it, and a session would log that
+        refusal on every frame it never renders. The rung answer is cached
+        per model, and only the load path ever decides it again, because the
+        eviction that frees the VRAM lives there and frame never reaches it
+        once the cached answer says offload (issue #270). The way to turn a
+        stale offload into full is to evict everyone and choose again against
+        the freed VRAM, which is exactly what load_model already does under
+        the GPU lock, so that is the path reused here rather than a second
+        eviction implementation. A pinned memory mode is an operator choice
+        and is left alone: pins are never demoted, and nothing here second-
+        guesses a pin that placed the model off-GPU; such a session gets the
+        per-frame fallback instead of an eviction the operator did not ask
+        for.
+        """
+        if self._pick_rung(manifest) == "full":
+            return True
+        if self.memory_mode != "auto":
+            return False
+        await self.load_model(manifest)
+        return self._pick_rung(manifest) == "full"
 
     async def unload_model(self, model_id: str) -> None:
         async with self._gpu:


### PR DESCRIPTION
# Description

Addresses the residency half of #270. A canvas session on a model that was not fully resident
rendered nothing at all, silently, for the life of the worker process.

Does not close #270: the refusal half is still open, see below.

# Details

`frame` refuses a model on an offload rung. The rung is cached per model by `_pick_rung`, and the
eviction that would free the VRAM lives on the load path, which `frame` never reaches once the
cached answer says offload. A queued job on another model was therefore enough to poison a
realtime session: it opened, every frame raised, the runner logged and continued, and the browser
held an Active session with its sent-frame count climbing and nothing coming back.

`ensure_realtime_resident` decides residency once, when the session's task starts.

- **It reuses `load_model`** rather than adding a second eviction. That path already evicts,
  re-selects the rung against the freed VRAM, and loads, all under the GPU lock.
- **It runs in the runner's own task, not the `open_session` handler.** The control loop reads
  every heartbeat and every frame for every session, so awaiting a model load there would stall
  the fleet socket until the load finished, which the API reads as a dead worker.
- **A pinned memory mode is left alone.** A pin is an operator's explicit choice, consistent with
  the existing rule that pins are never demoted. Such a session still gets the per-frame refusal.
- **The `frame` guard stays** as the safety net for a model evicted mid-session, and a model that
  still cannot be made resident is logged once rather than on every frame, where the noise buried
  the cause.

The third part of the issue, invalidating a cached rung when conditions change, was already done:
`_forget_rung_if_unloaded` exists and is called by `_drop_pipeline`.

# Still open on #270

Refusing an unservable session so the browser can say why. There is no per-session refusal on the
wire: the only close code is `CLOSE_PROTOCOL_VIOLATION`, which closes the whole fleet socket, and
`session_closed` sent unasked is deliberately ignored by `realtime.py`, which only settles ids
already in `closing_sessions`. That is a protocol decision rather than a local fix, and it is
written up on the issue with two candidate shapes.

# Verification

`ruff`, `mypy` over 12 source files, and 140 worker tests pass, up from 137.

Three new tests, each mutation-checked by breaking its rule and confirming the suite fails:

| Reverted rule | Failing test |
|---|---|
| the already-full early return | `test_ensure_realtime_resident_returns_true_without_evicting_when_full` |
| the pinned-mode guard | `test_ensure_realtime_resident_leaves_a_pinned_mode_alone` |
| the runner's residency call | `test_session_runner_logs_a_non_resident_model_once_and_keeps_rendering` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved realtime rendering when models are not fully resident in memory.
  * The system now attempts to restore model residency before processing frames.
  * Rendering continues with a single warning if full residency cannot be restored.
  * Resident models avoid unnecessary reloads or memory changes.
* **Tests**
  * Added coverage for resident, offloaded, stale, and pinned-memory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->