### PR TITLE
Pin that a guided job keeps the negative the user asked for

### DIFF
--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -201,11 +201,72 @@ def _input_image_bytes() -> bytes:
     return buffer.getvalue()
 
 
-def _assert_negative_reachable(kwargs: dict) -> None:
-    if kwargs.get("negative_prompt_embeds") is not None:
+def _fake_content_token_ids(text: str) -> list[int]:
+    return list(
+        _FakeTokenizer()(
+            text, add_special_tokens=False, truncation=False,
+        )["input_ids"],
+    )
+
+
+def _expected_pooled_marker(text: str) -> int:
+    token_ids = _fake_content_token_ids(text)
+    if token_ids:
+        return token_ids[0]
+    return _FakeTokenizer.eos_token_id
+
+
+def _assert_negative_reachable(
+    kwargs: dict,
+    expected_negative: str,
+    *,
+    expected_positive: str | None = None,
+) -> None:
+    negative_embeds = kwargs.get("negative_prompt_embeds")
+    if negative_embeds is not None:
+        prompt_embeds = kwargs["prompt_embeds"]
+        if negative_embeds is prompt_embeds:
+            raise AssertionError(
+                "negative_prompt_embeds is the same object as prompt_embeds",
+            )
+        negative_pooled = kwargs.get("negative_pooled_prompt_embeds")
+        if negative_pooled is not None:
+            expected_marker = _expected_pooled_marker(expected_negative)
+            if negative_pooled.marker != expected_marker:
+                raise AssertionError(
+                    "negative_pooled_prompt_embeds marker does not match "
+                    "the expected negative text",
+                )
+            pooled_prompt = kwargs.get("pooled_prompt_embeds")
+            if pooled_prompt is not None and negative_pooled is pooled_prompt:
+                raise AssertionError(
+                    "negative_pooled_prompt_embeds is the same object as "
+                    "pooled_prompt_embeds",
+                )
+            if expected_positive is not None:
+                if negative_pooled.marker == _expected_pooled_marker(
+                    expected_positive,
+                ):
+                    raise AssertionError(
+                        "negative pooled marker matches the positive text",
+                    )
+        else:
+            negative_tokens = len(_fake_content_token_ids(expected_negative))
+            if negative_embeds.shape[1] != negative_tokens:
+                raise AssertionError(
+                    "negative_prompt_embeds sequence length does not match "
+                    "the expected negative token count",
+                )
         return
-    if kwargs.get("negative_prompt") is not None:
+
+    negative_text = kwargs.get("negative_prompt")
+    if negative_text is not None:
+        if negative_text != expected_negative:
+            raise AssertionError(
+                "negative_prompt does not match the expected negative text",
+            )
         return
+
     raise AssertionError(
         "pipeline kwargs lack negative_prompt_embeds or negative_prompt",
     )
@@ -426,7 +487,7 @@ def test_generate_job_passes_negative_prompt_to_pipeline():
     manifest = _sdxl_job_manifest()
     params = {
         "prompt": "w0 w1",
-        "negative_prompt": "w3 w4",
+        "negative_prompt": "w3",
         "guidance": 6.0,
     }
     loop = asyncio.new_event_loop()
@@ -435,7 +496,9 @@ def test_generate_job_passes_negative_prompt_to_pipeline():
     finally:
         loop.close()
 
-    _assert_negative_reachable(pipeline.call_kwargs[0])
+    _assert_negative_reachable(
+        pipeline.call_kwargs[0], "w3", expected_positive="w0 w1",
+    )
     assert result.width == 64
     assert result.height == 48
 
@@ -448,7 +511,7 @@ def test_generate_i2i_job_passes_negative_prompt_to_pipeline():
     manifest = _sdxl_job_manifest()
     params = {
         "prompt": "w0 w1",
-        "negative_prompt": "w5 w6",
+        "negative_prompt": "w5 w6 w7",
         "guidance": 7.0,
     }
     loop = asyncio.new_event_loop()
@@ -459,7 +522,9 @@ def test_generate_i2i_job_passes_negative_prompt_to_pipeline():
     finally:
         loop.close()
 
-    _assert_negative_reachable(pipeline.call_kwargs[0])
+    _assert_negative_reachable(
+        pipeline.call_kwargs[0], "w5 w6 w7", expected_positive="w0 w1",
+    )
     assert result.width == 64
     assert result.height == 48
 

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -160,6 +160,57 @@ class _RenderPipeline:
         return SimpleNamespace(images=[Image.new("RGB", (32, 32))])
 
 
+class _JobPipeline:
+    """Records pipeline keyword arguments for job-path tests."""
+
+    def __init__(self, *, dual: bool = False):
+        fake = _fake_pipeline(dual=dual)
+        self.tokenizer = fake.tokenizer
+        self.text_encoder = fake.text_encoder
+        self.tokenizer_2 = fake.tokenizer_2
+        self.text_encoder_2 = fake.text_encoder_2
+        self.config = fake.config
+        self.call_kwargs: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.call_kwargs.append(kwargs)
+        return SimpleNamespace(images=[Image.new("RGB", (64, 48))])
+
+
+def _job_engine(pipeline: _JobPipeline) -> DiffusersEngine:
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = _FakeTorch()
+    engine.device = "cpu"
+    engine._pipelines = {}
+    engine._pipeline = MagicMock(return_value=pipeline)
+    return engine
+
+
+def _sdxl_job_manifest() -> Manifest:
+    return Manifest(
+        id="sdxl-base",
+        name="SDXL",
+        capabilities=["text_to_image", "image_to_image"],
+        prompt_token_limit=77,
+    )
+
+
+def _input_image_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (128, 96), (40, 80, 120)).save(buffer, "WEBP")
+    return buffer.getvalue()
+
+
+def _assert_negative_reachable(kwargs: dict) -> None:
+    if kwargs.get("negative_prompt_embeds") is not None:
+        return
+    if kwargs.get("negative_prompt") is not None:
+        return
+    raise AssertionError(
+        "pipeline kwargs lack negative_prompt_embeds or negative_prompt",
+    )
+
+
 def _frame_engine(pipeline: _RenderPipeline) -> DiffusersEngine:
     engine = DiffusersEngine.__new__(DiffusersEngine)
     engine.torch = _FakeTorch()
@@ -364,6 +415,53 @@ def test_realtime_sd3_frames_keep_the_string_prompt_path():
     assert pipeline.text_encoder.calls == 0
     assert all(kwargs.get("prompt") == "w0 w1" for kwargs in pipeline.render_kwargs)
     assert all("prompt_embeds" not in kwargs for kwargs in pipeline.render_kwargs)
+
+
+def test_generate_job_passes_negative_prompt_to_pipeline():
+    """Shipped sdxl-base guidance default is 6; a queued job at that value must
+    still reach _prompt_kwargs so the user's negative prompt is encoded, not
+    dropped by a zero-guidance shortcut that only forwards positive embeds."""
+    pipeline = _JobPipeline(dual=True)
+    engine = _job_engine(pipeline)
+    manifest = _sdxl_job_manifest()
+    params = {
+        "prompt": "w0 w1",
+        "negative_prompt": "w3 w4",
+        "guidance": 6.0,
+    }
+    loop = asyncio.new_event_loop()
+    try:
+        result = engine._generate(manifest, params, lambda _: None, loop)
+    finally:
+        loop.close()
+
+    _assert_negative_reachable(pipeline.call_kwargs[0])
+    assert result.width == 64
+    assert result.height == 48
+
+
+def test_generate_i2i_job_passes_negative_prompt_to_pipeline():
+    """Shipped ssd-1b guidance default is 7; img2img at that value must encode
+    the negative prompt the same way, not route through a helper that drops it."""
+    pipeline = _JobPipeline(dual=True)
+    engine = _job_engine(pipeline)
+    manifest = _sdxl_job_manifest()
+    params = {
+        "prompt": "w0 w1",
+        "negative_prompt": "w5 w6",
+        "guidance": 7.0,
+    }
+    loop = asyncio.new_event_loop()
+    try:
+        result = engine._generate_i2i(
+            manifest, params, lambda _: None, loop, _input_image_bytes(),
+        )
+    finally:
+        loop.close()
+
+    _assert_negative_reachable(pipeline.call_kwargs[0])
+    assert result.width == 64
+    assert result.height == 48
 
 
 def test_sdxl_pooled_embedding_comes_from_first_chunk():


### PR DESCRIPTION
# Description

Two tests, no production change. They pin that a queued job keeps the negative conditioning the user asked for, which `_prompt_kwargs` currently provides and nothing currently checks.

# Motivation

`_prompt_kwargs` is shared by four callers that disagree about the two things that make its result safe. The realtime paths in `_frame` pass a session `PromptCache` and fix `guidance_scale` at zero. The job paths, `_generate` and `_generate_i2i`, pass no cache and hand the pipeline `float(params.get("guidance", 0.0))`, which shipped manifests set above diffusers' classifier-free-guidance threshold: `sdxl-base` declares 6, `ssd-1b` 7, `dreamshaper-lcm` 1.5.

Nothing in the suite drives either job path into the real `_prompt_kwargs`. On a parallel branch a change routed those two call sites through a realtime-only helper whose guidance defaulted to zero, which returned a positive embedding and no negative. diffusers 0.39 does not raise in that case; it encodes an empty negative instead. Every batch text-to-image and image-to-image job with a negative prompt would have rendered with that negative silently dropped, and 151 tests passed with the defect present and 151 with it gone.

Main is not affected: `_prompt_kwargs` always returns both conditionings, so the hazard cannot arise as the code stands. These tests are here so it cannot be reintroduced quietly.

# Functionality

`test_generate_job_passes_negative_prompt_to_pipeline` drives `_generate` with guidance 6.0 and a negative prompt. `test_generate_i2i_job_passes_negative_prompt_to_pipeline` does the same for `_generate_i2i` with guidance 7.0 and an input image. Each asserts that what reaches the pipeline carries a negative it can act on: `negative_prompt_embeds` on the embedding path, or a `negative_prompt` string where the code defers to diffusers. The guidance values are the shipped defaults rather than numbers chosen to make a point.

# Details

Both were mutation-checked twice, once by the agent that wrote them and once independently: stripping every `negative` key from what reaches the pipeline in `_generate` and `_generate_i2i` fails both on `pipeline kwargs lack negative_prompt_embeds or negative_prompt`, and restoring gives 147 passing. `worker/worker/engine.py` is untouched, verified with `git diff --stat`.

While confirming this, two measurements on the reference RX 7600 XT worth recording against #311:

The session cache does engage on the shipped path. Wall time around `engine.frame` for `sdxl-turbo` at its one step and 512 px, 12 frames: 265.2 ms p50 on a cache hit against 279.2 ms when a fresh holder forces every frame to encode, so the holder is worth about 14 ms a frame. That has to be measured as wall time, because `GeneratedFrame.gpu_ms` starts its timer after `_prompt_kwargs` (issue #288) and would report no saving even when the text encoders have stopped running.

Removing the `chunk_count == 1` early return did not change what jobs render. Encoding the same short prompt and negative both ways, the project's chunker and `pipeline.encode_prompt` agree exactly: `prompt_embeds`, `negative_prompt_embeds`, `pooled_prompt_embeds` and the negative pooled embedding all have a maximum absolute difference of 0.000e+00.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for text-to-image and image-to-image generation workflows.
  * Verified negative prompts remain available during generation.
  * Added checks ensuring generated image dimensions are preserved.
  * Added fixtures for dual-encoder pipelines, SDXL manifests, and input image data.
  * Improved validation of generated pipeline settings across supported generation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->