### PR TITLE
Encode a realtime session's prompt once, not once per frame

### DIFF
--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -18,7 +18,7 @@ from worker.client import (
     serve_connection,
     warmup_realtime,
 )
-from worker.engine import GeneratedFrame, SimulatedEngine
+from worker.engine import GeneratedFrame, PromptCache, SimulatedEngine
 from worker.manifests import SIMULATED_MANIFEST, Manifest
 from worker.settings import Settings
 
@@ -542,7 +542,7 @@ class RecordingEngine(SimulatedEngine):
         super().__init__(0.01)
         self.observed = []
 
-    async def frame(self, manifest, params, payload):
+    async def frame(self, manifest, params, payload, *, prompt_cache=None):
         await asyncio.sleep(0.01)
         return GeneratedFrame(payload, 200)
 
@@ -577,6 +577,40 @@ def test_session_runner_observes_each_rendered_frame_for_its_model():
     asyncio.run(scenario())
     assert engine.observed == [("vega-rt", 200), ("vega-rt", 200)]
     assert len(socket.sent) == 2
+
+
+def test_session_runner_passes_the_same_prompt_cache_to_every_frame():
+    """The prompt embedding cache is owned by the session: the runner must
+    hand every frame the same holder, so concurrent sessions each encode
+    their own prompt once instead of evicting each other (issue #301)."""
+    socket = FakeSocket()
+    received: list = []
+
+    class CacheRecordingEngine(SimulatedEngine):
+        def __init__(self):
+            super().__init__(0.01)
+
+        async def frame(self, manifest, params, payload, *, prompt_cache=None):
+            received.append(prompt_cache)
+            await asyncio.sleep(0.01)
+            return GeneratedFrame(payload, 200)
+
+    engine = CacheRecordingEngine()
+    manifest = _realtime_manifest("vega-rt", steps_default=4)
+
+    async def scenario():
+        runner = SessionRunner(uuid.uuid4(), socket, engine, manifest,
+                               ensure_seed(manifest.with_defaults({"prompt": "x"})))
+        runner.submit(b"first")
+        await asyncio.sleep(0.03)
+        runner.submit(b"second")
+        await asyncio.sleep(0.03)
+        runner.close()
+
+    asyncio.run(scenario())
+    assert len(received) == 2
+    assert received[0] is received[1]
+    assert isinstance(received[0], PromptCache)
 
 
 def test_session_runner_logs_a_non_resident_model_once_and_keeps_rendering(caplog):

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -13,6 +13,7 @@ from worker.engine import (
     GeneratedFrame,
     OBSERVED_FRAME_SAMPLES,
     OBSERVED_FRAME_WINDOW,
+    PromptCache,
     REALTIME_SIZE,
     SimulatedEngine,
     _canvas_to_sketch_map,
@@ -29,6 +30,8 @@ class _FakeTensor:
 
 
 class _FakeTorch:
+    OutOfMemoryError = type("OutOfMemoryError", (Exception,), {})
+
     class _NoGrad:
         def __enter__(self):
             return None
@@ -136,6 +139,55 @@ def _clip_manifest():
     )
 
 
+class _RenderPipeline:
+    """A diffusers-style pipeline that renders and records what it was given.
+
+    Composed from the shared tokenizer/encoder fakes so the prompt encoding
+    counts are observable across frames, exactly like a real pipeline's
+    text encoders are.
+    """
+
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.text_encoder = _FakeTextEncoder(4)
+        self.tokenizer_2 = None
+        self.text_encoder_2 = None
+        self.config = SimpleNamespace(force_zeros_for_empty_prompt=True)
+        self.render_kwargs: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.render_kwargs.append(kwargs)
+        return SimpleNamespace(images=[Image.new("RGB", (32, 32))])
+
+
+def _frame_engine(pipeline: _RenderPipeline) -> DiffusersEngine:
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = _FakeTorch()
+    engine.device = "cpu"
+    engine._gpu = asyncio.Lock()
+    engine._codec = asyncio.Semaphore(CODEC_CONCURRENCY_LIMIT)
+    engine._pick_rung = MagicMock(return_value="full")
+    engine._evict_except = MagicMock()
+    engine._evict_poisoned = MagicMock()
+    engine._pipeline = MagicMock(return_value=pipeline)
+    return engine
+
+
+def _realtime_manifest() -> Manifest:
+    return Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+        prompt_token_limit=77,
+    )
+
+
+def _canvas_payload() -> bytes:
+    source = io.BytesIO()
+    Image.new("RGB", (24, 16), (1, 2, 3)).save(source, "PNG")
+    return source.getvalue()
+
+
 def test_long_prompt_embeddings_span_multiple_clip_windows():
     engine = _fake_prompt_engine()
     pipeline = _fake_pipeline()
@@ -167,14 +219,20 @@ def test_long_positive_and_short_negative_embeddings_have_matching_shapes():
     assert kwargs["negative_prompt_embeds"].shape == (1, 154, 4)
 
 
-def test_short_prompt_keeps_existing_pipeline_prompt_path():
+def test_short_prompt_embeds_without_chunking():
+    """A short prompt must produce embeddings too, or the realtime cache
+    never engages for the common case: the string path is re-encoded inside
+    diffusers on every frame."""
     engine = _fake_prompt_engine()
     pipeline = _fake_pipeline()
 
     kwargs = engine._prompt_kwargs(pipeline, _clip_manifest(), "w0 w1", None)
 
-    assert kwargs == {"prompt": "w0 w1"}
-    assert pipeline.text_encoder.calls == 0
+    assert "prompt" not in kwargs
+    assert kwargs["prompt_embeds"].shape == (1, 77, 4)
+    # One encode is two calls on the single CLIP: the positive prompt and the
+    # empty-string negative prompt both pass through the encoder.
+    assert pipeline.text_encoder.calls == 2
 
 
 def test_third_text_encoder_keeps_pipeline_prompt_path():
@@ -215,28 +273,97 @@ def test_fake_tokenizer_only_offers_what_a_real_one_does():
     assert real.num_special_tokens_to_add(pair=False) == 2
 
 
-def test_repeated_frames_reuse_the_encoded_prompt():
-    """A realtime session encodes the same prompt for every frame, and chunked
-    encoding is a full pass through each text encoder, so the second frame must
-    not pay for it again. Measured at 322 ms on CPU for two chunks against a
-    250 ms frame budget.
-    """
-    engine = _fake_prompt_engine()
-    pipeline = _fake_pipeline()
-    manifest = _clip_manifest()
-    prompt = " ".join(f"w{index}" for index in range(80))
+def test_realtime_session_encodes_its_prompt_once_across_frames():
+    """A realtime session encodes the same prompt for every frame, and
+    encoding is a full pass through each text encoder, so the second frame
+    must not pay for it again (measured at 322 ms on CPU for two chunks
+    against a 250 ms frame budget). The holder is per session, and the two
+    renders receive the very same tensors: nothing else about a frame (seed,
+    canvas, structure strength) reaches the text encoders."""
+    pipeline = _RenderPipeline()
+    engine = _frame_engine(pipeline)
+    manifest = _realtime_manifest()
+    cache = PromptCache()
 
-    first = engine._prompt_kwargs(pipeline, manifest, prompt, None)
-    after_first = pipeline.text_encoder.calls
-    second = engine._prompt_kwargs(pipeline, manifest, prompt, None)
+    async def scenario():
+        await engine.frame(manifest, {"prompt": "w0 w1"}, _canvas_payload(),
+                           prompt_cache=cache)
+        await engine.frame(manifest, {"prompt": "w0 w1"}, _canvas_payload(),
+                           prompt_cache=cache)
 
-    assert after_first > 0
-    assert pipeline.text_encoder.calls == after_first  # no re-encode
-    assert second is first
+    asyncio.run(scenario())
+    # One encode across both frames: the positive and the empty-string
+    # negative each pass through the single CLIP once on the first frame,
+    # and the second frame renders the cached tensors untouched.
+    assert pipeline.text_encoder.calls == 2
+    assert len(pipeline.render_kwargs) == 2
+    assert pipeline.render_kwargs[0]["prompt_embeds"] is pipeline.render_kwargs[1]["prompt_embeds"]
 
-    # A changed prompt has to be encoded again rather than served stale.
-    engine._prompt_kwargs(pipeline, manifest, prompt + " w99", None)
-    assert pipeline.text_encoder.calls > after_first
+
+def test_editing_the_prompt_between_frames_reencodes():
+    """The key is the encoded text, so an edited prompt misses and encodes
+    once, which is exactly what update_session carrying a new prompt is."""
+    pipeline = _RenderPipeline()
+    engine = _frame_engine(pipeline)
+    manifest = _realtime_manifest()
+    cache = PromptCache()
+
+    async def scenario():
+        await engine.frame(manifest, {"prompt": "w0 w1"}, _canvas_payload(),
+                           prompt_cache=cache)
+        await engine.frame(manifest, {"prompt": "w7 w8"}, _canvas_payload(),
+                           prompt_cache=cache)
+
+    asyncio.run(scenario())
+    # Each distinct prompt is encoded once (positive + empty negative).
+    assert pipeline.text_encoder.calls == 4
+
+
+def test_two_sessions_with_different_prompts_do_not_evict_each_other():
+    """The cache belongs to the session, so interleaved sessions with
+    different prompts each encode theirs once. A single pipeline-level entry
+    fails this: every frame from the other session evicts it, so each frame
+    re-encodes (eight encoder calls here)."""
+    pipeline = _RenderPipeline()
+    engine = _frame_engine(pipeline)
+    manifest = _realtime_manifest()
+    first = PromptCache()
+    second = PromptCache()
+
+    async def scenario():
+        for _ in range(2):
+            await engine.frame(manifest, {"prompt": "w0 w1"}, _canvas_payload(),
+                               prompt_cache=first)
+            await engine.frame(manifest, {"prompt": "w7 w8"}, _canvas_payload(),
+                               prompt_cache=second)
+
+    asyncio.run(scenario())
+    # One encode per session, four frames rendered: each session's second
+    # frame is a cache hit, so only two encodes (four encoder calls) happen.
+    assert pipeline.text_encoder.calls == 4
+    assert len(pipeline.render_kwargs) == 4
+
+
+def test_realtime_sd3_frames_keep_the_string_prompt_path():
+    """SD3 requires joint CLIP and T5 prompt embeddings; this CLIP-only
+    chunker cannot satisfy that contract, so its frames must keep passing the
+    raw prompt to diffusers rather than embeddings, cached or not."""
+    pipeline = _RenderPipeline()
+    pipeline.tokenizer_3 = object()
+    pipeline.text_encoder_3 = object()
+    engine = _frame_engine(pipeline)
+    manifest = _realtime_manifest()
+    cache = PromptCache()
+
+    async def scenario():
+        for _ in range(2):
+            await engine.frame(manifest, {"prompt": "w0 w1"}, _canvas_payload(),
+                               prompt_cache=cache)
+
+    asyncio.run(scenario())
+    assert pipeline.text_encoder.calls == 0
+    assert all(kwargs.get("prompt") == "w0 w1" for kwargs in pipeline.render_kwargs)
+    assert all("prompt_embeds" not in kwargs for kwargs in pipeline.render_kwargs)
 
 
 def test_sdxl_pooled_embedding_comes_from_first_chunk():
@@ -702,7 +829,7 @@ def test_frame_keeps_pillow_work_outside_gpu_lock():
         events.append(("pipeline", engine._gpu.locked()))
         return pipeline
 
-    def prompt_kwargs(*_args):
+    def prompt_kwargs(*_args, **_kwargs):
         events.append(("prompt", engine._gpu.locked()))
         return {"prompt": "frame"}
 
@@ -844,7 +971,7 @@ def test_frame_oom_retries_once_without_decoding_twice():
     rendered = Image.new("RGB", (32, 32), (12, 34, 56))
     canvases: list[Image.Image] = []
 
-    def run_frame(_manifest, _params, canvas, _strength):
+    def run_frame(_manifest, _params, canvas, _strength, **_kwargs):
         canvases.append(canvas)
         if len(canvases) == 1:
             raise torch_stub.OutOfMemoryError

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -17,7 +17,12 @@ from contextlib import suppress
 import httpx
 import websockets
 
-from worker.engine import Engine, SimulatedEngine, make_thumbnail_webp
+from worker.engine import (
+    Engine,
+    PromptCache,
+    SimulatedEngine,
+    make_thumbnail_webp,
+)
 from worker.categorize import categorize_output
 from worker.manifests import SIMULATED_MANIFEST, Manifest, load_manifests
 from worker.gpu_metrics import sample_gpu
@@ -217,6 +222,10 @@ class SessionRunner:
         self.frames = 0
         self.gpu_ms = 0
         self.started_at = time.monotonic()
+        # One holder for the session's prompt embeddings, passed to every
+        # frame: the cache lives and dies with the runner, so an engine-held
+        # cache would never have a release path to forget.
+        self.prompt_cache = PromptCache()
         self._task = asyncio.create_task(self._run(ws, engine, manifest))
 
     def submit(self, payload: bytes) -> None:
@@ -265,7 +274,9 @@ class SessionRunner:
             try:
                 # self.params is read per frame, so an update_session lands on
                 # the next frame while one in flight finishes on the old dict.
-                generated = await engine.frame(manifest, self.params, payload)
+                generated = await engine.frame(
+                    manifest, self.params, payload, prompt_cache=self.prompt_cache,
+                )
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -77,13 +77,31 @@ class GeneratedFrame:
     gpu_ms: int
 
 
+@dataclass
+class PromptCache:
+    """One cached prompt encoding, owned by the realtime session (issue #301).
+
+    The session creates the holder and passes it to every frame; the engine
+    never retains it, so there is no release path to forget and the entry is
+    dropped with the runner. The key is what was encoded, so an edited prompt
+    misses and re-encodes once, which is exactly what update_session carrying
+    a new prompt is; seed, canvas and structure strength never reach the text
+    encoders, so nothing else invalidates the entry.
+    """
+
+    entry: tuple[tuple[Any, Any, Any], dict[str, Any]] | None = None
+
+
 class Engine(Protocol):
     async def generate(
         self, manifest: Manifest, params: dict, progress: ProgressFn,
         *, input_image: bytes | None = None,
     ) -> GeneratedImage: ...
 
-    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame: ...
+    async def frame(
+        self, manifest: Manifest, params: dict, payload: bytes,
+        *, prompt_cache: PromptCache | None = None,
+    ) -> GeneratedFrame: ...
 
     def loaded_models(self) -> list[str]: ...
 
@@ -279,7 +297,10 @@ class SimulatedEngine:
         gpu_ms = int((time.monotonic() - start) * 1000)
         return GeneratedImage(encode_png(image), width, height, gpu_ms, load_ms)
 
-    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame:
+    async def frame(
+        self, manifest: Manifest, params: dict, payload: bytes,
+        *, prompt_cache: PromptCache | None = None,
+    ) -> GeneratedFrame:
         started = time.monotonic()
         await asyncio.sleep(self.inference_seconds)
         return GeneratedFrame(payload, int((time.monotonic() - started) * 1000))
@@ -1051,17 +1072,19 @@ class DiffusersEngine:
         manifest: Manifest,
         prompt: str,
         negative_prompt: str | None,
+        *,
+        prompt_cache: PromptCache | None = None,
     ) -> dict[str, Any]:
         # A realtime session calls this for every frame with the same prompt, and
-        # chunked encoding is a full pass through each text encoder: measured at
-        # 322 ms on CPU for a two chunk prompt, against a frame budget of 250 ms.
-        # Only the encoded result is worth keeping, so the cache holds one entry
-        # and lives on the pipeline, which means a model switch drops it with the
-        # pipeline instead of pinning embeddings for weights no longer loaded.
+        # encoding is a full pass through each text encoder: measured at 322 ms
+        # on CPU for a two chunk prompt, against a frame budget of 250 ms. Only
+        # the encoded result is worth keeping, so the cache holds one entry and
+        # lives on the session's holder, which the caller drops with the session
+        # instead of pinning embeddings for weights no longer loaded.
         cache_key = (manifest.id, prompt, negative_prompt)
-        cached = getattr(pipeline, "_potocolom_prompt_cache", None)
-        if cached is not None and cached[0] == cache_key:
-            return cached[1]
+        if prompt_cache is not None:
+            if prompt_cache.entry is not None and prompt_cache.entry[0] == cache_key:
+                return prompt_cache.entry[1]
 
         prompt_kwargs: dict[str, Any] = {"prompt": prompt}
         if negative_prompt is not None:
@@ -1118,8 +1141,6 @@ class DiffusersEngine:
                 raise ValueError(f"prompt token limit {window} leaves no content tokens")
             for token_ids in token_lists:
                 chunk_count = max(chunk_count, math.ceil(len(token_ids) / content_size))
-        if chunk_count == 1:
-            return prompt_kwargs
 
         positive_embeddings = []
         positive_pooled = None
@@ -1182,7 +1203,8 @@ class DiffusersEngine:
         if dual_encoder:
             result["pooled_prompt_embeds"] = positive_pooled
             result["negative_pooled_prompt_embeds"] = negative_pooled
-        pipeline._potocolom_prompt_cache = (cache_key, result)
+        if prompt_cache is not None:
+            prompt_cache.entry = (cache_key, result)
         return result
 
     async def generate(
@@ -1357,7 +1379,10 @@ class DiffusersEngine:
         loop.call_soon_threadsafe(progress, 1.0)
         return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 
-    async def frame(self, manifest: Manifest, params: dict, payload: bytes) -> GeneratedFrame:
+    async def frame(
+        self, manifest: Manifest, params: dict, payload: bytes,
+        *, prompt_cache: PromptCache | None = None,
+    ) -> GeneratedFrame:
         if "realtime" not in manifest.capabilities:
             raise ValueError(f"model {manifest.id} does not support realtime frames")
         if self._pick_rung(manifest) != "full":
@@ -1382,7 +1407,8 @@ class DiffusersEngine:
             frame_result: tuple[Image.Image, int] | None = None
             try:
                 frame_result = await self._run_to_completion(
-                    self._frame, manifest, frame_params, canvas, strength)
+                    self._frame, manifest, frame_params, canvas, strength,
+                    prompt_cache=prompt_cache)
             except self.torch.OutOfMemoryError:
                 pass  # retry outside: the live traceback pins failed tensors
             except (ValueError, TypeError):
@@ -1394,7 +1420,8 @@ class DiffusersEngine:
                 # The eviction mutates GPU residency, so it remains serialized.
                 self._evict_except(manifest.id)
                 frame_result = await self._run_to_completion(
-                    self._frame, manifest, frame_params, canvas, strength)
+                    self._frame, manifest, frame_params, canvas, strength,
+                    prompt_cache=prompt_cache)
             image, gpu_ms = frame_result
         async with self._codec:
             data = await asyncio.to_thread(encode_webp, image)
@@ -1406,6 +1433,8 @@ class DiffusersEngine:
         params: dict,
         canvas: Image.Image,
         strength: float,
+        *,
+        prompt_cache: PromptCache | None = None,
     ) -> tuple[Image.Image, int]:
         if manifest.t2i_adapter:
             # Conditioned text-to-image: the canvas (already converted to the
@@ -1420,6 +1449,7 @@ class DiffusersEngine:
                 manifest,
                 str(params.get("prompt", "")),
                 str(negative_prompt) if negative_prompt is not None else None,
+                prompt_cache=prompt_cache,
             )
             properties = manifest.parameters.get("properties", {})
             structure_strength = float(params.get(
@@ -1458,6 +1488,7 @@ class DiffusersEngine:
             manifest,
             str(params.get("prompt", "")),
             str(negative_prompt) if negative_prompt is not None else None,
+            prompt_cache=prompt_cache,
         )
         started = time.monotonic()
         image = pipeline(


### PR DESCRIPTION
# Description

Closes #301. A realtime session re-encoded its prompt on every frame. The prompt changes when the
user types; the canvas changes constantly.

# Details

A cache existed, but it held one entry on the pipeline keyed by
`(manifest.id, prompt, negative_prompt)`, so two concurrent sessions with different prompts evicted
each other on every frame. That is precisely the case the issue is about. Short prompts were never
cached at all: `if chunk_count == 1: return prompt_kwargs` meant only a prompt long enough to need
chunking took the encoding path.

**Ownership was the main design question.** The engine has no session concept, so a per-session
cache could have been a dict keyed by session id. It is not: that needs explicit release plumbing,
and a missed release leaks a multi-megabyte tensor pair. The issue makes the same argument, noting
the rung cache and calibrated slot count already outlive what they describe. Instead the runner
creates a `PromptCache` holder and passes it to each `frame` call, so the entry dies with the
session and there is no release path to forget.

**SD3 keeps the string path.** It needs joint CLIP and T5 embeddings and the CLIP-only chunker
cannot satisfy that contract, so "always produce embeddings" is not literal. That branch and its
comment are untouched.

# Verification

`ruff`, `mypy` over 12 source files, and 145 worker tests pass, up from 141.

Five new tests. Two mutation-checked against the rules that matter:

| Reverted rule | Result |
|---|---|
| the single-chunk early return | 4 tests fail |
| the pipeline-level cache, so sessions collide again | `test_two_sessions_with_different_prompts_do_not_evict_each_other` fails |

The second is the one worth reading: restoring the old cache fails exactly the test for the defect
this change exists to fix.

# What is not verified here

**The timing.** The 26 to 33 ms per frame was measured on a GPU. There is none available to this
change, `scripts/prototype-batch-sweep.py` was not run, and no performance claim is made beyond
the issue's own measurement.

**Equivalence of the chunker's single-chunk output with diffusers' own encoding.** Removing the
early return means a short prompt now goes through the chunker rather than being encoded inside
the pipeline. The issue reports a maximum absolute difference of exactly 0.0 between a
cached-embedding latent and a re-encoded one at the same seed, which is the relevant measurement,
but it was taken on a GPU and the tests here use a fake encoder, so they pin call counts and
identity rather than numerical equivalence. Worth a GPU check before this is relied on for output
stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved realtime frame generation by reusing prompt processing across frames within a session.
  * Reduced repeated prompt work while maintaining separate processing for different sessions.
  * Preserved prompt handling during retry scenarios and across supported generation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->