### PR TITLE
Keep the favorites list when no star resolves

### DIFF
--- a/frontend/src/lib/favorites-migration.test.ts
+++ b/frontend/src/lib/favorites-migration.test.ts
@@ -1,48 +1,92 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { planFavoriteMigration, type StarOutcome } from './favorites-migration.ts';
+import { runFavoriteMigration } from './favorites-migration.ts';
 
-const plan = (...outcomes: Array<readonly [string, StarOutcome]>) =>
-	planFavoriteMigration(outcomes);
+const ID_A = '11111111-1111-1111-1111-111111111111';
+const ID_B = '22222222-2222-2222-2222-222222222222';
+const ID_C = '33333333-3333-3333-3333-333333333333';
 
-test('a run where everything migrated retries nothing', () => {
-	const result = plan(['a', 'migrated'], ['b', 'migrated']);
+const answering = (byId: Record<string, number | null>) => {
+	const asked: string[] = [];
+	const star = async (id: string) => {
+		asked.push(id);
+		return byId[id] ?? null;
+	};
+	return { asked, star };
+};
+
+test('a run where every star returns 204 retries nothing', async () => {
+	const { star } = answering({ [ID_A]: 204, [ID_B]: 204 });
+	const result = await runFavoriteMigration([ID_A, ID_B], star);
 	assert.deepEqual(result.retry, []);
 	assert.equal(result.missing, 0);
 });
 
-test('an id that was never a job id is dropped and counted missing', () => {
-	const result = plan(['a', 'migrated'], ['not-a-uuid', 'invalid']);
+test('an id that was never a job id is dropped, counted missing, and never sent', async () => {
+	const { asked, star } = answering({ [ID_A]: 204 });
+	const result = await runFavoriteMigration([ID_A, 'not-a-uuid'], star);
 	assert.deepEqual(result.retry, []);
+	assert.equal(result.missing, 1);
+	assert.deepEqual(asked, [ID_A]);
+});
+
+test('an invalid id is counted missing even when nothing else migrated', async () => {
+	const { star } = answering({ [ID_A]: 404 });
+	const result = await runFavoriteMigration([ID_A, 'not-a-uuid'], star);
+	assert.deepEqual(result.retry, [ID_A]);
 	assert.equal(result.missing, 1);
 });
 
-test('every id answering 404 retries the whole list instead of discarding it', () => {
-	const result = plan(['a', 'not-found'], ['b', 'not-found'], ['c', 'not-found']);
-	assert.deepEqual(result.retry, ['a', 'b', 'c']);
+test('every id answering 404 retries the whole list instead of discarding it', async () => {
+	const { star } = answering({ [ID_A]: 404, [ID_B]: 404, [ID_C]: 404 });
+	const result = await runFavoriteMigration([ID_A, ID_B, ID_C], star);
+	assert.deepEqual(result.retry, [ID_A, ID_B, ID_C]);
 	assert.equal(result.missing, 0);
 });
 
-test('a 404 alongside a migrated sibling is counted missing, not retried', () => {
-	const result = plan(['a', 'migrated'], ['b', 'not-found']);
+test('a 404 beside a migrated sibling is still retried, never counted missing', async () => {
+	const { star } = answering({ [ID_A]: 204, [ID_B]: 404 });
+	const result = await runFavoriteMigration([ID_A, ID_B], star);
+	assert.deepEqual(result.retry, [ID_B]);
+	assert.equal(result.missing, 0);
+});
+
+test('a 404 beside an unanswered request is retried, whatever the order', async () => {
+	const { star } = answering({ [ID_A]: 404, [ID_B]: null });
+	assert.deepEqual((await runFavoriteMigration([ID_A, ID_B], star)).retry, [ID_A, ID_B]);
+	assert.deepEqual((await runFavoriteMigration([ID_B, ID_A], star)).retry, [ID_B, ID_A]);
+});
+
+test('an unanswered request is retried and never counted missing', async () => {
+	const { star } = answering({ [ID_A]: null });
+	const result = await runFavoriteMigration([ID_A], star);
+	assert.deepEqual(result.retry, [ID_A]);
+	assert.equal(result.missing, 0);
+});
+
+test('only 204 counts as migrated, so a proxy 200 is retried rather than dropped', async () => {
+	const { star } = answering({ [ID_A]: 200 });
+	const result = await runFavoriteMigration([ID_A], star);
+	assert.deepEqual(result.retry, [ID_A]);
+	assert.equal(result.missing, 0);
+});
+
+test('a 403 is retried rather than dropped', async () => {
+	const { star } = answering({ [ID_A]: 403 });
+	assert.deepEqual((await runFavoriteMigration([ID_A], star)).retry, [ID_A]);
+});
+
+test('a migrated id is never retried, so unstarring it survives a reload', async () => {
+	const { star } = answering({ [ID_A]: 204, [ID_B]: null });
+	const result = await runFavoriteMigration([ID_A, ID_B], star);
+	assert.deepEqual(result.retry, [ID_B]);
+});
+
+test('an empty run asks nothing and retries nothing', async () => {
+	const { asked, star } = answering({});
+	const result = await runFavoriteMigration([], star);
 	assert.deepEqual(result.retry, []);
-	assert.equal(result.missing, 1);
-});
-
-test('an unanswered request is retried and never counted missing', () => {
-	const result = plan(['a', 'failed']);
-	assert.deepEqual(result.retry, ['a']);
 	assert.equal(result.missing, 0);
-});
-
-test('a migrated id is never retried, so unstarring it survives a reload', () => {
-	const result = plan(['a', 'migrated'], ['b', 'failed']);
-	assert.deepEqual(result.retry, ['b']);
-});
-
-test('an empty run retries nothing', () => {
-	const result = plan();
-	assert.deepEqual(result.retry, []);
-	assert.equal(result.missing, 0);
+	assert.deepEqual(asked, []);
 });

--- a/frontend/src/lib/favorites-migration.test.ts
+++ b/frontend/src/lib/favorites-migration.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { planFavoriteMigration, type StarOutcome } from './favorites-migration.ts';
+
+const plan = (...outcomes: Array<readonly [string, StarOutcome]>) =>
+	planFavoriteMigration(outcomes);
+
+test('a run where everything migrated retries nothing', () => {
+	const result = plan(['a', 'migrated'], ['b', 'migrated']);
+	assert.deepEqual(result.retry, []);
+	assert.equal(result.missing, 0);
+});
+
+test('an id that was never a job id is dropped and counted missing', () => {
+	const result = plan(['a', 'migrated'], ['not-a-uuid', 'invalid']);
+	assert.deepEqual(result.retry, []);
+	assert.equal(result.missing, 1);
+});
+
+test('every id answering 404 retries the whole list instead of discarding it', () => {
+	const result = plan(['a', 'not-found'], ['b', 'not-found'], ['c', 'not-found']);
+	assert.deepEqual(result.retry, ['a', 'b', 'c']);
+	assert.equal(result.missing, 0);
+});
+
+test('a 404 alongside a migrated sibling is counted missing, not retried', () => {
+	const result = plan(['a', 'migrated'], ['b', 'not-found']);
+	assert.deepEqual(result.retry, []);
+	assert.equal(result.missing, 1);
+});
+
+test('an unanswered request is retried and never counted missing', () => {
+	const result = plan(['a', 'failed']);
+	assert.deepEqual(result.retry, ['a']);
+	assert.equal(result.missing, 0);
+});
+
+test('a migrated id is never retried, so unstarring it survives a reload', () => {
+	const result = plan(['a', 'migrated'], ['b', 'failed']);
+	assert.deepEqual(result.retry, ['b']);
+});
+
+test('an empty run retries nothing', () => {
+	const result = plan();
+	assert.deepEqual(result.retry, []);
+	assert.equal(result.missing, 0);
+});

--- a/frontend/src/lib/favorites-migration.ts
+++ b/frontend/src/lib/favorites-migration.ts
@@ -1,18 +1,18 @@
-export type StarOutcome = 'migrated' | 'not-found' | 'failed' | 'invalid';
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const STARRED_STATUS = 204;
 
-export function planFavoriteMigration(outcomes: ReadonlyArray<readonly [string, StarOutcome]>): {
-	retry: string[];
-	missing: number;
-} {
-	const databaseIsPopulated = outcomes.some(([, outcome]) => outcome === 'migrated');
+export async function runFavoriteMigration(
+	stored: readonly string[],
+	star: (id: string) => Promise<number | null>
+): Promise<{ retry: string[]; missing: number }> {
 	const retry: string[] = [];
 	let missing = 0;
-	for (const [id, outcome] of outcomes) {
-		if (outcome === 'migrated') continue;
-		if (outcome === 'invalid') missing += 1;
-		else if (outcome === 'failed') retry.push(id);
-		else if (databaseIsPopulated) missing += 1;
-		else retry.push(id);
+	for (const id of stored) {
+		if (!UUID_PATTERN.test(id)) {
+			missing += 1;
+			continue;
+		}
+		if ((await star(id)) !== STARRED_STATUS) retry.push(id);
 	}
 	return { retry, missing };
 }

--- a/frontend/src/lib/favorites-migration.ts
+++ b/frontend/src/lib/favorites-migration.ts
@@ -1,0 +1,18 @@
+export type StarOutcome = 'migrated' | 'not-found' | 'failed' | 'invalid';
+
+export function planFavoriteMigration(outcomes: ReadonlyArray<readonly [string, StarOutcome]>): {
+	retry: string[];
+	missing: number;
+} {
+	const databaseIsPopulated = outcomes.some(([, outcome]) => outcome === 'migrated');
+	const retry: string[] = [];
+	let missing = 0;
+	for (const [id, outcome] of outcomes) {
+		if (outcome === 'migrated') continue;
+		if (outcome === 'invalid') missing += 1;
+		else if (outcome === 'failed') retry.push(id);
+		else if (databaseIsPopulated) missing += 1;
+		else retry.push(id);
+	}
+	return { retry, missing };
+}

--- a/frontend/src/lib/i18n/en.json
+++ b/frontend/src/lib/i18n/en.json
@@ -333,6 +333,7 @@
 	"app.gen.star": "Star",
 	"app.gen.unstar": "Unstar",
 	"app.gen.favorite_missing": "{count} saved favorite(s) no longer exist.",
+	"app.gen.favorite_unrestored": "{count} saved favorite(s) could not be restored.",
 	"app.gen.favorite_expired": "An expired favorite is gone because favorites do not extend retention.",
 	"app.gen.favorite_save_failed": "The favorite could not be saved.",
 	"app.update.available": "A new version is available.",

--- a/frontend/src/lib/i18n/es.json
+++ b/frontend/src/lib/i18n/es.json
@@ -333,6 +333,7 @@
 	"app.gen.star": "Destacar",
 	"app.gen.unstar": "Quitar destacado",
 	"app.gen.favorite_missing": "Ya no existen {count} favoritos guardados.",
+	"app.gen.favorite_unrestored": "No se pudieron restaurar {count} favoritos guardados.",
 	"app.gen.favorite_expired": "Un favorito caducado ya no est\u00e1 porque los favoritos no ampl\u00edan la retenci\u00f3n.",
 	"app.gen.favorite_save_failed": "No se pudo guardar el favorito.",
 	"app.update.available": "Hay una versión nueva disponible.",

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -1,6 +1,7 @@
 // Shared studio state: the sidebar (model list, gallery) and the generate
 // panel look at the same registry and history.
 
+import { planFavoriteMigration, type StarOutcome } from '$lib/favorites-migration';
 import { t } from '$lib/i18n.svelte';
 import {
 	beginOptimisticStarMutation,
@@ -484,25 +485,24 @@ const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 export async function migrateStoredFavorites(): Promise<void> {
 	const stored = loadStarredIds();
 	if (stored.length === 0 || typeof localStorage === 'undefined') return;
-	// A value that was never a job id can never resolve, so count it as missing
-	// rather than letting its 422 hold the migration open forever.
-	let missing = stored.filter((id) => !UUID_PATTERN.test(id)).length;
-	let complete = true;
-	for (const id of stored.filter((value) => UUID_PATTERN.test(value))) {
+	const outcomes: Array<readonly [string, StarOutcome]> = [];
+	for (const id of stored) {
+		if (!UUID_PATTERN.test(id)) {
+			outcomes.push([id, 'invalid']);
+			continue;
+		}
 		try {
-			// Star directly: the endpoint's own 404 already reports an id that no
-			// longer resolves, so a preceding GET would only double the requests.
 			const starred = await fetch(`/api/v1/generations/${id}/star`, { method: 'POST' });
-			if (starred.status === 404) {
-				missing += 1;
-			} else if (!starred.ok) {
-				complete = false;
-			}
+			if (starred.ok) outcomes.push([id, 'migrated']);
+			else if (starred.status === 404) outcomes.push([id, 'not-found']);
+			else outcomes.push([id, 'failed']);
 		} catch {
-			complete = false;
+			outcomes.push([id, 'failed']);
 		}
 	}
-	if (complete) localStorage.removeItem(STARRED_STORAGE_KEY);
+	const { retry, missing } = planFavoriteMigration(outcomes);
+	if (retry.length === 0) localStorage.removeItem(STARRED_STORAGE_KEY);
+	else localStorage.setItem(STARRED_STORAGE_KEY, JSON.stringify(retry));
 	if (missing > 0) {
 		setFavoriteNotice(
 			'migration',

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -1,7 +1,7 @@
 // Shared studio state: the sidebar (model list, gallery) and the generate
 // panel look at the same registry and history.
 
-import { planFavoriteMigration, type StarOutcome } from '$lib/favorites-migration';
+import { runFavoriteMigration } from '$lib/favorites-migration';
 import { t } from '$lib/i18n.svelte';
 import {
 	beginOptimisticStarMutation,
@@ -480,30 +480,24 @@ export async function loadModels(): Promise<void> {
 	}
 }
 
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
 export async function migrateStoredFavorites(): Promise<void> {
 	const stored = loadStarredIds();
 	if (stored.length === 0 || typeof localStorage === 'undefined') return;
-	const outcomes: Array<readonly [string, StarOutcome]> = [];
-	for (const id of stored) {
-		if (!UUID_PATTERN.test(id)) {
-			outcomes.push([id, 'invalid']);
-			continue;
-		}
+	const { retry, missing } = await runFavoriteMigration(stored, async (id) => {
 		try {
-			const starred = await fetch(`/api/v1/generations/${id}/star`, { method: 'POST' });
-			if (starred.ok) outcomes.push([id, 'migrated']);
-			else if (starred.status === 404) outcomes.push([id, 'not-found']);
-			else outcomes.push([id, 'failed']);
+			return (await fetch(`/api/v1/generations/${id}/star`, { method: 'POST' })).status;
 		} catch {
-			outcomes.push([id, 'failed']);
+			return null;
 		}
-	}
-	const { retry, missing } = planFavoriteMigration(outcomes);
+	});
 	if (retry.length === 0) localStorage.removeItem(STARRED_STORAGE_KEY);
 	else localStorage.setItem(STARRED_STORAGE_KEY, JSON.stringify(retry));
-	if (missing > 0) {
+	if (retry.length > 0) {
+		setFavoriteNotice(
+			'migration',
+			t('app.gen.favorite_unrestored').replace('{count}', String(retry.length))
+		);
+	} else if (missing > 0) {
 		setFavoriteNotice(
 			'migration',
 			t('app.gen.favorite_missing').replace('{count}', String(missing))

--- a/frontend/src/lib/studio.svelte.ts
+++ b/frontend/src/lib/studio.svelte.ts
@@ -492,17 +492,14 @@ export async function migrateStoredFavorites(): Promise<void> {
 	});
 	if (retry.length === 0) localStorage.removeItem(STARRED_STORAGE_KEY);
 	else localStorage.setItem(STARRED_STORAGE_KEY, JSON.stringify(retry));
+	const notices: string[] = [];
 	if (retry.length > 0) {
-		setFavoriteNotice(
-			'migration',
-			t('app.gen.favorite_unrestored').replace('{count}', String(retry.length))
-		);
-	} else if (missing > 0) {
-		setFavoriteNotice(
-			'migration',
-			t('app.gen.favorite_missing').replace('{count}', String(missing))
-		);
+		notices.push(t('app.gen.favorite_unrestored').replace('{count}', String(retry.length)));
 	}
+	if (missing > 0) {
+		notices.push(t('app.gen.favorite_missing').replace('{count}', String(missing)));
+	}
+	setFavoriteNotice('migration', notices.length > 0 ? notices.join(' ') : null);
 }
 
 export async function loadHistory(): Promise<void> {


### PR DESCRIPTION
# Description

The one-shot migration that moves favorites out of browser localStorage into
PostgreSQL removed the stored list whenever every star it tried returned 404. A
404 left `complete` true, so a run in which nothing resolved still counted as a
success and erased the key. That list is the only record of those favorites, so
the removal could not be undone.

# Motivation

A 404 only proves the id is absent from the database the studio reached. It does
not prove the generation is gone. An API pointed at an empty, fresh, or foreign
database answers 404 for ids that are alive elsewhere.

This is not hypothetical. Before #262 every git worktree shared one database but
kept its own `data/` directory, so a studio on the usual port could reach an API
backed by a different database. On a real install all six stored favorites
404'd, the migration declared itself complete, and the list was erased. They were
recovered only because the ids happened to have been exported to a file by hand.

The migration runs once per browser and destroys its own input. There is no
second chance.

# Functionality

Nothing is discarded until it has migrated or is provably unusable.

- An id that migrated drops out, so a favorite the user removes later is not
  resurrected on the next load.
- An id that was never a UUID is dropped and counted missing, unchanged.
- An id whose request failed is retried on the next load, unchanged.
- An id that returned 404 is retried too, unless a sibling in the same pass
  migrated. One success proves the database is the right populated one, and only
  then is the absence final.

Whatever remains is written back instead of the key being removed, so the
migration self-heals: an install pointed at the wrong database recovers its
favorites on the next load against the right one.

# Details

The rule lives in `frontend/src/lib/favorites-migration.ts` as a pure function so
`node --test` can check it without the Svelte compiler, matching
`prompt-tokens.ts` and `lineage-layout.ts`. Seven cases cover it, including the
all-404 case that caused the loss; that test fails if the old "a 404 is always
final" behaviour is restored.

No new i18n keys. The "no longer exist" notice keeps its meaning: it counts ids
that are provably gone, and a retried 404 is not one of those.

`make verify-frontend` passes (69 tests, lint, check, build). `make verify` also
reports 3 pre-existing failures in `backend/tests/test_jobs.py`
(`test_a_hung_delete_does_not_delay_the_verdict`,
`test_a_cancelled_cleanup_is_recorded_for_the_sweep`, and a flaky
`test_a_stale_dispatch_token_cannot_speak_for_the_current_attempt`). They
reproduce on `main` with this branch stashed and are untouched by this change,
which is frontend only.

Closes #336


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved favorite migration handling for invalid, missing, and failed items.
  * Automatically retries favorites that could not be restored.
  * Reports how many favorites could not be restored or were missing.
  * Removes saved favorite data when no retries remain.
  * Added migration notices in English and Spanish.

* **Tests**
  * Added coverage for successful migrations, retries, missing items, failed requests, invalid IDs, mixed outcomes, and empty inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update after review (kimi-k3-max, two independent passes)

Copilot is out of quota, so the branch went to `kimi-k3-max` for an adversarial
read-only review. Both passes agreed on the substance. Three findings were acted
on; the diff is now smaller than the first cut.

**A 404 is no longer final under any condition.** The first cut dropped a 404
when a sibling in the same pass had migrated, on the theory that one success
proves the database is the right one. It proves less: `owned_job`
(`backend/app/jobs.py:469-473`) returns 404 for a job owned by another account,
not only for a missing one, and two databases cloned from one split share their
pre-split ids. In both topologies the rule counted live favorites as gone and
deleted the only record of them, which is the failure this branch exists to
remove. Removing the heuristic also removed the code that implemented it.

**Only 204 counts as migrated.** The endpoint returns exactly
`Response(status_code=204)` (`backend/app/jobs.py:1006-1013`), so the previous
`response.ok` additionally accepted any 2xx. A proxy or login page answering the
POST with 200 would have marked the id migrated and dropped it: the original bug
through a different door.

**An unrestorable id now says so.** Retrying without a notice left the user with
no favorites and no explanation on every load, which looks exactly like the bug
being fixed. `app.gen.favorite_unrestored` covers that state.
`app.gen.favorite_missing` keeps its wording and now fires only for values that
were never job ids, where "no longer exist" is accurate.

**The status mapping is now covered.** It previously lived in
`studio.svelte.ts`, which `node --test` cannot import, so mapping 404 to
`migrated` would have restored the original bug with every test still green. The
star request now goes through an injected callback. Eleven cases pin the rule,
and each guarantee has a mutation that breaks it: reverting the 404 rule fails 4
tests, accepting any 2xx fails 1, retrying invalid ids fails 2.

### Reviewer claim that did not hold

Both passes asserted there is no job-deletion path, and used it to argue a 404
can only ever mean wrong database. `scripts/cleanup-failed-jobs.py:30` deletes
`Job` rows via `make cleanup-failed`, and operator pruning does the same, so a
404 can be a real deletion. That weakens the argument but not the decision:
losing data is worse than a persistent notice, so a genuinely deleted favorite
now nags until the user clears it rather than being silently dropped.

### Known limitation, accepted

The list no longer drains while any id stays unresolved, so an unreachable or
wrong database costs N sequential POSTs per app load. N is the size of a legacy
favorites list. The notice now makes the state visible instead of silent.

`make verify-frontend` passes: 73 tests, lint, check, build.