### PR TITLE
Run CI jobs in parallel on four self-hosted runners

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -20,6 +20,9 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-host-ports
+
 jobs:
   backend:
     # Self-hosted on the reference desktop when GitHub-hosted minutes are exhausted.

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-host-ports
+
 jobs:
   simulation:
     # Self-hosted: docs/self-hosted-runner.md

--- a/Makefile
+++ b/Makefile
@@ -304,32 +304,48 @@ stack-restart: dev-restart ## alias for dev-restart
 # GitHub Actions self-hosted runner (docs/self-hosted-runner.md). Requires Docker
 # for the backend workflow postgres service. Uses gh to fetch registration tokens.
 CI_RUNNER_DIR ?= $(HOME)/.local/share/potocolom-actions-runner
+CI_RUNNERS ?= 4
+CI_RUNNER_DIRS = $(CI_RUNNER_DIR) $(foreach n,$(shell seq 2 $(CI_RUNNERS)),$(CI_RUNNER_DIR)-$(n))
 
-ci-runner-install: ## register the self-hosted Actions runner (once)
-	@RUNNER_INSTALL_DIR="$(CI_RUNNER_DIR)" bash "$(CURDIR)/scripts/install-actions-runner.sh"
+ci-runner-install: ## register CI_RUNNERS self-hosted Actions runners (once)
+	@i=0; for dir in $(CI_RUNNER_DIRS); do \
+		i=$$((i+1)); \
+		name="$$(hostname -s)-potocolom"; \
+		[ $$i -gt 1 ] && name="$$name-$$i"; \
+		RUNNER_INSTALL_DIR="$$dir" RUNNER_NAME="$$name" \
+			bash "$(CURDIR)/scripts/install-actions-runner.sh" || exit 1; \
+	done
 	@echo "Next: make ci-runner-service-install && make ci-runner-start"
 
-ci-runner-service-install: ## install runner as a systemd service (sudo, once)
-	@test -f "$(CI_RUNNER_DIR)/svc.sh" || { echo "run make ci-runner-install first" >&2; exit 1; }
-	@cd "$(CI_RUNNER_DIR)" && sudo ./svc.sh install
+ci-runner-service-install: ## install the runners as systemd services (sudo, once)
+	@for dir in $(CI_RUNNER_DIRS); do \
+		test -f "$$dir/svc.sh" || { echo "run make ci-runner-install first" >&2; exit 1; }; \
+		(cd "$$dir" && sudo ./svc.sh install) || exit 1; \
+	done
 
-ci-runner-start: ## start the self-hosted CI runner (systemd)
-	@test -f "$(CI_RUNNER_DIR)/svc.sh" || { echo "run make ci-runner-install first" >&2; exit 1; }
-	@cd "$(CI_RUNNER_DIR)" && sudo ./svc.sh start
-	@cd "$(CI_RUNNER_DIR)" && sudo ./svc.sh status
+ci-runner-start: ## start the self-hosted CI runners (systemd)
+	@for dir in $(CI_RUNNER_DIRS); do \
+		test -f "$$dir/svc.sh" || { echo "run make ci-runner-install first" >&2; exit 1; }; \
+		(cd "$$dir" && sudo ./svc.sh start) || exit 1; \
+	done
+	@$(MAKE) --no-print-directory ci-runner-status
 
-ci-runner-stop: ## stop the self-hosted CI runner
-	@test -f "$(CI_RUNNER_DIR)/svc.sh" || exit 0
-	@cd "$(CI_RUNNER_DIR)" && sudo ./svc.sh stop
+ci-runner-stop: ## stop the self-hosted CI runners
+	@for dir in $(CI_RUNNER_DIRS); do \
+		test -f "$$dir/svc.sh" || continue; \
+		(cd "$$dir" && sudo ./svc.sh stop) || exit 1; \
+	done
 
-ci-runner-restart: ci-runner-stop ci-runner-start ## restart the self-hosted CI runner
+ci-runner-restart: ci-runner-stop ci-runner-start ## restart the self-hosted CI runners
 
 ci-runner-status: ## show self-hosted runner service status
-	@if [ -f "$(CI_RUNNER_DIR)/svc.sh" ]; then \
-		cd "$(CI_RUNNER_DIR)" && sudo ./svc.sh status; \
-	else \
-		echo "runner not installed ($(CI_RUNNER_DIR))"; \
-	fi
+	@for dir in $(CI_RUNNER_DIRS); do \
+		if [ -f "$$dir/svc.sh" ]; then \
+			(cd "$$dir" && sudo ./svc.sh status); \
+		else \
+			echo "runner not installed ($$dir)"; \
+		fi; \
+	done
 
 cleanup-failed: dev-db ## remove failed generation jobs from the database
 	backend/.venv/bin/python scripts/cleanup-failed-jobs.py

--- a/Makefile
+++ b/Makefile
@@ -320,19 +320,23 @@ ci-runner-install: ## register CI_RUNNERS self-hosted Actions runners (once)
 ci-runner-service-install: ## install the runners as systemd services (sudo, once)
 	@for dir in $(CI_RUNNER_DIRS); do \
 		test -f "$$dir/svc.sh" || { echo "run make ci-runner-install first" >&2; exit 1; }; \
+		if [ -f "$$dir/.service" ]; then \
+			echo "service already installed for $$dir, skipping"; \
+			continue; \
+		fi; \
 		(cd "$$dir" && sudo ./svc.sh install) || exit 1; \
 	done
 
 ci-runner-start: ## start the self-hosted CI runners (systemd)
 	@for dir in $(CI_RUNNER_DIRS); do \
-		test -f "$$dir/svc.sh" || { echo "run make ci-runner-install first" >&2; exit 1; }; \
+		test -f "$$dir/.service" || { echo "run make ci-runner-service-install first" >&2; exit 1; }; \
 		(cd "$$dir" && sudo ./svc.sh start) || exit 1; \
 	done
 	@$(MAKE) --no-print-directory ci-runner-status
 
 ci-runner-stop: ## stop the self-hosted CI runners
 	@for dir in $(CI_RUNNER_DIRS); do \
-		test -f "$$dir/svc.sh" || continue; \
+		test -f "$$dir/.service" || continue; \
 		(cd "$$dir" && sudo ./svc.sh stop) || exit 1; \
 	done
 
@@ -340,10 +344,10 @@ ci-runner-restart: ci-runner-stop ci-runner-start ## restart the self-hosted CI 
 
 ci-runner-status: ## show self-hosted runner service status
 	@for dir in $(CI_RUNNER_DIRS); do \
-		if [ -f "$$dir/svc.sh" ]; then \
+		if [ -f "$$dir/.service" ]; then \
 			(cd "$$dir" && sudo ./svc.sh status); \
 		else \
-			echo "runner not installed ($$dir)"; \
+			echo "service not installed ($$dir)"; \
 		fi; \
 	done
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -33,7 +33,7 @@ node --version   # 24.x
 
 Keep Docker running (`systemctl enable --now docker`). The backend workflow uses postgres on host port **15432** so it does not clash with `make deps` on :5432.
 
-### 2. Register and start the runner
+### 2. Register and start the runners
 
 ```bash
 make ci-runner-install
@@ -43,6 +43,16 @@ make ci-runner-status            # should show active (running)
 ```
 
 Day to day: `make ci-runner-start` before opening PRs, `make ci-runner-stop` when done (optional).
+
+### 3. How many runners
+
+Every target installs and controls `CI_RUNNERS` runner instances (default **4**) so the path-filtered workflows of one push run at the same time instead of queueing behind each other. Instance 1 lives at `$(CI_RUNNER_DIR)`, the others at `$(CI_RUNNER_DIR)-2`, `-3`, `-4`, each with its own systemd service and its own `_work` tree. Registration needs one fresh token per instance; the Makefile loop lets the install script fetch each one through `gh`.
+
+Change the count with `make ci-runner-install CI_RUNNERS=6`, and pass the same value to the start, stop, and status targets. The reference desktop has 32 CPUs and 61 GB of RAM, so 4 concurrent jobs are comfortable.
+
+Two workflows bind fixed host ports (backend on 15432, simulation on 8901), so both declare a `concurrency` group. Runs of the same workflow still queue one at a time; different workflows run in parallel. Add a `concurrency` group to any new workflow that binds a host port.
+
+To add instances later, run `make ci-runner-install` again: it skips the directories that are already configured.
 
 ### Pre-PR checklist
 

--- a/scripts/install-actions-runner.sh
+++ b/scripts/install-actions-runner.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 REPO="${RUNNER_REPO:-Portocolom-Studio/potocolom}"
 INSTALL_DIR="${RUNNER_INSTALL_DIR:-$HOME/.local/share/potocolom-actions-runner}"
+NAME="${RUNNER_NAME:-$(hostname -s)-potocolom}"
 LABELS="${RUNNER_LABELS:-self-hosted,Linux,X64,potocolom}"
 RUNNER_USER="${SUDO_USER:-$USER}"
 RUNNER_URL="${RUNNER_URL:-https://github.com/$REPO}"
@@ -61,9 +62,9 @@ URL="https://github.com/actions/runner/releases/download/v${VERSION}/${TARBALL}"
 
 mkdir -p "$(dirname "$INSTALL_DIR")"
 if [ -f "$INSTALL_DIR/.runner" ]; then
-  echo "runner already configured at $INSTALL_DIR" >&2
-  echo "remove it first: cd $INSTALL_DIR && ./config.sh remove" >&2
-  exit 1
+  echo "runner already configured at $INSTALL_DIR, skipping"
+  echo "to re-register: cd $INSTALL_DIR && ./config.sh remove"
+  exit 0
 fi
 
 # A failed config.sh leaves a half-installed tree; start clean.
@@ -82,7 +83,7 @@ cd "$INSTALL_DIR"
 if ! ./config.sh \
   --url "$RUNNER_URL" \
   --token "$TOKEN" \
-  --name "$(hostname -s)-potocolom" \
+  --name "$NAME" \
   --labels "$LABELS" \
   --unattended \
   --replace; then


### PR DESCRIPTION
Closes #389\n\n# Description

The self-hosted CI ran every workflow through a single runner instance, so the path-filtered jobs of one push executed one after another. The host has 32 CPUs and 61 GB of RAM, of which one job uses a small fraction.

The `ci-runner-*` targets now loop over `CI_RUNNERS` instances (default four). Instance 1 keeps the existing directory; the others live at `$(CI_RUNNER_DIR)-2`, `-3`, `-4`, each with its own name, systemd service, and `_work` tree.

# Motivation

Wall-clock time on a PR that touches more than one component. A backend plus frontend push serialised two independent jobs for no reason.

# Functionality

- `make ci-runner-install|service-install|start|stop|restart|status` act on all instances. Override the count with `CI_RUNNERS=6`.
- `scripts/install-actions-runner.sh` accepts `RUNNER_NAME` and treats an already-configured directory as a skip instead of an error, so re-running it adds instances without disturbing the existing ones. Each instance fetches its own registration token, because those tokens are single-use.
- `backend.yml` and `simulation.yml` declare a `concurrency` group.

# Details

The concurrency groups are the correctness half of this change. Both workflows bind fixed host ports: postgres on 15432 for backend, uvicorn on 8901 for simulation. A single runner made that safe by accident, since it never ran two jobs at once. With four runners, two runs of the same workflow would fight over the port. The group keeps same-workflow runs queued while different workflows overlap freely, which is the parallelism we actually want. Any new workflow that binds a host port needs the same group, and `docs/self-hosted-runner.md` says so.

Verified with `make verify` (exit 0) and all four runners registered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and managing multiple self-hosted CI runners concurrently.
  * Added unique runner directories, names, services, and lifecycle operations for each configured runner.
  * Added workflow concurrency controls for port-dependent jobs.

* **Bug Fixes**
  * Improved runner registration behavior, including clearer handling of already-configured runners and corrected runner naming.

* **Documentation**
  * Updated self-hosted runner guidance with multi-runner setup, configuration, and concurrency instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->