### PR TITLE
Collect the blobs of a job that failed without a verdict

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1677,7 +1677,14 @@ async def requeue_or_fail(job_id: uuid.UUID, reason: str) -> None:
             publish(job_id, {"state": "queued", "attempt": 2})
             logger.info("job %s requeued after %s", job_id, reason)
             return
-    await mark_failed(job_id, reason)
+        user_id = job.user_id
+        attempt = job.attempt
+    if await mark_failed(job_id, reason):
+        # A verdictless failure can still have uploaded: nothing downstream
+        # names those objects and no verdict path ran, so this is their only
+        # collector. The commit is durable before any delete, and a failing
+        # delete must not fail the job: the purge records it instead.
+        await purge_attempt_blobs(user_id, job_id, attempt)
 
 
 def on_worker_lost(worker: realtime.Worker) -> None:

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -860,6 +860,169 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
 
 
 @pytest.mark.db
+def test_a_stalled_job_failed_past_its_retry_collects_its_uploads(monkeypatch):
+    """A job failed by the sweeper past its one retry never got a worker
+    verdict, so requeue_or_fail's failing branch is the only collector its
+    uploads have (issue #312)."""
+    monkeypatch.setenv("JOB_STALL_SECONDS", "600")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-stall-fail")
+                job_id = client.post(
+                    "/api/v1/generations",
+                    json={"model_id": "sd-test", "params": {"prompt": "stall fail"}},
+                ).json()["job_id"]
+                first = worker.receive_json()
+                assert first["job_id"] == job_id
+
+                force_one_requeue(client, job_id)
+                second = worker.receive_json()
+                assert second["job_id"] == job_id
+                # Attempt 2 uploads its PNG and then dies without a verdict.
+                second_key = urlsplit(second["upload"]["url"]).path.rsplit(
+                    "/api/v1/files/", 1)[-1]
+                assert put_upload(client, second["upload"],
+                                  png_bytes()).status_code == 200
+                storage = jobs.get_storage()
+                assert storage.path(second_key).exists()
+
+                # Stall again: past the one retry, the sweeper fails the row.
+                jobs.last_progress_at[uuid.UUID(job_id)] = 0.0
+                asyncio.run(jobs.sweep_stalled_jobs())
+                poll_until(client, job_id, "failed")
+
+                assert not storage.path(second_key).exists(), \
+                    "a verdictless failure kept its upload"
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
+
+
+@pytest.mark.db
+def test_a_refused_failure_collects_nothing(monkeypatch):
+    """mark_failed refuses when the row went terminal, or moved to a later
+    attempt, while this failure was in flight. The keys then belong to whoever
+    won, so collecting on a refusal deletes their objects (issue #312).
+
+    The refusal is forced rather than raced: it happens inside mark_failed's
+    own locked read, which a test cannot reach by timing.
+    """
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-refused-fail")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "refused"}},
+            ).json()["job_id"]
+            worker.receive_json()
+            # Past the one retry, so requeue_or_fail reaches its failing
+            # branch rather than requeueing again.
+            force_one_requeue(client, job_id)
+            dispatch = worker.receive_json()
+            key = urlsplit(dispatch["upload"]["url"]).path.rsplit("/api/v1/files/", 1)[-1]
+            assert put_upload(client, dispatch["upload"], png_bytes()).status_code == 200
+            storage = jobs.get_storage()
+            assert storage.path(key).exists()
+
+            async def refuse(job_id, reason, expected_attempt=None):
+                return False
+
+            monkeypatch.setattr(jobs, "mark_failed", refuse)
+            asyncio.run(jobs.requeue_or_fail(uuid.UUID(job_id), "late worker loss"))
+
+            assert storage.path(key).exists(), \
+                "a refused failure deleted objects that belong to the winner"
+            # No tidy-up: the autouse fixture clears the job rows and the
+            # in-process dispatch state after every db test (issue #279).
+
+
+@pytest.mark.db
+def test_a_lost_job_failed_past_its_retry_collects_its_uploads(monkeypatch):
+    """A worker that dies past the one retry fails the job through the
+    lost_jobs conduit, which is requeue_or_fail's failing branch; the uploads
+    must be collected there too (issue #312)."""
+    monkeypatch.setenv("JOB_STALL_SECONDS", "600")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-lost-fail")
+                job_id = client.post(
+                    "/api/v1/generations",
+                    json={"model_id": "sd-test", "params": {"prompt": "lost fail"}},
+                ).json()["job_id"]
+                first = worker.receive_json()
+                assert first["job_id"] == job_id
+
+                force_one_requeue(client, job_id)
+                second = worker.receive_json()
+                assert second["job_id"] == job_id
+                second_key = urlsplit(second["upload"]["url"]).path.rsplit(
+                    "/api/v1/files/", 1)[-1]
+                assert put_upload(client, second["upload"],
+                                  png_bytes()).status_code == 200
+                storage = jobs.get_storage()
+                assert storage.path(second_key).exists()
+            # The worker died without a verdict: the disconnect handler files
+            # the job under lost_jobs and the dispatch loop fails it.
+            poll_until(client, job_id, "failed")
+
+            deadline = time.monotonic() + 3
+            while time.monotonic() < deadline and storage.path(second_key).exists():
+                time.sleep(0.05)
+            assert not storage.path(second_key).exists(), \
+                "a verdictless failure kept its upload"
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
+
+
+@pytest.mark.db
+def test_a_requeue_keeps_the_earlier_attempts_blobs(monkeypatch):
+    """The requeue branch deliberately collects nothing: the retry may still
+    upload to attempt one's keys, so their objects must survive the requeue
+    (issue #312)."""
+    monkeypatch.setenv("JOB_STALL_SECONDS", "600")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-requeue-keeps")
+                job_id = client.post(
+                    "/api/v1/generations",
+                    json={"model_id": "sd-test", "params": {"prompt": "keep"}},
+                ).json()["job_id"]
+                first = worker.receive_json()
+                assert first["job_id"] == job_id
+                first_key = urlsplit(first["upload"]["url"]).path.rsplit(
+                    "/api/v1/files/", 1)[-1]
+                first_thumb = urlsplit(first["thumb_upload"]["url"]).path.rsplit(
+                    "/api/v1/files/", 1)[-1]
+
+                # The first attempt uploaded before it stalled.
+                storage = jobs.get_storage()
+                asyncio.run(_write_blob(storage, first_key, png_bytes()))
+                asyncio.run(_write_blob(storage, first_thumb, png_bytes()))
+
+                force_one_requeue(client, job_id)
+                second = worker.receive_json()
+                assert second["job_id"] == job_id
+
+                assert storage.path(first_key).exists(), \
+                    "the requeue collected the earlier attempt"
+                assert storage.path(first_thumb).exists(), \
+                    "the requeue collected the earlier attempt's thumbnail"
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
+
+
+@pytest.mark.db
 def test_a_reported_failure_does_not_leave_its_upload_behind():
     """job_failed never calls image_info, so nothing bounds or collects it.
 
@@ -3547,6 +3710,61 @@ def test_a_failed_purge_is_recorded_for_the_sweep(monkeypatch):
             assert row.first_failed_at is not None
             assert row.next_attempt_at is not None
             assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "failed"
+
+
+@pytest.mark.db
+def test_a_failed_verdictless_collection_is_recorded_for_the_sweep(monkeypatch):
+    """A delete that fails during requeue_or_fail's collection leaves a
+    pending_deletes row naming that key, exactly as the verdict paths do, and
+    the job still reaches failed: the cleanup failure must never fail the job
+    (issue #312)."""
+    monkeypatch.setenv("JOB_STALL_SECONDS", "600")
+    from app.settings import get_settings
+    get_settings.cache_clear()
+    try:
+        with TestClient(app) as client:
+            with client.websocket_connect("/api/v1/fleet") as worker:
+                fleet_hello(worker, "w-verdictless-record")
+                asyncio.run(_clear_pending_deletes())
+                job_id = client.post(
+                    "/api/v1/generations",
+                    json={"model_id": "sd-test", "params": {"prompt": "verdictless"}},
+                ).json()["job_id"]
+                first = worker.receive_json()
+                assert first["job_id"] == job_id
+
+                force_one_requeue(client, job_id)
+                second = worker.receive_json()
+                assert second["job_id"] == job_id
+                second_key = urlsplit(second["upload"]["url"]).path.rsplit(
+                    "/api/v1/files/", 1)[-1]
+                assert put_upload(client, second["upload"],
+                                  png_bytes()).status_code == 200
+
+                real_storage = jobs.get_storage()
+
+                class RefusingDelete:
+                    """Stands in for storage; only deletes fail, like a denied
+                    permission that is sticky for the whole cleanup."""
+
+                    def __getattr__(self, name):
+                        return getattr(real_storage, name)
+
+                    async def delete(self, storage_key):
+                        raise PermissionError(f"denied {storage_key}")
+
+                monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
+                jobs.last_progress_at[uuid.UUID(job_id)] = 0.0
+                asyncio.run(jobs.sweep_stalled_jobs())
+                poll_until(client, job_id, "failed")
+
+                row = _await_pending_delete(second_key)
+                assert row.attempts == 0  # the sweep owns the counter, not the purge
+                assert row.last_error is not None
+                assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "failed"
+    finally:
+        monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
+        get_settings.cache_clear()
 
 
 @pytest.mark.db


### PR DESCRIPTION
Closes #312. Implemented by OpenCode (deepseek-v4-flash, max effort) to a design I fixed in the brief; gated and mutation-checked by me.

A job can reach a terminal state with no worker verdict: the stall sweeper past its one retry, a worker that dies, a restart that recovers a running row. All three funnel into requeue_or_fail, whose failing branch called mark_failed and returned, while the only two callers of purge_attempt_blobs are the worker verdicts. Attempt two uploads, the worker dies before job_done, the sweeper fails the row, and the object sits there with no asset row naming it: the same silent leak #254 removes, through a door it did not cover.

The failing branch collects now, and only when mark_failed reports that it committed. A refusal means the row went terminal or moved to a later attempt while this failure was in flight, and the keys then belong to whoever won.

## The requeue branch is deliberately untouched

It leaves attempt one objects behind, which the success path collects only if the job later succeeds. Collecting at requeue time is not safe on S3: the presigned PUT of the attempt being replaced stays valid for its whole TTL and needs no backend check, so a stale worker can land bytes after the purge, and the If-None-Match guard then keeps them with no collector left. The local backend re-checks against the inflight entry and would be safe. That asymmetry is storage-specific and wants its own issue rather than a guess here. The delegate surfaced this while implementing, and a test pins the current behaviour so a future change to it is deliberate.

## Verified

Five tests, each proved by breaking what it covers. One of them took three attempts to make honest: my first version asserted the refusal guard against a job at attempt one, where requeue_or_fail requeues and never reaches the guard at all, so it passed against a mutation that removed the guard entirely. It now drives the job past its retry first.

make verify green: 329 backend, 141 worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed jobs now reliably reach their final failed state even when upload cleanup encounters an error.
  * Uploads from failed and earlier attempts are cleaned up appropriately.
  * Uploads belonging to replacement attempts are preserved during failure handling.
* **Tests**
  * Added coverage for stalled, disconnected, retried, and cleanup-failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->