### PR TITLE
Do not park the fleet loop on a wedged blob delete

### DIFF
--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1345,7 +1345,10 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             if not committed:
                 return  # a requeue or another verdict owns the row now
             clear_if_current(worker, job_id, current)
-            await purge_attempt_blobs(current.user_id, job_id, current.attempt)
+            schedule_blob_cleanup(
+                purge_attempt_blobs(current.user_id, job_id, current.attempt),
+                what=f"invalid output for job {job_id}",
+            )
             return
         image_dimensions = (image.width, image.height)
         if has_thumbnail:
@@ -1433,16 +1436,10 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         # collects them: the asset row only ever names the winning key.
         for earlier in range(1, current.attempt):
             orphans.extend(storage_keys_for_attempt(current.user_id, job_id, earlier))
-        for orphan in orphans:
-            try:
-                await _bounded_delete(orphan)
-            except Exception as error:
-                # The same leak purge_attempt_blobs had, one function away: the
-                # success path collects the earlier attempts and an unreported
-                # thumbnail, and nothing else ever names those keys.
-                logger.warning("could not remove orphaned blob %s for job %s", orphan,
-                               job_id, exc_info=True)
-                await record_pending_delete(orphan, _trim_error(error))
+        schedule_blob_cleanup(
+            _purge_keys(orphans, job_id),
+            what=f"orphans for job {job_id}",
+        )
         try:
             url = await get_storage().url(current.storage_key)
         except Exception:
@@ -1470,7 +1467,43 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
         clear_if_current(worker, job_id, current)
         # A reported failure can still have uploaded: nothing downstream names
         # those objects, so this is their only collector.
-        await purge_attempt_blobs(current.user_id, job_id, current.attempt)
+        schedule_blob_cleanup(
+            purge_attempt_blobs(current.user_id, job_id, current.attempt),
+            what=f"failed attempt for job {job_id}",
+        )
+
+
+_blob_cleanup_tasks: set[asyncio.Task] = set()
+
+
+def schedule_blob_cleanup(coro, *, what: str) -> None:
+    """Run terminal blob deletes off the fleet reader (issue #313).
+
+    The verdict has already committed. A wedged delete must not park
+    last_seen; pending_deletes remains the backstop if this task fails.
+    """
+    async def guarded() -> None:
+        try:
+            await coro
+        except BaseException:
+            logger.exception("background blob cleanup failed (%s)", what)
+
+    task = asyncio.create_task(guarded())
+    _blob_cleanup_tasks.add(task)
+    task.add_done_callback(_blob_cleanup_tasks.discard)
+
+
+async def _purge_keys(keys: list[str], job_id: uuid.UUID) -> None:
+    for key in keys:
+        try:
+            await _bounded_delete(key)
+        except Exception as error:
+            # The same leak purge_attempt_blobs had, one function away: the
+            # success path collects the earlier attempts and an unreported
+            # thumbnail, and nothing else ever names those keys.
+            logger.warning("could not remove orphaned blob %s for job %s", key,
+                           job_id, exc_info=True)
+            await record_pending_delete(key, _trim_error(error))
 
 
 async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: int) -> None:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -21,6 +21,7 @@ import time
 import unicodedata
 import uuid
 from collections.abc import AsyncIterator
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from itertools import count
@@ -1485,6 +1486,8 @@ def schedule_blob_cleanup(coro, *, what: str) -> None:
     async def guarded() -> None:
         try:
             await coro
+        except asyncio.CancelledError:
+            raise
         except BaseException:
             logger.exception("background blob cleanup failed (%s)", what)
 
@@ -1493,17 +1496,35 @@ def schedule_blob_cleanup(coro, *, what: str) -> None:
     task.add_done_callback(_blob_cleanup_tasks.discard)
 
 
+async def drain_blob_cleanup() -> None:
+    """Cancel leftover deletes while the database can still record them."""
+    tasks = list(_blob_cleanup_tasks)
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        with suppress(asyncio.CancelledError):
+            await task
+
+
 async def _purge_keys(keys: list[str], job_id: uuid.UUID) -> None:
-    for key in keys:
-        try:
-            await _bounded_delete(key)
-        except Exception as error:
-            # The same leak purge_attempt_blobs had, one function away: the
-            # success path collects the earlier attempts and an unreported
-            # thumbnail, and nothing else ever names those keys.
-            logger.warning("could not remove orphaned blob %s for job %s", key,
-                           job_id, exc_info=True)
-            await record_pending_delete(key, _trim_error(error))
+    pending = list(keys)
+    try:
+        while pending:
+            key = pending[0]
+            try:
+                await _bounded_delete(key)
+            except Exception as error:
+                # The same leak purge_attempt_blobs had, one function away: the
+                # success path collects the earlier attempts and an unreported
+                # thumbnail, and nothing else ever names those keys.
+                logger.warning("could not remove blob %s for job %s", key,
+                               job_id, exc_info=True)
+                await record_pending_delete(key, _trim_error(error))
+            pending.pop(0)
+    except asyncio.CancelledError:
+        for key in pending:
+            await asyncio.shield(record_pending_delete(key, "cleanup cancelled"))
+        raise
 
 
 async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: int) -> None:
@@ -1517,17 +1538,12 @@ async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: in
     S3Storage.delete purges every version of the key, not just the current
     one, so this reclaims the storage rather than hiding it.
     """
-    for earlier in range(1, attempt + 1):
-        for key in storage_keys_for_attempt(user_id, job_id, earlier):
-            try:
-                await _bounded_delete(key)
-            except Exception as error:
-                # Warning, not debug: a missing object does not normally make
-                # a delete raise, so this is a real cleanup failure such as a
-                # denied permission, and the sweep is what retries it.
-                logger.warning("could not remove blob %s for job %s", key, job_id,
-                               exc_info=True)
-                await record_pending_delete(key, _trim_error(error))
+    keys = [
+        key
+        for earlier in range(1, attempt + 1)
+        for key in storage_keys_for_attempt(user_id, job_id, earlier)
+    ]
+    await _purge_keys(keys, job_id)
 
 
 async def _bounded_delete(storage_key: str) -> None:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -100,6 +100,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         asyncio.create_task(telemetry_loop()),
     ]
     yield
+    await jobs.drain_blob_cleanup()
     for task in tasks:
         task.cancel()
         with suppress(asyncio.CancelledError):

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1653,11 +1653,21 @@ async def _pending_delete(storage_key: str) -> PendingDelete | None:
         return await session.get(PendingDelete, storage_key)
 
 
-def _await_pending_delete(storage_key: str, timeout=3.0) -> PendingDelete:
+def _await_pending_delete(storage_key: str, timeout=3.0, client=None) -> PendingDelete:
     """The recording happens after the commit that publishes the terminal
-    state, so a test that polled for the state can arrive first."""
+    state, so a test that polled for the state can arrive first.
+
+    Verdict cleanup is a background task (issue #313). asyncio.run from the
+    test thread while that task still holds the engine deadlocks, so a live
+    TestClient must pump the loop until the task set is empty first.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
+        if client is not None:
+            client.get("/api/v1/health")
+            if jobs._blob_cleanup_tasks:
+                time.sleep(0.05)
+                continue
         row = asyncio.run(_pending_delete(storage_key))
         if row is not None:
             return row
@@ -3695,21 +3705,49 @@ def test_a_failed_purge_is_recorded_for_the_sweep(monkeypatch):
                               "reason": "worker said no",
                               "dispatch_token": dispatch["dispatch_token"]})
             poll_until(client, job_id, "failed")
-
-            def recorded() -> PendingDelete | None:
-                return asyncio.run(_pending_delete(key))
-
-            deadline = time.monotonic() + 3
-            while time.monotonic() < deadline and recorded() is None:
-                time.sleep(0.05)
-            row = recorded()
-            assert row is not None, "the failed delete was not recorded"
+            row = _await_pending_delete(key, client=client)
             assert row.storage_key == key
             assert row.attempts == 0  # the sweep owns the counter, not the purge
             assert row.last_error is not None
             assert row.first_failed_at is not None
             assert row.next_attempt_at is not None
             assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "failed"
+
+
+@pytest.mark.db
+def test_a_hung_delete_does_not_delay_the_verdict(monkeypatch):
+    """A wedged mount must not park the fleet reader on the terminal path.
+
+    last_seen only advances when the fleet loop processes a message, so an
+    awaited 60 s delete makes a live worker look dead (issue #313).
+    """
+    hang = threading.Event()
+
+    async def hung_delete(storage_key):
+        while not hang.is_set():
+            await asyncio.sleep(0.05)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-hung-delete")
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "hang"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            # Patch after startup so maintain_deletes_loop's first pass
+            # cannot sit on this hang for the life of the client.
+            monkeypatch.setattr(jobs, "_bounded_delete", hung_delete)
+            started = time.monotonic()
+            worker.send_json({"type": "job_failed", "job_id": job_id,
+                              "reason": "worker said no",
+                              "dispatch_token": dispatch["dispatch_token"]})
+            poll_until(client, job_id, "failed", timeout=1.0)
+            assert time.monotonic() - started < 1.0
+            hang.set()
+            for task in list(jobs._blob_cleanup_tasks):
+                task.cancel()
+            client.get("/api/v1/health")
 
 
 @pytest.mark.db
@@ -3758,7 +3796,7 @@ def test_a_failed_verdictless_collection_is_recorded_for_the_sweep(monkeypatch):
                 asyncio.run(jobs.sweep_stalled_jobs())
                 poll_until(client, job_id, "failed")
 
-                row = _await_pending_delete(second_key)
+                row = _await_pending_delete(second_key, client=client)
                 assert row.attempts == 0  # the sweep owns the counter, not the purge
                 assert row.last_error is not None
                 assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "failed"
@@ -3804,7 +3842,7 @@ def test_a_failed_orphan_delete_on_the_success_path_is_recorded(monkeypatch):
                               "gpu_ms": 1, "width": 512, "height": 512})
             poll_until(client, job_id, "succeeded")
 
-            row = _await_pending_delete(thumb_key)
+            row = _await_pending_delete(thumb_key, client=client)
             assert "denied" in (row.last_error or "")
 
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -3751,6 +3751,40 @@ def test_a_hung_delete_does_not_delay_the_verdict(monkeypatch):
 
 
 @pytest.mark.db
+def test_a_cancelled_cleanup_is_recorded_for_the_sweep(monkeypatch):
+    """Shutdown cancel must not drop remaining keys: pending_deletes is the
+    backstop (issue #313 follow-up)."""
+    hang = threading.Event()
+
+    async def hung_delete(storage_key):
+        while not hang.is_set():
+            await asyncio.sleep(0.05)
+
+    with TestClient(app) as client:
+        with client.websocket_connect("/api/v1/fleet") as worker:
+            fleet_hello(worker, "w-cancel-cleanup")
+            asyncio.run(_clear_pending_deletes())
+            job_id = client.post(
+                "/api/v1/generations",
+                json={"model_id": "sd-test", "params": {"prompt": "cancel"}},
+            ).json()["job_id"]
+            dispatch = dispatch_for(worker, job_id)
+            key = urlsplit(dispatch["upload"]["url"]).path.rsplit(
+                "/api/v1/files/", 1)[-1]
+            monkeypatch.setattr(jobs, "_bounded_delete", hung_delete)
+            worker.send_json({"type": "job_failed", "job_id": job_id,
+                              "reason": "worker said no",
+                              "dispatch_token": dispatch["dispatch_token"]})
+            poll_until(client, job_id, "failed", timeout=1.0)
+            for task in list(jobs._blob_cleanup_tasks):
+                task.cancel()
+            hang.set()
+            row = _await_pending_delete(key, client=client)
+            assert row.storage_key == key
+            assert row.last_error == "cleanup cancelled"
+
+
+@pytest.mark.db
 def test_a_failed_verdictless_collection_is_recorded_for_the_sweep(monkeypatch):
     """A delete that fails during requeue_or_fail's collection leaves a
     pending_deletes row naming that key, exactly as the verdict paths do, and


### PR DESCRIPTION
Closes #313.

After the terminal commit and `clear_if_current`, blob deletes from the verdict path run in a background task with a top-level exception guard. `pending_deletes` remains the backstop. `requeue_or_fail` still awaits purge, because that path is not the fleet loop.

A hung delete no longer delays the fleet `last_seen` path. Tests that already poll a recording still pass: they pump `/api/v1/health` until the cleanup tasks drain, instead of `asyncio.run` against a live engine.

Protocol stays 3. No change to `dispatch_for`.

## Verified

`backend/tests/test_jobs.py`: 89 passed. `make verify` green in the worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Job verdicts are now returned without waiting for blob cleanup operations to finish.

- **Reliability**
  - Cleanup continues asynchronously for successful, failed, and invalid job attempts.
  - Cleanup failures are tracked and logged without interrupting verdict processing.
  - Pending deletions are recorded consistently, including orphaned data cleanup.
  - Cleanup tasks are completed or safely recorded for retry during application shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
