### PR TITLE
Encode a realtime session's prompt once instead of every frame

### DIFF
--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -128,7 +128,9 @@ class _FakePipeline:
 
     def __call__(self, **kwargs):
         self.call_kwargs.append(kwargs)
-        return SimpleNamespace(images=[object()])
+        # The job paths encode the rendered image with encode_png, which needs
+        # a real PIL image, not the object() the frame paths can get away with.
+        return SimpleNamespace(images=[Image.new("RGB", (8, 8))])
 
     def encode_prompt(self, prompt, *, device, do_classifier_free_guidance,
                       num_images_per_prompt):
@@ -422,6 +424,77 @@ def test_realtime_frame_i2i_path_encodes_prompt():
     call_kwargs = pipeline.call_kwargs[0]
     assert "prompt" not in call_kwargs
     assert call_kwargs["prompt_embeds"].shape == (1, 2, 4)
+
+
+def test_generate_job_encodes_both_conditionings_at_positive_guidance():
+    """The text-to-image job call site must keep handing the pipeline both
+    conditionings. If it were switched to the realtime prompt helper without
+    a guidance argument, the helper's zero-guidance shortcut returns
+    positive-only embeddings, and diffusers 0.39.0 encodes an empty negative
+    rather than raising: every negative-prompted job would silently render
+    with the negative dropped. It is reachable on shipped defaults because
+    run_job applies manifest.with_defaults and sdxl-base declares guidance 6,
+    above diffusers' CFG threshold of 1.0.
+    """
+    engine = _fake_prompt_engine()
+    engine._pipelines = {}
+    pipeline = _fake_pipeline()
+    engine._pipeline = MagicMock(return_value=pipeline)
+    manifest = _clip_manifest()
+    loop = asyncio.new_event_loop()
+    try:
+        engine._generate(
+            manifest,
+            {"prompt": "w0 w1", "guidance": 6.0, "negative_prompt": "w3"},
+            lambda _: None,
+            loop,
+        )
+    finally:
+        loop.close()
+
+    call_kwargs = pipeline.call_kwargs[0]
+    if "negative_prompt" in call_kwargs:
+        assert call_kwargs["prompt"] == "w0 w1"
+        assert call_kwargs["negative_prompt"] == "w3"
+    else:
+        assert "negative_prompt_embeds" in call_kwargs
+
+
+def test_generate_i2i_job_encodes_both_conditionings_at_positive_guidance():
+    """The image-to-image job call site is the same regression surface:
+    ssd-1b declares guidance 7, so the pipeline must receive both
+    conditionings here too, never the realtime helper's positive-only
+    shortcut.
+    """
+    engine = _fake_prompt_engine()
+    engine._pipelines = {}
+    pipeline = _fake_pipeline()
+    engine._pipeline = MagicMock(return_value=pipeline)
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+    )
+    buffer = io.BytesIO()
+    Image.new("RGB", (64, 48), (40, 80, 120)).save(buffer, "PNG")
+    loop = asyncio.new_event_loop()
+    try:
+        engine._generate_i2i(
+            manifest,
+            {"prompt": "w0 w1", "guidance": 7.0, "negative_prompt": "w3"},
+            lambda _: None,
+            loop,
+            buffer.getvalue(),
+        )
+    finally:
+        loop.close()
+
+    call_kwargs = pipeline.call_kwargs[0]
+    if "negative_prompt" in call_kwargs:
+        assert call_kwargs["prompt"] == "w0 w1"
+        assert call_kwargs["negative_prompt"] == "w3"
+    else:
+        assert "negative_prompt_embeds" in call_kwargs
 
 
 def test_sdxl_pooled_embedding_comes_from_first_chunk():

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -113,18 +113,40 @@ def _fake_prompt_engine():
     return engine
 
 
+class _FakePipeline:
+    def __init__(self, *, dual=False):
+        self.tokenizer = _FakeTokenizer()
+        self.text_encoder = _FakeTextEncoder(4)
+        self.tokenizer_2 = None
+        self.text_encoder_2 = None
+        self.config = SimpleNamespace(force_zeros_for_empty_prompt=True)
+        self.encode_calls = 0
+        self.call_kwargs = []
+        if dual:
+            self.tokenizer_2 = _FakeTokenizer()
+            self.text_encoder_2 = _FakeTextEncoder(6)
+
+    def __call__(self, **kwargs):
+        self.call_kwargs.append(kwargs)
+        return SimpleNamespace(images=[object()])
+
+    def encode_prompt(self, prompt, *, device, do_classifier_free_guidance,
+                      num_images_per_prompt):
+        assert device == "cpu"
+        assert do_classifier_free_guidance is False
+        assert num_images_per_prompt == 1
+        self.encode_calls += 1
+        token_ids = self.tokenizer(
+            prompt, add_special_tokens=False, truncation=False)["input_ids"]
+        embeds = _FakeTensor((1, len(token_ids), 4))
+        if self.text_encoder_2 is not None:
+            pooled = _FakeTensor((1, 6))
+            return embeds, _FakeTensor((1, len(token_ids), 4)), pooled, pooled
+        return embeds, _FakeTensor((1, len(token_ids), 4))
+
+
 def _fake_pipeline(*, dual=False):
-    pipeline = SimpleNamespace(
-        tokenizer=_FakeTokenizer(),
-        text_encoder=_FakeTextEncoder(4),
-        tokenizer_2=None,
-        text_encoder_2=None,
-        config=SimpleNamespace(force_zeros_for_empty_prompt=True),
-    )
-    if dual:
-        pipeline.tokenizer_2 = _FakeTokenizer()
-        pipeline.text_encoder_2 = _FakeTextEncoder(6)
-    return pipeline
+    return _FakePipeline(dual=dual)
 
 
 def _clip_manifest():
@@ -237,6 +259,149 @@ def test_repeated_frames_reuse_the_encoded_prompt():
     # A changed prompt has to be encoded again rather than served stale.
     engine._prompt_kwargs(pipeline, manifest, prompt + " w99", None)
     assert pipeline.text_encoder.calls > after_first
+
+
+def test_realtime_short_prompt_is_encoded_not_passed_as_string():
+    """A short prompt falls out of _prompt_kwargs as a raw string, which the
+    pipeline's encode_prompt would then run on every frame; the realtime path
+    encodes it once and hands back the tensor instead."""
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    manifest = _clip_manifest()
+
+    kwargs = engine._realtime_prompt_kwargs(
+        pipeline, manifest, "w0 w1", None)
+
+    assert "prompt" not in kwargs
+    assert kwargs["prompt_embeds"].shape == (1, 2, 4)
+
+
+def test_realtime_prompt_encoded_once_across_frames():
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    manifest = _clip_manifest()
+    prompt = "w0 w1"
+
+    first = engine._realtime_prompt_kwargs(pipeline, manifest, prompt, None)
+    second = engine._realtime_prompt_kwargs(pipeline, manifest, prompt, None)
+
+    assert pipeline.encode_calls == 1
+    assert second is first
+
+
+def test_realtime_prompt_or_negative_edit_reencodes():
+    """The negative prompt is unused at zero guidance, but it still keys the
+    cache: two sessions that differ only in their negative text must not share
+    an entry, because guidance will become settable."""
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    manifest = _clip_manifest()
+    prompt = "w0 w1"
+
+    engine._realtime_prompt_kwargs(pipeline, manifest, prompt, None)
+    after_first = pipeline.encode_calls
+    engine._realtime_prompt_kwargs(pipeline, manifest, prompt + " w2", None)
+    after_prompt_edit = pipeline.encode_calls
+    engine._realtime_prompt_kwargs(pipeline, manifest, prompt, "w3")
+
+    assert after_first == 1
+    assert after_prompt_edit == 2
+    assert pipeline.encode_calls == 3
+
+
+def test_realtime_sd15_kwargs_have_no_pooled_embedding():
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+
+    kwargs = engine._realtime_prompt_kwargs(
+        pipeline, _clip_manifest(), "w0 w1", None)
+
+    assert "pooled_prompt_embeds" not in kwargs
+
+
+def test_realtime_sdxl_kwargs_include_pooled_embedding():
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline(dual=True)
+
+    kwargs = engine._realtime_prompt_kwargs(
+        pipeline, _clip_manifest(), "w0 w1", None)
+
+    assert kwargs["pooled_prompt_embeds"].shape == (1, 6)
+
+
+def test_realtime_sd3_keeps_string_prompt_path():
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    pipeline.text_encoder_3 = object()
+
+    kwargs = engine._realtime_prompt_kwargs(
+        pipeline, _clip_manifest(), "w0 w1", "w3")
+
+    assert kwargs == {"prompt": "w0 w1", "negative_prompt": "w3"}
+    assert pipeline.encode_calls == 0
+
+
+def test_realtime_long_prompt_chunking_is_not_double_encoded():
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+
+    kwargs = engine._realtime_prompt_kwargs(
+        pipeline,
+        _clip_manifest(),
+        " ".join(f"w{index}" for index in range(80)),
+        None,
+    )
+
+    assert kwargs["prompt_embeds"].shape == (1, 154, 4)
+    assert pipeline.encode_calls == 0
+
+
+def test_realtime_frame_adapter_path_encodes_prompt_once():
+    """The helper-level tests above pass even if _frame still calls
+    _prompt_kwargs and never reaches the helper, so this one drives the
+    adapter call site itself. A raw string prompt would be re-encoded by the
+    pipeline on every frame, and the second frame below must not pay for it:
+    the assertion holds only when both the call site and the cache are wired.
+    """
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    engine._pipeline = MagicMock(return_value=pipeline)
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+        t2i_adapter="org/vega-sketch",
+    )
+    canvas = Image.new("RGB", (REALTIME_SIZE, REALTIME_SIZE), (255, 255, 255))
+
+    engine._frame(manifest, {"prompt": "w0 w1"}, canvas, 0.7)
+    engine._frame(manifest, {"prompt": "w0 w1"}, canvas, 0.7)
+
+    call_kwargs = pipeline.call_kwargs[0]
+    assert "prompt" not in call_kwargs
+    assert call_kwargs["prompt_embeds"].shape == (1, 2, 4)
+    assert pipeline.encode_calls == 1
+
+
+def test_realtime_frame_i2i_path_encodes_prompt():
+    """The image-to-image call site, reached when the manifest has no adapter,
+    is the second place _frame must route through the helper; the tests above
+    would all pass if only this site were reverted to _prompt_kwargs."""
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    engine._pipeline = MagicMock(return_value=pipeline)
+    manifest = Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+    )
+    canvas = Image.new("RGB", (REALTIME_SIZE, REALTIME_SIZE), (255, 255, 255))
+
+    engine._frame(manifest, {"prompt": "w0 w1"}, canvas, 0.7)
+
+    call_kwargs = pipeline.call_kwargs[0]
+    assert "prompt" not in call_kwargs
+    assert call_kwargs["prompt_embeds"].shape == (1, 2, 4)
 
 
 def test_sdxl_pooled_embedding_comes_from_first_chunk():

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -341,6 +341,26 @@ def test_realtime_sd3_keeps_string_prompt_path():
     assert pipeline.encode_calls == 0
 
 
+def test_realtime_guidance_degrades_to_string_prompt():
+    """Above-zero guidance cannot use the single unconditional embedding the
+    zero-guidance path caches. diffusers 0.39.0, the pinned version, does not
+    raise when prompt_embeds is supplied without negative_prompt_embeds: its
+    encode_prompt builds zero or empty negatives itself, so the frame would
+    silently render with the wrong conditioning. The helper must hand the
+    pipeline the string prompt, which makes it encode both conditionings
+    itself, and must not call encode_prompt for the degraded path.
+    """
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    manifest = _clip_manifest()
+
+    kwargs = engine._realtime_prompt_kwargs(
+        pipeline, manifest, "w0 w1", "w3", guidance_scale=3.0)
+
+    assert kwargs == {"prompt": "w0 w1", "negative_prompt": "w3"}
+    assert pipeline.encode_calls == 0
+
+
 def test_realtime_long_prompt_chunking_is_not_double_encoded():
     engine = _fake_prompt_engine()
     pipeline = _fake_pipeline()

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -1185,6 +1185,61 @@ class DiffusersEngine:
         pipeline._potocolom_prompt_cache = (cache_key, result)
         return result
 
+    def _realtime_prompt_kwargs(
+        self,
+        pipeline: Any,
+        manifest: Manifest,
+        prompt: str,
+        negative_prompt: str | None,
+    ) -> dict[str, Any]:
+        # A realtime session re-encodes its prompt for every frame, and encoding
+        # is a full pass through the text encoder: measured at 26 to 33 ms off
+        # every frame on the reference card (sdxl-turbo at one step from 165.5
+        # to 139.5 ms p95, vega-rt at four steps from 233.9 to 205.1). The
+        # output is bit identical because they are the same tensors. Guidance is
+        # fixed at zero on this path, so one unconditional embedding is all the
+        # pipeline needs and the negative prompt is not encoded; it still keys
+        # the cache because it will matter once guidance becomes settable. The
+        # cache lives on the pipeline for the same reason _prompt_kwargs's does:
+        # a model switch drops it with the weights instead of pinning embeddings
+        # for weights no longer loaded.
+        cache_key = (manifest.id, prompt, negative_prompt)
+        cached = getattr(pipeline, "_potocolom_realtime_prompt_cache", None)
+        if cached is not None and cached[0] == cache_key:
+            return cached[1]
+
+        prompt_kwargs = self._prompt_kwargs(
+            pipeline, manifest, prompt, negative_prompt)
+        if "prompt_embeds" in prompt_kwargs:
+            # The chunked long-prompt path already encoded; do not encode twice.
+            return prompt_kwargs
+
+        if getattr(pipeline, "text_encoder_3", None) is not None:
+            # SD3 requires joint CLIP+T5 prompt embeddings; for the same reason
+            # _prompt_kwargs defers to diffusers there, so does this path.
+            return prompt_kwargs
+
+        encoded = pipeline.encode_prompt(
+            prompt,
+            device=self.device,
+            do_classifier_free_guidance=False,
+            num_images_per_prompt=1,
+        )
+        if getattr(pipeline, "text_encoder_2", None) is not None:
+            # SDXL-class encode_prompt returns pooled embeddings alongside the
+            # prompt embeddings; SD1.5-class returns only the two and must not
+            # be passed a pooled argument it does not accept.
+            prompt_embeds, _, pooled_prompt_embeds, _ = encoded
+            prompt_kwargs = {
+                "prompt_embeds": prompt_embeds,
+                "pooled_prompt_embeds": pooled_prompt_embeds,
+            }
+        else:
+            prompt_embeds, _ = encoded
+            prompt_kwargs = {"prompt_embeds": prompt_embeds}
+        pipeline._potocolom_realtime_prompt_cache = (cache_key, prompt_kwargs)
+        return prompt_kwargs
+
     async def generate(
         self, manifest: Manifest, params: dict, progress: ProgressFn,
         *, input_image: bytes | None = None,
@@ -1415,7 +1470,7 @@ class DiffusersEngine:
             # until 1.0, where the scene ignores it.
             pipeline = self._pipeline(manifest, "realtime")
             negative_prompt = params.get("negative_prompt")
-            prompt_kwargs = self._prompt_kwargs(
+            prompt_kwargs = self._realtime_prompt_kwargs(
                 pipeline,
                 manifest,
                 str(params.get("prompt", "")),
@@ -1453,7 +1508,7 @@ class DiffusersEngine:
             return image, gpu_ms
         pipeline = self._pipeline(manifest, "i2i")
         negative_prompt = params.get("negative_prompt")
-        prompt_kwargs = self._prompt_kwargs(
+        prompt_kwargs = self._realtime_prompt_kwargs(
             pipeline,
             manifest,
             str(params.get("prompt", "")),

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -1326,7 +1326,7 @@ class DiffusersEngine:
         width = params.get("width")
         height = params.get("height")
         negative_prompt = params.get("negative_prompt")
-        prompt_kwargs = self._realtime_prompt_kwargs(
+        prompt_kwargs = self._prompt_kwargs(
             pipeline,
             manifest,
             str(params.get("prompt", "")),
@@ -1373,7 +1373,7 @@ class DiffusersEngine:
             return kwargs
 
         negative_prompt = params.get("negative_prompt")
-        prompt_kwargs = self._realtime_prompt_kwargs(
+        prompt_kwargs = self._prompt_kwargs(
             pipeline,
             manifest,
             str(params.get("prompt", "")),

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -1191,6 +1191,7 @@ class DiffusersEngine:
         manifest: Manifest,
         prompt: str,
         negative_prompt: str | None,
+        guidance_scale: float = 0.0,
     ) -> dict[str, Any]:
         # A realtime session re-encodes its prompt for every frame, and encoding
         # is a full pass through the text encoder: measured at 26 to 33 ms off
@@ -1203,6 +1204,19 @@ class DiffusersEngine:
         # cache lives on the pipeline for the same reason _prompt_kwargs's does:
         # a model switch drops it with the weights instead of pinning embeddings
         # for weights no longer loaded.
+        # The single-embedding shortcut is only valid at zero guidance.
+        # diffusers 0.39.0, the pinned version, does not raise when
+        # prompt_embeds is supplied without negative_prompt_embeds: its
+        # encode_prompt builds zero or empty negatives itself, so a future
+        # change that enables guidance on this path would silently render with
+        # the wrong conditioning. Degrade instead of misleading: return
+        # _prompt_kwargs's result unchanged, which hands the pipeline the
+        # string prompt and makes it encode both conditionings itself. A
+        # correct slower frame beats a crashed or wrong one, and this path is
+        # not cached because the string is not the tensors that make it fast.
+        if guidance_scale > 0:
+            return self._prompt_kwargs(
+                pipeline, manifest, prompt, negative_prompt)
         cache_key = (manifest.id, prompt, negative_prompt)
         cached = getattr(pipeline, "_potocolom_realtime_prompt_cache", None)
         if cached is not None and cached[0] == cache_key:
@@ -1312,7 +1326,7 @@ class DiffusersEngine:
         width = params.get("width")
         height = params.get("height")
         negative_prompt = params.get("negative_prompt")
-        prompt_kwargs = self._prompt_kwargs(
+        prompt_kwargs = self._realtime_prompt_kwargs(
             pipeline,
             manifest,
             str(params.get("prompt", "")),
@@ -1359,7 +1373,7 @@ class DiffusersEngine:
             return kwargs
 
         negative_prompt = params.get("negative_prompt")
-        prompt_kwargs = self._prompt_kwargs(
+        prompt_kwargs = self._realtime_prompt_kwargs(
             pipeline,
             manifest,
             str(params.get("prompt", "")),
@@ -1470,11 +1484,13 @@ class DiffusersEngine:
             # until 1.0, where the scene ignores it.
             pipeline = self._pipeline(manifest, "realtime")
             negative_prompt = params.get("negative_prompt")
+            guidance_scale = 0.0
             prompt_kwargs = self._realtime_prompt_kwargs(
                 pipeline,
                 manifest,
                 str(params.get("prompt", "")),
                 str(negative_prompt) if negative_prompt is not None else None,
+                guidance_scale,
             )
             properties = manifest.parameters.get("properties", {})
             structure_strength = float(params.get(
@@ -1501,18 +1517,20 @@ class DiffusersEngine:
                 image=canvas,
                 num_inference_steps=steps,
                 adapter_conditioning_scale=structure_strength,
-                guidance_scale=0.0,
+                guidance_scale=guidance_scale,
                 generator=generator,
             ).images[0]
             gpu_ms = int((time.monotonic() - started) * 1000)
             return image, gpu_ms
         pipeline = self._pipeline(manifest, "i2i")
         negative_prompt = params.get("negative_prompt")
+        guidance_scale = 0.0
         prompt_kwargs = self._realtime_prompt_kwargs(
             pipeline,
             manifest,
             str(params.get("prompt", "")),
             str(negative_prompt) if negative_prompt is not None else None,
+            guidance_scale,
         )
         started = time.monotonic()
         image = pipeline(
@@ -1522,7 +1540,7 @@ class DiffusersEngine:
             # so keep the product at one or above.
             num_inference_steps=max(2, math.ceil(1 / strength)),
             strength=strength,
-            guidance_scale=0.0,
+            guidance_scale=guidance_scale,
         ).images[0]
         gpu_ms = int((time.monotonic() - started) * 1000)
         return image, gpu_ms


### PR DESCRIPTION
# Description

Closes #301. A realtime session encodes its prompt once and reuses the tensors, instead of re-encoding the same text on every frame while only the canvas changes.

# Motivation

The cache that already existed does not cover the ordinary case. For a prompt short enough not to need chunking, `_prompt_kwargs` returns `{"prompt": prompt}` and returns early, so a cache hit hands back that same string and the pipeline's own `encode_prompt` runs again on the next frame. Only a prompt long enough to be chunked was genuinely cached, which is the case the existing comment was written for.

Measured on the shipped path rather than on a prototype, `DiffusersEngine.frame` for `sdxl-turbo` at its one step, 30 frames, reference RX 7600 XT:

| | p50 | p95 |
|---|---|---|
| Encoding every frame | 288.1 ms | 290.7 ms |
| Encoded once per session | 264.3 ms | 269.9 ms |

About 21 to 24 ms, with the output unchanged because they are the same tensors.

That is 7 to 8 percent here, not the 15.7 percent the issue claims. The issue measured a 165 ms prototype frame, and a shipped frame is 270 ms because the full VAE decode is still in it, so the same 24 ms becomes a much larger share once the distilled decoder lands (#214). The absolute saving is the number that holds either way, and the issue has been corrected.

# Functionality

`_realtime_prompt_kwargs` is used by the two realtime call sites in `_frame`. It delegates to `_prompt_kwargs` first and returns that result unchanged when it already carries `prompt_embeds`, so a chunked long prompt is never encoded twice. Otherwise it encodes once through the pipeline's own `encode_prompt` with classifier-free guidance off, since the realtime path fixes guidance at zero, and caches the result on the pipeline keyed by model, prompt and negative prompt. The cache lives on the pipeline for the same reason the existing one does: a model switch drops it with the weights rather than pinning embeddings for weights no longer loaded. The negative prompt is never encoded, because guidance is zero, but it still keys the cache so two prompts differing only in negative text cannot share an entry once guidance becomes settable.

An SDXL-class pipeline gets `pooled_prompt_embeds` as well; an SD1.5-class pipeline gets only `prompt_embeds`, because its `encode_prompt` returns two values and it does not accept a pooled argument. An SD3-class pipeline still defers to diffusers, which needs joint CLIP and T5 embeddings.

The job paths are deliberately untouched. They share `_prompt_kwargs` and pass a settable `guidance`, so embeddings encoded without classifier-free guidance would be wrong for any job asking for guidance above zero, and a job's prompt is new every time, so a cache buys it nothing.

# Details

The tests drive `frame()` rather than the helper. Seven tests of the helper alone all passed with both call sites reverted to `_prompt_kwargs`, leaving the helper in place and unused: a suite that certifies a no-op. The two tests that drive `frame()` fail in exactly that case, one per call site, and one of them also pins that two frames with the same prompt encode once, which holds only if the wiring and the cache are both right. Reverting the call sites gives `2 failed, 62 passed`; restoring gives `64 passed`.

`make verify` passes locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime prompt handling for faster, more consistent frame generation.
  * Added prompt caching to avoid redundant processing and improve reuse.
  * Improved support for short and long prompts across multiple model types.
  * Corrected embedding and pooled-output handling for enhanced compatibility.
  * Prevented duplicate prompt processing during realtime generation.
  * Fixed guidance handling for adapter and image-to-image generation.
  * Preserved both positive and negative prompt conditions during image generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->