### PR TITLE
Spend canvas search pages only on a real request

### DIFF
--- a/frontend/src/lib/components/lineage-canvas.svelte
+++ b/frontend/src/lib/components/lineage-canvas.svelte
@@ -60,6 +60,7 @@
 		retainedLineageTreeOffsets,
 		retainedRetryBudget,
 		settleLineageRootStarReconciliation,
+		shouldSpendAnchorSearchPage,
 		type InitialLineageViewportAnchor,
 		type LineageRootStarReconciliation
 	} from '$lib/lineage-canvas-state';
@@ -1009,11 +1010,18 @@
 		// revisits it, so wait: the observer calls back here once it has one.
 		if (viewportWidth === 0 || viewportHeight === 0) return;
 		if (
-			restoredViewport?.rootId &&
-			!persistedRoots.some((root) => root.id === restoredViewport.rootId) &&
-			rootsHaveMore &&
-			anchorSearchPages < MAX_ANCHOR_SEARCH_PAGES &&
-			!rootsFailed
+			shouldSpendAnchorSearchPage({
+				viewportReady,
+				rootsHaveMore,
+				rootsFailed,
+				rootsLoading,
+				pagesUsed: anchorSearchPages,
+				maxPages: MAX_ANCHOR_SEARCH_PAGES,
+				missingAnchor: Boolean(
+					restoredViewport?.rootId &&
+					!persistedRoots.some((root) => root.id === restoredViewport.rootId)
+				)
+			})
 		) {
 			anchorSearchPages += 1;
 			void loadRoots();

--- a/frontend/src/lib/lineage-canvas-state.test.ts
+++ b/frontend/src/lib/lineage-canvas-state.test.ts
@@ -10,6 +10,7 @@ import {
 	decideViewportScheduleAfterRootPage,
 	lineageTreeOmittedHistoryJobIds,
 	lineageTreeNeedsHistoryRefresh,
+	shouldSpendAnchorSearchPage,
 	retainedLineageTreeOffsets,
 	retainedRetryBudget,
 	rebaseLineageViewport,
@@ -464,4 +465,23 @@ test('a persistently failing subtree retries once, not forever', () => {
 	// new request and earns its own single retry.
 	attemptLoad(true);
 	assert.equal(decideLineageTreeLoad(true, entry), 'retry');
+});
+
+test('anchor search spends a page only when loadRoots would start work', () => {
+	const ready = {
+		viewportReady: false,
+		rootsHaveMore: true,
+		rootsFailed: false,
+		rootsLoading: false,
+		pagesUsed: 0,
+		maxPages: 4,
+		missingAnchor: true
+	};
+	assert.equal(shouldSpendAnchorSearchPage(ready), true);
+	assert.equal(shouldSpendAnchorSearchPage({ ...ready, rootsLoading: true }), false);
+	assert.equal(shouldSpendAnchorSearchPage({ ...ready, viewportReady: true }), false);
+	assert.equal(shouldSpendAnchorSearchPage({ ...ready, missingAnchor: false }), false);
+	assert.equal(shouldSpendAnchorSearchPage({ ...ready, rootsHaveMore: false }), false);
+	assert.equal(shouldSpendAnchorSearchPage({ ...ready, rootsFailed: true }), false);
+	assert.equal(shouldSpendAnchorSearchPage({ ...ready, pagesUsed: 4 }), false);
 });

--- a/frontend/src/lib/lineage-canvas-state.ts
+++ b/frontend/src/lib/lineage-canvas-state.ts
@@ -266,6 +266,28 @@ export function lineageTreeNeedsHistoryRefresh(
 	return false;
 }
 
+export function shouldSpendAnchorSearchPage(args: {
+	viewportReady: boolean;
+	rootsHaveMore: boolean;
+	rootsFailed: boolean;
+	rootsLoading: boolean;
+	pagesUsed: number;
+	maxPages: number;
+	missingAnchor: boolean;
+}): boolean {
+	// True only when initializeViewport would start a roots request. loadRoots
+	// no-ops while a page is in flight, so spending the allowance then burns
+	// one of four searches without a request (issue #303).
+	return (
+		!args.viewportReady &&
+		args.missingAnchor &&
+		args.rootsHaveMore &&
+		!args.rootsFailed &&
+		!args.rootsLoading &&
+		args.pagesUsed < args.maxPages
+	);
+}
+
 export function lineageTreeOmittedHistoryJobIds(
 	nodes: CachedNode[],
 	history: Generation[]

--- a/worker/models/sdxl-base.json
+++ b/worker/models/sdxl-base.json
@@ -50,7 +50,7 @@
       },
       "strength": {
         "type": "number",
-        "minimum": 0.05,
+        "minimum": 0.1,
         "maximum": 1,
         "default": 0.75
       }

--- a/worker/models/vega-rt.json
+++ b/worker/models/vega-rt.json
@@ -24,7 +24,7 @@
       },
       "strength": {
         "type": "number",
-        "minimum": 0.05,
+        "minimum": 0.1,
         "maximum": 1,
         "default": 0.7
       },


### PR DESCRIPTION
Closes #303. Closes #302.

`initializeViewport` spends an `anchorSearchPages` allowance only when `loadRoots` actually starts work. A viewport that is already loading, or that has nothing to fetch, does not burn a page.

`sdxl-base` and `vega-rt` now declare `strength.minimum` 0.1, matching the studio slider. `inferStep` is unchanged. `sdxl-turbo` is unchanged.

## Verified

Frontend lint, check, 62 tests, and build green. Worker manifest tests cover the two minima.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lineage canvas anchor search to load additional results only when needed, while respecting loading, failure, and page limits.
  * Added coverage for anchor-search pagination conditions.

* **Model Settings**
  * Increased the minimum allowed strength value for select image-generation models from 0.05 to 0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
