### PR TITLE
Add readiness, a bounded database pool, and the accounts upgrade guard

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from alembic import command
 from alembic.config import Config
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -27,12 +27,13 @@ from sqlalchemy.ext.asyncio import (
 from sqlalchemy.pool import NullPool
 
 from app.settings import get_settings
-from app.tables import User
+from app.tables import InstallationAuthState, User
 
 logger = logging.getLogger("potocolom.db")
 
 LOCAL_USER_EMAIL = "local@localhost"
 MIN_POSTGRES_VERSION = (13, 0)
+ACCOUNTS_STARTUP_LOCK_KEY = 184467
 
 engine: AsyncEngine | None = None
 session_factory: async_sessionmaker[AsyncSession] | None = None
@@ -84,12 +85,9 @@ async def connect() -> bool:
     except Exception as error:
         logger.warning("database unavailable (%s); generations and history are disabled", error)
         return False
-    # No connection pool: asyncpg connections are bound to the event loop that
-    # created them, and the test client legitimately drives requests and
-    # websockets on separate loops. A single-process self-host loses little;
-    # pool tuning belongs to the cloud profile work.
-    engine = create_async_engine(async_url(settings.database_url), poolclass=NullPool)
+    engine = create_async_engine(async_url(settings.database_url), pool_size=5, max_overflow=10)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    await validate_startup_auth_mode(settings.auth_mode)
     local_user_id = await _ensure_local_user(session_factory)
     return True
 
@@ -124,3 +122,46 @@ async def get_session() -> AsyncIterator[AsyncSession]:
         raise HTTPException(status_code=503, detail="database unavailable")
     async with session_factory() as session:
         yield session
+
+
+async def require_account_dependencies() -> None:
+    if engine is None or session_factory is None:
+        raise HTTPException(status_code=503, detail="account dependencies unavailable")
+
+
+async def read_installation_auth_mode() -> str | None:
+    if session_factory is None:
+        raise RuntimeError("database unavailable")
+    async with session_factory() as session:
+        state = await session.get(InstallationAuthState, 1)
+        return state.auth_mode if state is not None else None
+
+
+async def enable_accounts_mode(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with factory() as session:
+        async with session.begin():
+            await session.execute(
+                text(
+                    "INSERT INTO installation_auth_state (id, auth_mode) "
+                    "VALUES (1, 'accounts') ON CONFLICT (id) DO NOTHING"
+                )
+            )
+
+
+async def validate_startup_auth_mode(configured: str) -> None:
+    persisted = await read_installation_auth_mode()
+    if configured == "accounts" and persisted != "accounts":
+        raise RuntimeError("accounts mode requires explicit installation enable")
+    if configured == "none" and persisted == "accounts":
+        raise RuntimeError("accounts installation cannot start in none mode")
+
+
+async def acquire_accounts_startup_lock(asyncpg_connection) -> bool:
+    acquired = await asyncpg_connection.fetchval(
+        "SELECT pg_try_advisory_lock($1::bigint)", ACCOUNTS_STARTUP_LOCK_KEY
+    )
+    if not acquired:
+        raise RuntimeError("another accounts startup is in progress")
+    return True

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import uuid
 from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from pathlib import Path
 
 from alembic import command
@@ -158,10 +159,16 @@ async def validate_startup_auth_mode(configured: str) -> None:
         raise RuntimeError("accounts installation cannot start in none mode")
 
 
-async def acquire_accounts_startup_lock(asyncpg_connection) -> bool:
+@asynccontextmanager
+async def accounts_startup_lock(asyncpg_connection) -> AsyncIterator[None]:
     acquired = await asyncpg_connection.fetchval(
         "SELECT pg_try_advisory_lock($1::bigint)", ACCOUNTS_STARTUP_LOCK_KEY
     )
     if not acquired:
         raise RuntimeError("another accounts startup is in progress")
-    return True
+    try:
+        yield
+    finally:
+        await asyncpg_connection.fetchval(
+            "SELECT pg_advisory_unlock($1::bigint)", ACCOUNTS_STARTUP_LOCK_KEY
+        )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 
 from fastapi import FastAPI
+from sqlalchemy import text
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import Response
 from starlette.staticfiles import StaticFiles
@@ -24,6 +25,7 @@ from app.realtime import router as realtime_router
 from app.registry import router as registry_router
 from app.security import SecurityHeadersMiddleware, unhandled_exception_response
 from app.settings import get_settings
+from app.storage import get_storage
 from app.studio import router as studio_router
 from app.telemetry import DESTINATION, telemetry_loop
 from app.telemetry import router as telemetry_router
@@ -139,6 +141,20 @@ async def health() -> dict:
     # Answers from process state only: the load balancer must not be convinced
     # to kill healthy tasks during a database incident (docs/blueprint.md).
     return {"status": "ok"}
+
+
+@app.get("/api/v1/ready")
+async def ready() -> Response:
+    try:
+        if db.engine is None:
+            return Response(status_code=503)
+        async with db.engine.connect() as connection:
+            await connection.execute(text("SELECT 1"))
+        if not await get_storage().ready():
+            return Response(status_code=503)
+    except Exception:
+        return Response(status_code=503)
+    return Response(status_code=200)
 
 
 @app.get("/api/v1/config")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,8 +41,8 @@ def _reject_unimplemented_auth_mode(mode: str) -> None:
     raise RuntimeError(
         f"AUTH_MODE={mode} is not implemented and "
         "authenticates nobody, so every request would resolve to the local "
-        "admin user. Unset AUTH_MODE or set it to none (local is tracked "
-        "in #5, oauth in #9)."
+        "admin user. Unset AUTH_MODE or set it to none (accounts is tracked "
+        "in #5 and #9)."
     )
 
 

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -8,8 +8,8 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    auth_mode: Literal["none", "local", "oauth"] = "none"
-    oauth_providers: str = ""  # comma separated, read only when auth_mode is oauth
+    auth_mode: Literal["none", "accounts"] = "none"
+    oauth_providers: str = ""
     billing_enabled: bool = False
     log_format: Literal["plain", "json"] = "plain"
     fleet_token_key: str = ""
@@ -56,9 +56,11 @@ class Settings(BaseSettings):
     def auth_methods(self) -> list[str]:
         if self.auth_mode == "none":
             return []
-        methods = ["local"]
-        if self.auth_mode == "oauth":
-            methods += [p.strip() for p in self.oauth_providers.split(",") if p.strip()]
+        methods = ["password"]
+        methods += [
+            provider for provider in (part.strip() for part in self.oauth_providers.split(","))
+            if provider in {"google", "github"}
+        ]
         return methods
 
 

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -282,6 +282,8 @@ def _inspect(data: bytes) -> tuple[int, int, str] | None:
 
 
 class Storage(Protocol):
+    async def ready(self) -> bool: ...
+
     async def upload_target(self, key: str, token: str | None = None) -> UploadTarget: ...
 
     async def image_info(self, key: str) -> ImageInfo | None: ...
@@ -308,6 +310,9 @@ class LocalStorage:
         if not path.is_relative_to(self.root.resolve()):
             raise ValueError("storage key escapes the storage root")
         return path
+
+    async def ready(self) -> bool:
+        return await asyncio.to_thread(self.root.is_dir)
 
     async def upload_target(self, key: str, token: str | None = None) -> UploadTarget:
         content_type = PNG_CONTENT_TYPE if key.endswith(".png") else WEBP_CONTENT_TYPE
@@ -412,6 +417,15 @@ class S3Storage:
             aws_secret_access_key=settings.storage_s3_secret_key or None,
             config=Config(signature_version="s3v4"),  # MinIO requires SigV4
         )
+
+    async def ready(self) -> bool:
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(self.client.head_bucket, Bucket=self.bucket), timeout=2
+            )
+        except Exception:
+            return False
+        return True
 
     async def upload_target(self, key: str, token: str | None = None) -> UploadTarget:
         # Presigning is local computation, no network round trip. The token is

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -15,7 +15,7 @@ import time
 import zlib
 from dataclasses import dataclass, field
 from concurrent.futures import ThreadPoolExecutor
-from functools import lru_cache
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import Protocol
 from urllib.parse import urlencode
@@ -29,6 +29,9 @@ OUTPUT_UPLOAD_URL_TTL = 3600
 # attempt for good, and the default executor is shared with every other
 # off-loop read this app makes.
 DELETE_THREADS = 4
+# Readiness gets its own pool for the same reason, and a smaller one: the probe
+# is unauthenticated, so its rate is set by whoever is calling it.
+READY_THREADS = 2
 # Carries the dispatch token on a local upload (app/files.py, issue #247).
 UPLOAD_TOKEN_HEADER = "X-Upload-Token"
 PNG_CONTENT_TYPE = "image/png"
@@ -52,6 +55,11 @@ DOWNLOAD_NAME_PATTERN = re.compile(
 @lru_cache
 def _delete_threads() -> ThreadPoolExecutor:
     return ThreadPoolExecutor(max_workers=DELETE_THREADS, thread_name_prefix="storage-delete")
+
+
+@lru_cache
+def _ready_threads() -> ThreadPoolExecutor:
+    return ThreadPoolExecutor(max_workers=READY_THREADS, thread_name_prefix="storage-ready")
 
 
 def validate_download_name(name: str) -> str:
@@ -312,7 +320,8 @@ class LocalStorage:
         return path
 
     async def ready(self) -> bool:
-        return await asyncio.to_thread(self.root.is_dir)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(_ready_threads(), self.root.is_dir)
 
     async def upload_target(self, key: str, token: str | None = None) -> UploadTarget:
         content_type = PNG_CONTENT_TYPE if key.endswith(".png") else WEBP_CONTENT_TYPE
@@ -419,10 +428,12 @@ class S3Storage:
         )
 
     async def ready(self) -> bool:
+        loop = asyncio.get_running_loop()
+        probe = loop.run_in_executor(
+            _ready_threads(), partial(self.client.head_bucket, Bucket=self.bucket)
+        )
         try:
-            await asyncio.wait_for(
-                asyncio.to_thread(self.client.head_bucket, Bucket=self.bucket), timeout=2
-            )
+            await asyncio.wait_for(probe, timeout=2)
         except Exception:
             return False
         return True

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -230,6 +230,14 @@ class PendingDelete(Base):
     __table_args__ = (Index("pending_deletes_due", "next_attempt_at"),)
 
 
+class InstallationAuthState(Base):
+    __tablename__ = "installation_auth_state"
+
+    id: Mapped[int] = mapped_column(SmallInteger, primary_key=True)
+    auth_mode: Mapped[str] = mapped_column(Text)
+    enabled_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
 class WorkerIdentity(Base):
     __tablename__ = "workers"
 

--- a/backend/migrations/versions/0014_installation_auth_state.py
+++ b/backend/migrations/versions/0014_installation_auth_state.py
@@ -1,0 +1,20 @@
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "installation_auth_state",
+        sa.Column("id", sa.SmallInteger(), primary_key=True),
+        sa.Column("auth_mode", sa.Text(), nullable=False),
+        sa.Column("enabled_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("installation_auth_state")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -202,6 +202,18 @@ def _drop_database() -> None:
 DATABASE_AVAILABLE = _prepare_database()
 
 
+_RUNNER = asyncio.Runner()
+
+
+def run_on_test_loop(awaitable):
+    return _RUNNER.run(awaitable)
+
+
+@pytest.fixture
+def portal_runner():
+    return _RUNNER.run
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "db: needs the development PostgreSQL")
 
@@ -309,6 +321,7 @@ def _no_inherited_jobs(request):
 def pytest_sessionfinish(session, exitstatus):
     if DATABASE_AVAILABLE and _OURS:
         _drop_database()
+    _RUNNER.close()
 
 
 def pytest_collection_modifyitems(config, items):

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -23,15 +23,15 @@ def test_config_defaults():
 
 def test_auth_methods_by_mode():
     assert Settings(auth_mode="none").auth_methods == []
-    assert Settings(auth_mode="local").auth_methods == ["local"]
-    assert Settings(auth_mode="oauth", oauth_providers="google,github").auth_methods == [
-        "local",
+    assert Settings(auth_mode="accounts").auth_methods == ["password"]
+    assert Settings(auth_mode="accounts", oauth_providers="google,github").auth_methods == [
+        "password",
         "google",
         "github",
     ]
     # Whitespace around commas must not leak into method names.
-    assert Settings(auth_mode="oauth", oauth_providers="google, github, ").auth_methods == [
-        "local",
+    assert Settings(auth_mode="accounts", oauth_providers="google, github, ").auth_methods == [
+        "password",
         "google",
         "github",
     ]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -43,7 +43,7 @@ def test_viewer_reads_but_cannot_mutate_and_preview_is_admin_only():
     missing_job = uuid.UUID("00000000-0000-0000-0000-000000000000")
     with TestClient(app) as client:
         try:
-            asyncio.run(_set_local_role("viewer"))
+            client.portal.call(_set_local_role, "viewer")
             assert client.get("/api/v1/generations").status_code == 200
             assert client.get("/api/v1/benchmark/sessions").status_code == 403
             assert client.post(
@@ -51,28 +51,28 @@ def test_viewer_reads_but_cannot_mutate_and_preview_is_admin_only():
             ).status_code == 403
             assert client.get("/api/v1/telemetry/preview").status_code == 403
 
-            asyncio.run(_set_local_role("user"))
+            client.portal.call(_set_local_role, "user")
             assert client.post(
                 f"/api/v1/generations/{missing_job}/star"
             ).status_code == 404
             assert client.get("/api/v1/telemetry/preview").status_code == 403
 
-            asyncio.run(_set_local_role("admin"))
+            client.portal.call(_set_local_role, "admin")
             assert client.post(
                 f"/api/v1/generations/{missing_job}/star"
             ).status_code == 404
             assert client.get("/api/v1/telemetry/preview").status_code == 200
         finally:
-            asyncio.run(_set_local_role("admin"))
+            client.portal.call(_set_local_role, "admin")
 
 
 @pytest.mark.db
 def test_existing_implicit_local_user_is_promoted_to_admin():
-    with TestClient(app):
+    with TestClient(app) as client:
         assert db.session_factory is not None
         assert db.local_user_id is not None
-        asyncio.run(_set_local_role("user"))
-        user_id = asyncio.run(db._ensure_local_user(db.session_factory))
+        client.portal.call(_set_local_role, "user")
+        user_id = client.portal.call(db._ensure_local_user, db.session_factory)
         assert user_id == db.local_user_id
 
         async def read_role() -> str:
@@ -82,4 +82,4 @@ def test_existing_implicit_local_user_is_promoted_to_admin():
                 assert user is not None
                 return user.role
 
-        assert asyncio.run(read_role()) == "admin"
+        assert client.portal.call(read_role) == "admin"

--- a/backend/tests/test_auth_r2.py
+++ b/backend/tests/test_auth_r2.py
@@ -187,9 +187,14 @@ def test_accounts_without_redis_refuses_concurrent_startup(portal_runner):
         first = await asyncpg.connect(db.get_settings().database_url)
         second = await asyncpg.connect(db.get_settings().database_url)
         try:
-            assert await db.acquire_accounts_startup_lock(first) is True
-            with pytest.raises(RuntimeError, match="accounts startup"):
-                await db.acquire_accounts_startup_lock(second)
+            async with db.accounts_startup_lock(first):
+                with pytest.raises(RuntimeError, match="accounts startup"):
+                    async with db.accounts_startup_lock(second):
+                        pass
+            # A session lock the holder never releases wedges every restart
+            # until PostgreSQL reaps the backend on its keepalive timeout.
+            async with db.accounts_startup_lock(second):
+                pass
         finally:
             await second.close()
             await first.close()

--- a/backend/tests/test_auth_r2.py
+++ b/backend/tests/test_auth_r2.py
@@ -1,0 +1,197 @@
+import asyncio
+
+import asyncpg
+import pytest
+from fastapi import Depends
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+from sqlalchemy import select
+from sqlalchemy.pool import NullPool
+
+from app import auth
+from app import db
+import app.main as main_module
+from app.main import app
+from app.settings import Settings
+from app.tables import Asset
+
+
+def test_accounts_mode_exposes_password_and_allowed_providers():
+    assert Settings(auth_mode="accounts").auth_methods == ["password"]
+    assert Settings(auth_mode="accounts", oauth_providers="google, github, ").auth_methods == [
+        "password", "google", "github"
+    ]
+
+
+def test_health_and_readiness_when_connect_fails(monkeypatch):
+    async def unavailable():
+        db.engine = None
+        db.session_factory = None
+        return False
+
+    monkeypatch.setattr(db, "connect", unavailable)
+    with TestClient(app) as client:
+        assert client.get("/api/v1/health").status_code == 200
+        assert client.get("/api/v1/ready").status_code == 503
+
+
+@pytest.mark.db
+def test_readiness_when_required_stores_are_available(monkeypatch):
+    with TestClient(app) as client:
+        assert client.get("/api/v1/ready").status_code == 200
+
+
+@pytest.mark.db
+def test_readiness_reports_unavailable_asset_store(monkeypatch):
+    class UnavailableStore:
+        async def ready(self):
+            return False
+
+    monkeypatch.setattr(main_module, "get_storage", lambda: UnavailableStore(), raising=False)
+    with TestClient(app) as client:
+        assert client.get("/api/v1/ready").status_code == 503
+
+
+@pytest.mark.db
+def test_database_engine_uses_bounded_pool(portal_runner):
+    assert portal_runner(db.connect()) is True
+    try:
+        assert db.engine is not None
+        assert not isinstance(db.engine.pool, NullPool)
+        assert db.engine.pool.size() > 0
+        assert db.engine.pool._max_overflow >= 0
+    finally:
+        portal_runner(db.dispose())
+
+
+@pytest.mark.db
+def test_pooled_engine_route_setup_and_dispose_share_one_loop(monkeypatch):
+    loops = []
+    original_connect = db.connect
+    original_dispose = db.dispose
+    route = "/__r2_loop_probe"
+
+    async def connect():
+        loops.append(("connect", asyncio.get_running_loop()))
+        return await original_connect()
+
+    async def dispose():
+        loops.append(("dispose", asyncio.get_running_loop()))
+        return await original_dispose()
+
+    async def probe(session=Depends(db.get_session)):
+        loops.append(("route", asyncio.get_running_loop()))
+        await session.execute(text("SELECT 1"))
+        return {"ok": True}
+
+    monkeypatch.setattr(db, "connect", connect)
+    monkeypatch.setattr(db, "dispose", dispose)
+    app.add_api_route(route, probe)
+    added = next(item for item in app.routes if getattr(item, "path", None) == route)
+    try:
+        with TestClient(app) as client:
+            async def setup():
+                loops.append(("setup", asyncio.get_running_loop()))
+                async with db.session_factory() as session:
+                    await session.execute(text("SELECT 1"))
+
+            client.portal.call(setup)
+            assert client.get(route).status_code == 200
+    finally:
+        app.router.routes.remove(added)
+    assert len({loop for _, loop in loops}) == 1
+
+
+def test_account_dependency_rejects_before_principal(monkeypatch):
+    called = False
+
+    async def principal():
+        nonlocal called
+        called = True
+        raise AssertionError("principal construction must not run")
+
+    app.dependency_overrides[auth.current_user] = principal
+    monkeypatch.setattr(db, "engine", None)
+    monkeypatch.setattr(db, "session_factory", None)
+    route = "/__r2_account_dependency_probe"
+
+    async def probe(_=Depends(db.require_account_dependencies), principal=Depends(auth.current_user)):
+        return {"ok": True}
+
+    app.add_api_route(route, probe)
+    added = next(item for item in app.routes if getattr(item, "path", None) == route)
+    try:
+        response = TestClient(app).get(route)
+    finally:
+        app.dependency_overrides.clear()
+        app.router.routes.remove(added)
+    assert response.status_code == 503
+    assert not called
+
+
+@pytest.mark.db
+def test_accounts_enable_persists_mode_and_existing_ownership(portal_runner):
+    assert portal_runner(db.connect()) is True
+    enabled = False
+    try:
+        assert db.local_user_id is not None
+        user_id = db.local_user_id
+        async def ownership():
+            async with db.session_factory() as session:
+                rows = await session.execute(select(Asset.id, Asset.user_id))
+                return rows.all()
+
+        async def create_asset():
+            async with db.session_factory() as session:
+                asset = Asset(
+                    user_id=user_id,
+                    storage_key=f"{user_id}/r2.png",
+                    mime="image/png",
+                    width=1,
+                    height=1,
+                )
+                session.add(asset)
+                await session.commit()
+
+        portal_runner(create_asset())
+        existing_asset_owner = portal_runner(ownership())
+        with pytest.raises(RuntimeError, match="explicit"):
+            portal_runner(db.validate_startup_auth_mode("accounts"))
+        async def enable_twice():
+            await asyncio.gather(
+                db.enable_accounts_mode(db.session_factory),
+                db.enable_accounts_mode(db.session_factory),
+            )
+
+        portal_runner(enable_twice())
+        enabled = True
+        assert portal_runner(db.read_installation_auth_mode()) == "accounts"
+        assert portal_runner(ownership()) == existing_asset_owner
+        assert db.local_user_id == user_id
+        with pytest.raises(RuntimeError, match="accounts"):
+            portal_runner(db.validate_startup_auth_mode("none"))
+    finally:
+        if enabled:
+            async def remove_auth_state():
+                async with db.session_factory() as session:
+                    await session.execute(text("DELETE FROM installation_auth_state"))
+                    await session.commit()
+
+            portal_runner(remove_auth_state())
+        portal_runner(db.dispose())
+
+
+@pytest.mark.db
+def test_accounts_without_redis_refuses_concurrent_startup(portal_runner):
+    async def exercise():
+        first = await asyncpg.connect(db.get_settings().database_url)
+        second = await asyncpg.connect(db.get_settings().database_url)
+        try:
+            assert await db.acquire_accounts_startup_lock(first) is True
+            with pytest.raises(RuntimeError, match="accounts startup"):
+                await db.acquire_accounts_startup_lock(second)
+        finally:
+            await second.close()
+            await first.close()
+
+    portal_runner(exercise())

--- a/backend/tests/test_benchmark_sessions.py
+++ b/backend/tests/test_benchmark_sessions.py
@@ -1,4 +1,3 @@
-import asyncio
 import uuid
 
 from fastapi.testclient import TestClient
@@ -130,7 +129,7 @@ def test_benchmark_session_reads_are_install_scoped(monkeypatch):
                     row.user_id = other_id
                     await session.commit()
 
-            asyncio.run(change_provenance())
+            client.portal.call(change_provenance)
             listed = client.get("/api/v1/benchmark/sessions")
             assert session_id in {uuid.UUID(row["id"]) for row in listed.json()}
             assert client.get(
@@ -165,7 +164,7 @@ def test_benchmark_history_survives_deleting_the_account_that_ran_it(monkeypatch
                     await session.execute(delete(User).where(User.id == runner_id))
                     await session.commit()
 
-            asyncio.run(delete_the_runner())
+            client.portal.call(delete_the_runner)
             assert client.get(f"/api/v1/benchmark/sessions/{session_id}").status_code == 200
 
             async def provenance_cleared() -> None:
@@ -174,6 +173,6 @@ def test_benchmark_history_survives_deleting_the_account_that_ran_it(monkeypatch
                     row = await session.get(BenchmarkSession, session_id)
                     assert row is not None and row.user_id is None
 
-            asyncio.run(provenance_cleared())
+            client.portal.call(provenance_cleared)
     finally:
         get_settings.cache_clear()

--- a/backend/tests/test_endpoint_hardening.py
+++ b/backend/tests/test_endpoint_hardening.py
@@ -142,9 +142,9 @@ def test_asset_id_read_is_session_bound_and_owner_scoped(tmp_path, monkeypatch):
     storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
     monkeypatch.setattr("app.files.get_storage", lambda: storage)
     with _client() as client:
-        owner = asyncio.run(_persist_user("user", "asset-owner"))
-        other = asyncio.run(_persist_user("viewer", "asset-other"))
-        admin = asyncio.run(_persist_user("admin", "asset-admin"))
+        owner = client.portal.call(_persist_user, "user", "asset-owner")
+        other = client.portal.call(_persist_user, "viewer", "asset-other")
+        admin = client.portal.call(_persist_user, "admin", "asset-admin")
         key = f"{owner.id}/asset.png"
         path = storage.path(key)
         path.parent.mkdir(parents=True)
@@ -155,7 +155,7 @@ def test_asset_id_read_is_session_bound_and_owner_scoped(tmp_path, monkeypatch):
                 session.add(Asset(id=asset_id, user_id=owner.id, storage_key=key,
                                   mime="image/png", width=1, height=1))
                 await session.commit()
-        asyncio.run(create_asset())
+        client.portal.call(create_asset)
         app.dependency_overrides[current_user] = lambda: owner
         owner_response = client.get(f"/api/v1/assets/{asset_id}")
         assert owner_response.status_code == 200
@@ -173,8 +173,8 @@ def test_expired_asset_is_not_readable_by_owner_or_admin(tmp_path, monkeypatch):
     storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
     monkeypatch.setattr("app.files.get_storage", lambda: storage)
     with _client() as client:
-        owner = asyncio.run(_persist_user("user", "expired-asset-owner"))
-        admin = asyncio.run(_persist_user("admin", "expired-asset-admin"))
+        owner = client.portal.call(_persist_user, "user", "expired-asset-owner")
+        admin = client.portal.call(_persist_user, "admin", "expired-asset-admin")
         key = f"{owner.id}/expired-asset.png"
         path = storage.path(key)
         path.parent.mkdir(parents=True)
@@ -188,7 +188,7 @@ def test_expired_asset_is_not_readable_by_owner_or_admin(tmp_path, monkeypatch):
                                   expires_at=datetime(2020, 1, 1, tzinfo=timezone.utc)))
                 await session.commit()
 
-        asyncio.run(create_asset())
+        client.portal.call(create_asset)
         for principal in (owner, admin):
             app.dependency_overrides[current_user] = lambda principal=principal: principal
             assert client.get(f"/api/v1/assets/{asset_id}").status_code == 404

--- a/backend/tests/test_estimates.py
+++ b/backend/tests/test_estimates.py
@@ -1,6 +1,5 @@
-import asyncio
-
 import pytest
+from conftest import run_on_test_loop
 
 from app import db, estimates
 from app.estimates import estimate_gpu_ms, schema_defaults
@@ -132,7 +131,7 @@ def test_observed_timing_database_failure_uses_shipped_constant(monkeypatch):
     estimates._observed_scales = {"sdxl-fast": 0.5}
     monkeypatch.setattr(db, "session_factory", BrokenSession)
 
-    asyncio.run(estimates.refresh_observed_timings())
+    run_on_test_loop(estimates.refresh_observed_timings())
 
     assert estimate_gpu_ms(
         "sdxl-fast", {"width": 1024, "height": 1024, "steps": 8}

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -2005,7 +2005,7 @@ def test_expired_source_asset_is_rejected_for_img2img_and_upscale():
                         )
                     )
 
-            jobs_before = asyncio.run(seed())
+            jobs_before = client.portal.call(seed)
             queue_before = list(jobs.queues._heaps.get(jobs.JOB_QUEUE, []))
 
             for model_id, params in (
@@ -2031,7 +2031,7 @@ def test_expired_source_asset_is_rejected_for_img2img_and_upscale():
                         )
                     )
 
-            assert asyncio.run(count_jobs()) == jobs_before
+            assert client.portal.call(count_jobs) == jobs_before
             assert jobs.queues._heaps.get(jobs.JOB_QUEUE, []) == queue_before
 
 

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs, urlencode, urlsplit
 
 import pytest
+from conftest import run_on_test_loop
 from sqlalchemy import delete, func, select
 from fastapi.testclient import TestClient
 
@@ -286,7 +287,7 @@ def test_generation_download_names_count_only_visible_masters():
 
     base_name = "potocolom-20260729-142530-a-lighthouse"
     with TestClient(app, headers=FLEET_HEADERS) as client:
-        job_id = asyncio.run(seed_generation())
+        job_id = client.portal.call(seed_generation)
         single_asset = client.get(f"/api/v1/generations/{job_id}").json()["assets"][0]
         assert urlsplit(single_asset["url"]).path == f"/api/v1/assets/{single_asset['id']}"
         assert parse_qs(urlsplit(single_asset["download_url"]).query) == {
@@ -294,7 +295,7 @@ def test_generation_download_names_count_only_visible_masters():
         }
         assert urlsplit(single_asset["download_url"]).path == f"/api/v1/assets/{single_asset['id']}"
 
-        asyncio.run(add_second_asset(job_id))
+        client.portal.call(add_second_asset, job_id)
         batch_assets = client.get(f"/api/v1/generations/{job_id}").json()["assets"]
         assert len(batch_assets) == 2
         for position, asset in enumerate(batch_assets, start=1):
@@ -305,7 +306,7 @@ def test_generation_download_names_count_only_visible_masters():
             }
             assert urlsplit(asset["download_url"]).path == f"/api/v1/assets/{asset['id']}"
 
-        expired_first_job_id = asyncio.run(seed_generation_with_expired_first())
+        expired_first_job_id = client.portal.call(seed_generation_with_expired_first)
         surviving_assets = client.get(
             f"/api/v1/generations/{expired_first_job_id}"
         ).json()["assets"]
@@ -348,7 +349,7 @@ def test_generation_end_to_end():
             # usage_events carries no job id, and the database is truncated once
             # per session, so this job's row is identified by the count rising
             # rather than by any matching row existing.
-            events_before = asyncio.run(job_events())
+            events_before = client.portal.call(job_events)
 
             created = client.post("/api/v1/generations",
                                   json={"model_id": "sd-test",
@@ -418,7 +419,7 @@ def test_generation_end_to_end():
 
             # The thumbnail row carries the inspected dimensions, not a
             # derivation from the master's: the object is the truth.
-            assert asyncio.run(recorded_thumb_dimensions()) == (320, 200)
+            assert client.portal.call(recorded_thumb_dimensions) == (320, 200)
 
             history = client.get("/api/v1/generations").json()
             assert any(entry["id"] == job_id for entry in history)
@@ -437,7 +438,7 @@ def test_generation_end_to_end():
                     row.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
                     await session.commit()
 
-            asyncio.run(expire_asset())
+            client.portal.call(expire_asset)
             expired = client.get("/api/v1/generations?starred=true").json()[0]
             assert expired["assets"] == []
             assert expired["expired_favorite"] is True
@@ -452,7 +453,7 @@ def test_generation_end_to_end():
             assert "succeeded" in events.text
 
             def usage_written() -> bool:
-                return asyncio.run(job_events()) > events_before
+                return client.portal.call(job_events) > events_before
 
             deadline = time.monotonic() + 3
             while time.monotonic() < deadline and not usage_written():
@@ -520,7 +521,7 @@ def test_generation_persists_the_full_capability_list_for_a_narrowed_model(
 
             # The row may be missing when the worker registered while the
             # database was down; drop it so this POST is the write under test.
-            asyncio.run(drop_model_row())
+            client.portal.call(drop_model_row)
             created = client.post("/api/v1/generations",
                                   json={"model_id": "sd-narrow",
                                         "params": {"prompt": "x"}})
@@ -532,7 +533,7 @@ def test_generation_persists_the_full_capability_list_for_a_narrowed_model(
                     row = await session.get(Model, "sd-narrow")
                     return list(row.capabilities) if row is not None else None
 
-            capabilities = asyncio.run(row_capabilities())
+            capabilities = client.portal.call(row_capabilities)
     assert capabilities == ["text_to_image", "image_to_image", "realtime"]
 
 
@@ -622,7 +623,7 @@ def force_one_requeue(client, job_id: str, timeout=5.0) -> dict:
     """
     key = uuid.UUID(job_id)
     jobs.last_progress_at[key] = 0.0  # older than any stall the settings allow
-    asyncio.run(jobs.sweep_stalled_jobs())
+    client.portal.call(jobs.sweep_stalled_jobs)
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         job = client.get(f"/api/v1/generations/{job_id}").json()
@@ -839,8 +840,8 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
                 storage = jobs.get_storage()
                 first_key = first_path.rsplit("/api/v1/files/", 1)[-1]
                 first_thumb_key = first_thumb.rsplit("/api/v1/files/", 1)[-1]
-                asyncio.run(_write_blob(storage, first_key, png_bytes()))
-                asyncio.run(_write_blob(storage, first_thumb_key, png_bytes()))
+                run_on_test_loop(_write_blob(storage, first_key, png_bytes()))
+                run_on_test_loop(_write_blob(storage, first_thumb_key, png_bytes()))
 
                 assert put_upload(client, second["upload"],
                                   png_bytes()).status_code == 200
@@ -849,8 +850,8 @@ def test_a_retry_does_not_leave_the_earlier_attempt_behind(monkeypatch):
                                   "dispatch_token": second["dispatch_token"]})
                 poll_until(client, job_id, "succeeded")
 
-                assert asyncio.run(storage.image_info(first_key)) is None
-                assert asyncio.run(storage.image_info(first_thumb_key)) is None
+                assert run_on_test_loop(storage.image_info(first_key)) is None
+                assert run_on_test_loop(storage.image_info(first_thumb_key)) is None
     finally:
         monkeypatch.delenv("JOB_STALL_SECONDS", raising=False)
         get_settings.cache_clear()
@@ -888,7 +889,7 @@ def test_a_stalled_job_failed_past_its_retry_collects_its_uploads(monkeypatch):
 
                 # Stall again: past the one retry, the sweeper fails the row.
                 jobs.last_progress_at[uuid.UUID(job_id)] = 0.0
-                asyncio.run(jobs.sweep_stalled_jobs())
+                client.portal.call(jobs.sweep_stalled_jobs)
                 poll_until(client, job_id, "failed")
 
                 assert not storage.path(second_key).exists(), \
@@ -928,7 +929,7 @@ def test_a_refused_failure_collects_nothing(monkeypatch):
                 return False
 
             monkeypatch.setattr(jobs, "mark_failed", refuse)
-            asyncio.run(jobs.requeue_or_fail(uuid.UUID(job_id), "late worker loss"))
+            client.portal.call(jobs.requeue_or_fail, uuid.UUID(job_id), "late worker loss")
 
             assert storage.path(key).exists(), \
                 "a refused failure deleted objects that belong to the winner"
@@ -1003,8 +1004,8 @@ def test_a_requeue_keeps_the_earlier_attempts_blobs(monkeypatch):
 
                 # The first attempt uploaded before it stalled.
                 storage = jobs.get_storage()
-                asyncio.run(_write_blob(storage, first_key, png_bytes()))
-                asyncio.run(_write_blob(storage, first_thumb, png_bytes()))
+                run_on_test_loop(_write_blob(storage, first_key, png_bytes()))
+                run_on_test_loop(_write_blob(storage, first_thumb, png_bytes()))
 
                 force_one_requeue(client, job_id)
                 second = worker.receive_json()
@@ -1250,7 +1251,7 @@ def test_a_success_commit_failure_leaves_the_job_recoverable(monkeypatch):
             # Recovery: the entry is still tracked with a stale progress stamp,
             # so the sweeper requeues it and the retry reaches a terminal state.
             jobs.last_progress_at[key] = 0.0
-            asyncio.run(jobs.sweep_stalled_jobs())
+            client.portal.call(jobs.sweep_stalled_jobs)
             poll_until_attempt(client, job_id, 2, timeout=3.0)
             redispatch = worker.receive_json()
             assert redispatch["type"] == "dispatch_job"
@@ -1293,7 +1294,7 @@ def test_a_failure_commit_failure_leaves_the_job_recoverable(monkeypatch):
             assert realtime.workers["w-fail-commit"].jobs_in_flight == 1
 
             jobs.last_progress_at[key] = 0.0
-            asyncio.run(jobs.sweep_stalled_jobs())
+            client.portal.call(jobs.sweep_stalled_jobs)
             poll_until_attempt(client, job_id, 2, timeout=3.0)
             redispatch = worker.receive_json()
             worker.send_json({"type": "job_failed", "job_id": job_id,
@@ -1337,7 +1338,7 @@ def test_a_failed_recovery_keeps_the_lost_job_retryable(monkeypatch):
                 await session.commit()
             return job_id
 
-        job_id = asyncio.run(seed())
+        job_id = client.portal.call(seed)
         lost = [job_id]
         real_requeue_or_fail = jobs.requeue_or_fail
         real_dispatch_step = jobs.dispatch_step
@@ -1358,12 +1359,12 @@ def test_a_failed_recovery_keeps_the_lost_job_retryable(monkeypatch):
         monkeypatch.setattr(jobs, "lost_jobs", lost)
         monkeypatch.setattr(jobs, "requeue_or_fail", flaky_requeue)
         try:
-            asyncio.run(real_dispatch_step())
+            client.portal.call(real_dispatch_step)
         except RuntimeError:
             pass  # the first recovery failed; the job must stay at the head
         assert lost == [job_id], "a failed recovery dropped the only reference"
 
-        asyncio.run(real_dispatch_step())
+        client.portal.call(real_dispatch_step)
         assert lost == []
         assert reasons == ["worker disconnected", "worker disconnected"]
         assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "failed"
@@ -1374,7 +1375,7 @@ def test_a_failing_recovery_does_not_starve_the_jobs_behind_it(monkeypatch):
     """Holding the head would stop the sweep and the dispatch behind it for as
     long as one entry keeps raising, so a failure rotates to the tail."""
     _stall_safe(monkeypatch)
-    with TestClient(app, headers=FLEET_HEADERS):
+    with TestClient(app, headers=FLEET_HEADERS) as client:
         stuck, healthy = uuid.uuid4(), uuid.uuid4()
         lost = [stuck, healthy]
         recovered = []
@@ -1397,7 +1398,7 @@ def test_a_failing_recovery_does_not_starve_the_jobs_behind_it(monkeypatch):
         monkeypatch.setattr(jobs, "requeue_or_fail", flaky_requeue)
         monkeypatch.setattr(jobs, "sweep_stalled_jobs", counted_sweep)
 
-        asyncio.run(real_dispatch_step())
+        client.portal.call(real_dispatch_step)
 
         assert recovered == [healthy], "the job behind the failing one never ran"
         assert lost == [stuck], "the failing entry must stay, at the tail"
@@ -1429,7 +1430,9 @@ def test_completed_event_uses_the_persisted_asset_url(monkeypatch):
                         )
                     ) or 0)
 
-            events_before = asyncio.run(job_events())
+            # usage_events carries no job id, and the database is truncated once
+            # per session, so this job's row is identified by the count rising.
+            events_before = client.portal.call(job_events)
             published = []
             monkeypatch.setattr(
                 jobs, "publish",
@@ -1479,7 +1482,7 @@ def test_completed_event_uses_the_persisted_asset_url(monkeypatch):
             assert tracking_url.calls == []
 
             def usage_written() -> bool:
-                return asyncio.run(job_events()) > events_before
+                return client.portal.call(job_events) > events_before
 
             deadline = time.monotonic() + 3
             while time.monotonic() < deadline and not usage_written():
@@ -1703,8 +1706,8 @@ def test_a_rejected_retry_collects_every_attempt(monkeypatch):
                 storage = jobs.get_storage()
                 first_key = first_path.rsplit("/api/v1/files/", 1)[-1]
                 first_thumb_key = first_thumb.rsplit("/api/v1/files/", 1)[-1]
-                asyncio.run(_write_blob(storage, first_key, png_bytes()))
-                asyncio.run(_write_blob(storage, first_thumb_key, png_bytes()))
+                run_on_test_loop(_write_blob(storage, first_key, png_bytes()))
+                run_on_test_loop(_write_blob(storage, first_thumb_key, png_bytes()))
 
                 # The retry's output is rejected: the key is still inflight so
                 # the PUT succeeds, and the invalid bytes fail verification.
@@ -1758,7 +1761,10 @@ def _await_pending_delete(storage_key: str, timeout=3.0, client=None) -> Pending
             if jobs._blob_cleanup_tasks:
                 time.sleep(0.05)
                 continue
-        row = asyncio.run(_pending_delete(storage_key))
+        if client is not None:
+            row = client.portal.call(_pending_delete, storage_key)
+        else:
+            row = run_on_test_loop(_pending_delete(storage_key))
         if row is not None:
             return row
         time.sleep(0.05)
@@ -1838,7 +1844,7 @@ def test_recover_requeues_running_and_dispatches_queued():
         await db.dispose()
         return ids
 
-    queued_id, running_id = asyncio.run(prepare())
+    queued_id, running_id = run_on_test_loop(prepare())
 
     with TestClient(app, headers=FLEET_HEADERS) as client:
         requeued = client.get(f"/api/v1/generations/{running_id}").json()
@@ -2502,7 +2508,7 @@ def test_generation_history_roots_only_filter_pages_roots():
                 await session.commit()
             return newest_root_id, older_root_id, child_id
 
-        newest_root_id, older_root_id, child_id = asyncio.run(seed())
+        newest_root_id, older_root_id, child_id = client.portal.call(seed)
 
         first = client.get(
             "/api/v1/generations",
@@ -2581,7 +2587,7 @@ def test_generation_lineage_chain_orders_ancestors_and_children():
                 await session.commit()
             return root_id, edit_id, upscale_id
 
-        root_id, edit_id, upscale_id = asyncio.run(seed())
+        root_id, edit_id, upscale_id = client.portal.call(seed)
 
         root = client.get(f"/api/v1/generations/{root_id}/lineage").json()
         assert root["ancestors"] == []
@@ -2637,7 +2643,7 @@ def test_generation_lineage_fanout_orders_children_by_created_at():
                 await session.commit()
             return root_id, [children[1], children[2], children[0]]
 
-        root_id, expected = asyncio.run(seed())
+        root_id, expected = client.portal.call(seed)
         lineage = client.get(f"/api/v1/generations/{root_id}/lineage").json()
         assert [entry["job_id"] for entry in lineage["children"]] == [
             str(job_id) for job_id in expected
@@ -2682,7 +2688,7 @@ def test_generation_lineage_root_counts_grandchildren():
                 await session.commit()
             return root_id
 
-        root_id = asyncio.run(seed())
+        root_id = client.portal.call(seed)
         lineage = client.get(f"/api/v1/generations/{root_id}/lineage").json()
         assert lineage["ancestors"] == []
         assert len(lineage["children"]) == 1
@@ -2739,7 +2745,7 @@ def test_generation_lineage_includes_upload_root():
                 await session.commit()
             return leaf_id, edit_id
 
-        leaf_id, edit_id = asyncio.run(seed())
+        leaf_id, edit_id = client.portal.call(seed)
         lineage = client.get(f"/api/v1/generations/{leaf_id}/lineage").json()
         assert [entry["job_id"] for entry in lineage["ancestors"]] == [None, str(edit_id)]
         upload = lineage["ancestors"][0]
@@ -2788,7 +2794,7 @@ def test_generation_lineage_keeps_missing_middle_ancestor():
                 await session.commit()
             return leaf_id, root_id, middle_id
 
-        leaf_id, root_id, middle_id = asyncio.run(seed())
+        leaf_id, root_id, middle_id = client.portal.call(seed)
         lineage = client.get(f"/api/v1/generations/{leaf_id}/lineage").json()
         assert [entry["job_id"] for entry in lineage["ancestors"]] == [
             str(root_id),
@@ -2832,7 +2838,7 @@ def test_generation_lineage_foreign_job_is_not_found():
                 await session.commit()
             return job_id
 
-        job_id = asyncio.run(seed())
+        job_id = client.portal.call(seed)
         response = client.get(f"/api/v1/generations/{job_id}/lineage")
         assert response.status_code == 404
         assert response.json() == {"detail": "no such generation"}
@@ -2870,7 +2876,7 @@ def test_generation_subtree_bounds_depth_and_reports_truncation(monkeypatch):
                 await session.commit()
             return root_id, ids
 
-        root_id, ids = asyncio.run(seed())
+        root_id, ids = client.portal.call(seed)
         response = client.get(f"/api/v1/generations/{root_id}/subtree")
         assert response.status_code == 200
         body = response.json()
@@ -2912,7 +2918,7 @@ def test_generation_subtree_caps_nodes_and_reports_truncation(monkeypatch):
                 await session.commit()
             return root_id
 
-        root_id = asyncio.run(seed())
+        root_id = client.portal.call(seed)
         response = client.get(f"/api/v1/generations/{root_id}/subtree")
         assert response.status_code == 200
         body = response.json()
@@ -2971,7 +2977,7 @@ def test_generation_subtree_is_owned_and_excludes_thumbnail_edges():
                 await session.commit()
             return root_id, child_id, foreign_id
 
-        root_id, child_id, foreign_id = asyncio.run(seed())
+        root_id, child_id, foreign_id = client.portal.call(seed)
         subtree = client.get(f"/api/v1/generations/{root_id}/subtree")
         assert subtree.status_code == 200
         returned = [node["generation"]["id"] for node in subtree.json()["nodes"]]
@@ -3011,7 +3017,7 @@ def test_generation_subtree_and_descendant_count_are_cycle_safe():
                 await session.commit()
             return root_id, child_id
 
-        root_id, child_id = asyncio.run(seed())
+        root_id, child_id = client.portal.call(seed)
         subtree = client.get(f"/api/v1/generations/{root_id}/subtree")
         assert subtree.status_code == 200
         assert [node["generation"]["id"] for node in subtree.json()["nodes"]] == [
@@ -3064,7 +3070,7 @@ def test_generation_lineage_descendant_depth_is_bounded(monkeypatch):
                 await session.commit()
             return root_id
 
-        root_id = asyncio.run(seed())
+        root_id = client.portal.call(seed)
         lineage = client.get(f"/api/v1/generations/{root_id}/lineage")
         assert lineage.status_code == 200
         assert lineage.json()["descendant_count"] == 1
@@ -3125,7 +3131,7 @@ def test_generation_serializer_never_signs_foreign_assets():
                 await session.commit()
             return job_id
 
-        job_id = asyncio.run(seed())
+        job_id = client.portal.call(seed)
         response = client.get(f"/api/v1/generations/{job_id}")
         assert response.status_code == 200
         assert response.json()["assets"] == []
@@ -3183,7 +3189,7 @@ def test_generation_cursor_anchor_must_match_every_filter():
                 await session.commit()
             return ids
 
-        ids = asyncio.run(seed())
+        ids = client.portal.call(seed)
         for state in states:
             for starred in (False, True):
                 for roots_only in (False, True):
@@ -3248,7 +3254,7 @@ def test_thumbnail_source_is_rejected_and_not_counted_as_derivative():
                     await session.commit()
                 return root_id, thumbnail_id
 
-            root_id, thumbnail_id = asyncio.run(seed())
+            root_id, thumbnail_id = client.portal.call(seed)
             detail = client.get(f"/api/v1/generations/{root_id}")
             assert detail.status_code == 200
             assert detail.json()["has_derivatives"] is False
@@ -3275,12 +3281,12 @@ def test_non_finite_progress_is_ignored():
     )
     try:
         for unusable in (float("nan"), float("inf"), 10 ** 400, [1], {"a": 1}, None):
-            asyncio.run(jobs.on_worker_message(worker, {
+            run_on_test_loop(jobs.on_worker_message(worker, {
                 "type": "job_progress", "job_id": str(job_id), "progress": unusable,
                 "dispatch_token": "token",
             }))
             assert job_id not in jobs.live_progress, f"{unusable!r} was stored"
-        asyncio.run(jobs.on_worker_message(worker, {
+        run_on_test_loop(jobs.on_worker_message(worker, {
             "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
             "dispatch_token": "token",
         }))
@@ -3326,7 +3332,7 @@ def test_job_done_with_unusable_numbers_leaves_the_job_recoverable():
             dispatch_token="token",
         )
         try:
-            asyncio.run(jobs.on_worker_message(worker, {
+            run_on_test_loop(jobs.on_worker_message(worker, {
                 "type": "job_done", "job_id": str(job_id), "gpu_ms": unusable,
                 "width": unusable, "height": unusable,
                 # Without the token this worker is at the current protocol and
@@ -3397,11 +3403,11 @@ def test_a_stale_dispatch_token_cannot_speak_for_the_current_attempt():
 
             # The superseded attempt reports success. It knows the job id and
             # holds the same socket, and must still not be believed.
-            asyncio.run(jobs.on_worker_message(current.worker, {
+            client.portal.call(jobs.on_worker_message, current.worker, {
                 "type": "job_done", "job_id": job_id,
                 "dispatch_token": superseded.dispatch_token,
                 "gpu_ms": 1, "width": 512, "height": 512,
-            }))
+            })
             assert jobs.inflight.get(key) is current
             assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "running"
 
@@ -3432,10 +3438,10 @@ def test_an_n1_worker_that_omits_the_dispatch_token_is_ignored():
             assert worker.receive_json()["job_id"] == job_id
             key = uuid.UUID(job_id)
             current = jobs.inflight[key]
-            asyncio.run(jobs.on_worker_message(current.worker, {
+            client.portal.call(jobs.on_worker_message, current.worker, {
                 "type": "job_done", "job_id": job_id,
                 "gpu_ms": 7, "width": 512, "height": 512,
-            }))
+            })
             assert jobs.inflight.get(key) is current
             assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "running"
             assert client.put(
@@ -3464,10 +3470,10 @@ def test_a_current_worker_that_omits_the_dispatch_token_is_ignored():
 
             key = uuid.UUID(job_id)
             current = jobs.inflight[key]
-            asyncio.run(jobs.on_worker_message(current.worker, {
+            client.portal.call(jobs.on_worker_message, current.worker, {
                 "type": "job_done", "job_id": job_id,
                 "gpu_ms": 7, "width": 512, "height": 512,
-            }))
+            })
             assert jobs.inflight.get(key) is current
             assert client.get(f"/api/v1/generations/{job_id}").json()["state"] == "running"
 
@@ -3479,7 +3485,7 @@ def test_a_current_worker_that_omits_the_dispatch_token_is_ignored():
                     )
                     return list(result.scalars())
 
-            assert asyncio.run(recorded_assets()) == []
+            assert client.portal.call(recorded_assets) == []
 
             # Finish the job with its own token, as the stale-token test
             # does: a job left running is requeued when this socket closes.
@@ -3629,7 +3635,7 @@ def test_a_non_ascii_dispatch_token_is_ignored():
         dispatch_token="token",
     )
     try:
-        asyncio.run(jobs.on_worker_message(worker, {
+        run_on_test_loop(jobs.on_worker_message(worker, {
             "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
             "dispatch_token": "caf\u00e9",
         }))
@@ -3871,7 +3877,7 @@ def test_a_worker_built_without_a_registration_is_not_lenient():
         dispatch_token="token",
     )
     try:
-        asyncio.run(jobs.on_worker_message(worker, {
+        run_on_test_loop(jobs.on_worker_message(worker, {
             "type": "job_progress", "job_id": str(job_id), "progress": 0.5,
         }))
         assert job_id not in jobs.live_progress
@@ -3889,7 +3895,7 @@ def test_a_failed_purge_is_recorded_for_the_sweep(monkeypatch):
     with TestClient(app, headers=FLEET_HEADERS) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
             fleet_hello(worker, "w-purge-recorded")
-            asyncio.run(_clear_pending_deletes())
+            client.portal.call(_clear_pending_deletes)
             job_id = client.post(
                 "/api/v1/generations",
                 json={"model_id": "sd-test", "params": {"prompt": "record"}},
@@ -3974,7 +3980,7 @@ def test_a_cancelled_cleanup_is_recorded_for_the_sweep(monkeypatch):
     with TestClient(app, headers=FLEET_HEADERS) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
             fleet_hello(worker, "w-cancel-cleanup")
-            asyncio.run(_clear_pending_deletes())
+            client.portal.call(_clear_pending_deletes)
             job_id = client.post(
                 "/api/v1/generations",
                 json={"model_id": "sd-test", "params": {"prompt": "cancel"}},
@@ -4008,7 +4014,7 @@ def test_a_failed_verdictless_collection_is_recorded_for_the_sweep(monkeypatch):
         with TestClient(app, headers=FLEET_HEADERS) as client:
             with client.websocket_connect("/api/v1/fleet") as worker:
                 fleet_hello(worker, "w-verdictless-record")
-                asyncio.run(_clear_pending_deletes())
+                client.portal.call(_clear_pending_deletes)
                 job_id = client.post(
                     "/api/v1/generations",
                     json={"model_id": "sd-test", "params": {"prompt": "verdictless"}},
@@ -4038,7 +4044,7 @@ def test_a_failed_verdictless_collection_is_recorded_for_the_sweep(monkeypatch):
 
                 monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
                 jobs.last_progress_at[uuid.UUID(job_id)] = 0.0
-                asyncio.run(jobs.sweep_stalled_jobs())
+                client.portal.call(jobs.sweep_stalled_jobs)
                 poll_until(client, job_id, "failed")
 
                 row = _await_pending_delete(second_key, client=client)
@@ -4058,7 +4064,7 @@ def test_a_failed_orphan_delete_on_the_success_path_is_recorded(monkeypatch):
     with TestClient(app, headers=FLEET_HEADERS) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
             fleet_hello(worker, "w-orphan-record")
-            asyncio.run(_clear_pending_deletes())
+            client.portal.call(_clear_pending_deletes)
             job_id = client.post(
                 "/api/v1/generations",
                 json={"model_id": "sd-test", "params": {"prompt": "orphan record"}},
@@ -4093,31 +4099,31 @@ def test_a_failed_orphan_delete_on_the_success_path_is_recorded(monkeypatch):
 
 @pytest.mark.db
 def test_the_sweep_deletes_the_object_and_drops_the_row():
-    with TestClient(app, headers=FLEET_HEADERS):
+    with TestClient(app, headers=FLEET_HEADERS) as client:
         key = f"{db.local_user_id}/sweep-success.png"
-        asyncio.run(_clear_pending_deletes())
-        asyncio.run(_seed_pending_delete(
-            key, attempts=0, due=datetime.now(timezone.utc) - timedelta(hours=1),
-        ))
+        client.portal.call(_clear_pending_deletes)
+        client.portal.call(
+            _seed_pending_delete, key, 0, datetime.now(timezone.utc) - timedelta(hours=1)
+        )
         storage = jobs.get_storage()
-        asyncio.run(_write_blob(storage, key, png_bytes()))
+        client.portal.call(_write_blob, storage, key, png_bytes())
 
-        asyncio.run(jobs.retry_pending_deletes())
+        client.portal.call(jobs.retry_pending_deletes)
 
         assert not storage.path(key).exists(), "the sweep left the object behind"
-        assert asyncio.run(_pending_delete(key)) is None, "the row survived its delete"
+        assert client.portal.call(_pending_delete, key) is None, "the row survived its delete"
 
 
 @pytest.mark.db
 def test_a_sweep_failure_backs_off_and_keeps_the_row(monkeypatch):
-    with TestClient(app, headers=FLEET_HEADERS):
+    with TestClient(app, headers=FLEET_HEADERS) as client:
         key = f"{db.local_user_id}/sweep-backoff.png"
-        asyncio.run(_clear_pending_deletes())
-        asyncio.run(_seed_pending_delete(
-            key, attempts=0, due=datetime.now(timezone.utc) - timedelta(hours=1),
-        ))
+        client.portal.call(_clear_pending_deletes)
+        client.portal.call(
+            _seed_pending_delete, key, 0, datetime.now(timezone.utc) - timedelta(hours=1)
+        )
         storage = jobs.get_storage()
-        asyncio.run(_write_blob(storage, key, png_bytes()))
+        client.portal.call(_write_blob, storage, key, png_bytes())
 
         class RefusingDelete:
             def __getattr__(self, name):
@@ -4127,9 +4133,9 @@ def test_a_sweep_failure_backs_off_and_keeps_the_row(monkeypatch):
                 raise PermissionError(f"denied {storage_key}")
 
         monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
-        asyncio.run(jobs.retry_pending_deletes())
+        client.portal.call(jobs.retry_pending_deletes)
 
-        row = asyncio.run(_pending_delete(key))
+        row = client.portal.call(_pending_delete, key)
         assert row is not None, "a failed sweep dropped the row"
         assert row.attempts == 1
         assert row.last_error is not None
@@ -4139,14 +4145,14 @@ def test_a_sweep_failure_backs_off_and_keeps_the_row(monkeypatch):
 
 @pytest.mark.db
 def test_the_eighth_failure_alerts_once_and_keeps_retrying(monkeypatch):
-    with TestClient(app, headers=FLEET_HEADERS):
+    with TestClient(app, headers=FLEET_HEADERS) as client:
         key = f"{db.local_user_id}/give-up.png"
-        asyncio.run(_clear_pending_deletes())
-        asyncio.run(_seed_pending_delete(
-            key, attempts=7, due=datetime.now(timezone.utc) - timedelta(minutes=1),
-        ))
+        client.portal.call(_clear_pending_deletes)
+        client.portal.call(
+            _seed_pending_delete, key, 7, datetime.now(timezone.utc) - timedelta(minutes=1)
+        )
         storage = jobs.get_storage()
-        asyncio.run(_write_blob(storage, key, png_bytes()))
+        client.portal.call(_write_blob, storage, key, png_bytes())
 
         class RefusingDelete:
             def __getattr__(self, name):
@@ -4163,9 +4169,9 @@ def test_the_eighth_failure_alerts_once_and_keeps_retrying(monkeypatch):
         jobs.logger.addHandler(handler)
         try:
             monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
-            asyncio.run(jobs.retry_pending_deletes())
+            client.portal.call(jobs.retry_pending_deletes)
 
-            row = asyncio.run(_pending_delete(key))
+            row = client.portal.call(_pending_delete, key)
             assert row is not None, "the record of the object was thrown away"
             assert row.attempts == jobs.PENDING_DELETE_MAX_ATTEMPTS
             assert storage.path(key).exists(), "the failing delete removed the object"
@@ -4173,21 +4179,21 @@ def test_the_eighth_failure_alerts_once_and_keeps_retrying(monkeypatch):
 
             # Ninth failure: still retried, and silent. Alerting on every
             # failure past the eighth would bury the one line that matters.
-            asyncio.run(_make_due(key))
-            asyncio.run(jobs.retry_pending_deletes())
+            client.portal.call(_make_due, key)
+            client.portal.call(jobs.retry_pending_deletes)
             assert sum("still cannot delete" in message for message in messages) == 1
-            row = asyncio.run(_pending_delete(key))
+            row = client.portal.call(_pending_delete, key)
             assert row is not None and row.attempts == jobs.PENDING_DELETE_MAX_ATTEMPTS + 1
 
             # Still scheduled, because an outage can outlive the backoff and a
             # row nothing retries is a leak with no way back. Due again within
             # the hour cap, and the next healthy sweep collects it.
             assert row.next_attempt_at is not None
-            asyncio.run(_make_due(key))
+            client.portal.call(_make_due, key)
             monkeypatch.undo()
-            asyncio.run(jobs.retry_pending_deletes())
+            client.portal.call(jobs.retry_pending_deletes)
             assert not storage.path(key).exists(), "recovery never collected the object"
-            assert asyncio.run(_pending_delete(key)) is None
+            assert client.portal.call(_pending_delete, key) is None
         finally:
             jobs.logger.removeHandler(handler)
 
@@ -4196,15 +4202,15 @@ def test_the_eighth_failure_alerts_once_and_keeps_retrying(monkeypatch):
 def test_recording_a_key_again_does_not_undo_its_backoff():
     """The upsert can be waiting on the sweep's row lock, so writing its own
     due time would hand back a key the sweep had just pushed an hour out."""
-    with TestClient(app, headers=FLEET_HEADERS):
+    with TestClient(app, headers=FLEET_HEADERS) as client:
         key = f"{db.local_user_id}/re-record.png"
-        asyncio.run(_clear_pending_deletes())
+        client.portal.call(_clear_pending_deletes)
         later = datetime.now(timezone.utc) + timedelta(minutes=30)
-        asyncio.run(_seed_pending_delete(key, attempts=3, due=later))
+        client.portal.call(_seed_pending_delete, key, 3, later)
 
-        asyncio.run(jobs.record_pending_delete(key, "denied again"))
+        client.portal.call(jobs.record_pending_delete, key, "denied again")
 
-        row = asyncio.run(_pending_delete(key))
+        row = client.portal.call(_pending_delete, key)
         assert row is not None
         assert row.last_error == "denied again", "the new error was not recorded"
         assert row.next_attempt_at == later, "the backoff was reset by a re-recording"
@@ -4213,20 +4219,20 @@ def test_recording_a_key_again_does_not_undo_its_backoff():
 
 @pytest.mark.db
 def test_a_sweep_retries_only_rows_that_are_due():
-    with TestClient(app, headers=FLEET_HEADERS):
+    with TestClient(app, headers=FLEET_HEADERS) as client:
         due_key = f"{db.local_user_id}/due.png"
         future_key = f"{db.local_user_id}/not-due.png"
         now = datetime.now(timezone.utc)
-        asyncio.run(_clear_pending_deletes())
-        asyncio.run(_seed_pending_delete(due_key, attempts=0, due=now - timedelta(minutes=5)))
-        asyncio.run(_seed_pending_delete(future_key, attempts=0, due=now + timedelta(hours=1)))
+        client.portal.call(_clear_pending_deletes)
+        client.portal.call(_seed_pending_delete, due_key, 0, now - timedelta(minutes=5))
+        client.portal.call(_seed_pending_delete, future_key, 0, now + timedelta(hours=1))
         storage = jobs.get_storage()
-        asyncio.run(_write_blob(storage, due_key, png_bytes()))
-        asyncio.run(_write_blob(storage, future_key, png_bytes()))
+        client.portal.call(_write_blob, storage, due_key, png_bytes())
+        client.portal.call(_write_blob, storage, future_key, png_bytes())
 
-        asyncio.run(jobs.retry_pending_deletes())
+        client.portal.call(jobs.retry_pending_deletes)
 
         assert not storage.path(due_key).exists(), "the due key was not retried"
         assert storage.path(future_key).exists(), "a key that was not due got deleted"
-        assert asyncio.run(_pending_delete(due_key)) is None
-        assert asyncio.run(_pending_delete(future_key)) is not None
+        assert client.portal.call(_pending_delete, due_key) is None
+        assert client.portal.call(_pending_delete, future_key) is not None

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1466,7 +1466,7 @@ def test_completed_event_uses_the_persisted_asset_url(monkeypatch):
                         select(Asset.storage_key).where(Asset.id == uuid.UUID(asset_id))
                     ))
 
-            storage_key = asyncio.run(asset_storage_key())
+            storage_key = client.portal.call(asset_storage_key)
 
             deadline = time.monotonic() + 3
             while time.monotonic() < deadline and not any(
@@ -3387,6 +3387,7 @@ def test_a_stale_dispatch_token_cannot_speak_for_the_current_attempt():
                 json={"model_id": "sd-test", "params": {"prompt": "token"}},
             ).json()["job_id"]
             assert worker.receive_json()["job_id"] == job_id
+            poll_until(client, job_id, "running")
 
             # What a requeue to the same worker leaves behind: a new entry,
             # same Worker object, new key, new token.
@@ -3436,6 +3437,7 @@ def test_an_n1_worker_that_omits_the_dispatch_token_is_ignored():
                 json={"model_id": "sd-test", "params": {"prompt": "n-1"}},
             ).json()["job_id"]
             assert worker.receive_json()["job_id"] == job_id
+            poll_until(client, job_id, "running")
             key = uuid.UUID(job_id)
             current = jobs.inflight[key]
             client.portal.call(jobs.on_worker_message, current.worker, {
@@ -3467,6 +3469,7 @@ def test_a_current_worker_that_omits_the_dispatch_token_is_ignored():
                 json={"model_id": "sd-test", "params": {"prompt": "missing token"}},
             ).json()["job_id"]
             assert worker.receive_json()["job_id"] == job_id
+            poll_until(client, job_id, "running")
 
             key = uuid.UUID(job_id)
             current = jobs.inflight[key]

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
@@ -14,45 +15,28 @@ from app.settings import get_settings
 
 
 @pytest.mark.parametrize("mode", ["local", "oauth"])
-def test_unimplemented_auth_mode_refuses_to_start(monkeypatch, mode):
-    """An unimplemented AUTH_MODE must fail startup loudly, not silently downgrade.
-
-    current_user never reads the mode and resolves every request to the local
-    admin user, so leaving local or oauth configured would serve the API with
-    no authentication at all. The lifespan raises on entry, before the rest of
-    the process comes up.
-    """
+def test_retired_auth_mode_fails_settings_validation(monkeypatch, mode):
     monkeypatch.setenv("AUTH_MODE", mode)
     get_settings.cache_clear()
     try:
-        # Match the mode as well as the variable: a message naming a mode the
-        # operator never set would satisfy the looser check while telling them
-        # to fix the wrong thing.
-        with pytest.raises(RuntimeError, match=f"AUTH_MODE={mode}"):
-            with TestClient(app):
-                pass
+        with pytest.raises(ValidationError) as error:
+            get_settings()
+        assert mode in str(error.value)
+        assert "none" in str(error.value)
+        assert "accounts" in str(error.value)
     finally:
         get_settings.cache_clear()
 
 
 def test_unimplemented_auth_mode_cannot_even_import(monkeypatch):
-    """An unimplemented AUTH_MODE must refuse to import, not just to start.
-
-    The ASGI lifespan protocol is optional: uvicorn --lifespan off and a
-    TestClient outside a context manager serve the app without it, so a gate
-    that runs only inside lifespan is bypassable. Importing the module is
-    unavoidable, so the gate must fire there too.
-    """
-    monkeypatch.setenv("AUTH_MODE", "local")
+    monkeypatch.setenv("AUTH_MODE", "accounts")
     get_settings.cache_clear()
     try:
-        with pytest.raises(RuntimeError, match="AUTH_MODE=local"):
+        with pytest.raises(RuntimeError, match="AUTH_MODE=accounts"):
             importlib.reload(main_module)
     finally:
         monkeypatch.delenv("AUTH_MODE", raising=False)
         get_settings.cache_clear()
-        # Reload with the environment restored so the module left in
-        # sys.modules is the good one and later tests are not poisoned.
         importlib.reload(main_module)
 
 

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -83,7 +83,7 @@ def test_registration_persists_worker_identity():
     with TestClient(app, headers=FLEET_HEADERS) as client:
         with client.websocket_connect("/api/v1/fleet") as worker:
             fleet_hello(worker, "w-identity")
-            identity = asyncio.run(_wait_for_worker("w-identity"))
+            identity = client.portal.call(_wait_for_worker, "w-identity")
             assert identity is not None
             assert identity.device == "rocm"
             assert identity.memory_mode == "model_offload"
@@ -112,8 +112,8 @@ def test_maintenance_prunes_stale_worker_identities():
                 await session.get(WorkerIdentity, "w-retention-recent"),
             )
 
-    with TestClient(app, headers=FLEET_HEADERS):
-        stale, recent = asyncio.run(exercise())
+    with TestClient(app, headers=FLEET_HEADERS) as client:
+        stale, recent = client.portal.call(exercise)
         assert stale is None
         assert recent is not None
 
@@ -252,8 +252,8 @@ def test_usage_event_maintenance_rolls_up_prunes_and_is_idempotent(monkeypatch):
             await session.commit()
         return first_rebuild, second_rebuild, first, second
 
-    with TestClient(app, headers=FLEET_HEADERS):
-        first_rebuild, second_rebuild, first, second = asyncio.run(exercise())
+    with TestClient(app, headers=FLEET_HEADERS) as client:
+        first_rebuild, second_rebuild, first, second = client.portal.call(exercise)
 
     assert first_rebuild == second_rebuild
     assert first == second
@@ -299,8 +299,8 @@ def test_usage_event_rollups_are_hard_deleted_with_user():
         async with db.session_factory() as session:
             return await session.get(UsageEventRollup, rollup_id)
 
-    with TestClient(app, headers=FLEET_HEADERS):
-        assert asyncio.run(exercise()) is None
+    with TestClient(app, headers=FLEET_HEADERS) as client:
+        assert client.portal.call(exercise) is None
 
 
 @pytest.mark.db
@@ -322,7 +322,7 @@ def test_heartbeat_persists_gpu_sample():
                     "power_w": 120.0,
                 },
             })
-            rows = asyncio.run(_wait_for_samples())
+            rows = client.portal.call(_wait_for_samples)
             assert rows, "heartbeat sample was not persisted"
             row = rows[0]
             assert row.worker_id == "w-metrics"
@@ -338,7 +338,7 @@ def test_heartbeat_persists_gpu_sample():
                 async with db.session_factory() as session:
                     return await session.get(WorkerIdentity, "w-metrics")
 
-            identity = asyncio.run(read_worker())
+            identity = client.portal.call(read_worker)
             assert identity is not None
             assert identity.device == "rocm"
             assert identity.memory_mode == "model_offload"
@@ -361,14 +361,14 @@ def test_gpu_history_round_trip():
 
     with TestClient(app, headers=FLEET_HEADERS) as client:
         assert db.session_factory is not None
-        asyncio.run(_clear_gpu_metrics())
+        client.portal.call(_clear_gpu_metrics)
 
         async def insert():
             async with db.session_factory() as session:
                 session.add(sample)
                 await session.commit()
 
-        asyncio.run(insert())
+        client.portal.call(insert)
 
         response = client.get(
             "/api/v1/metrics/gpu/history",
@@ -415,7 +415,7 @@ def test_job_dispatch_and_finish_timestamps():
             job = None
             deadline = time.monotonic() + 3.0
             while time.monotonic() < deadline:
-                job = asyncio.run(read_job())
+                job = client.portal.call(read_job)
                 assert job is not None
                 if job.dispatched_at is not None and job.state == "running":
                     break
@@ -435,7 +435,7 @@ def test_job_dispatch_and_finish_timestamps():
 
             deadline = time.monotonic() + 3.0
             while time.monotonic() < deadline:
-                job = asyncio.run(read_job())
+                job = client.portal.call(read_job)
                 if job.state in ("failed", "succeeded"):
                     break
                 time.sleep(0.05)

--- a/backend/tests/test_realtime.py
+++ b/backend/tests/test_realtime.py
@@ -3,6 +3,7 @@ import time
 import uuid
 
 import pytest
+from conftest import run_on_test_loop
 from fastapi.testclient import TestClient
 from sqlalchemy import select
 from starlette.datastructures import Address, Headers
@@ -223,7 +224,7 @@ def test_a_refused_fleet_handshake_is_never_accepted(monkeypatch):
         "server": ("127.0.0.1", 8000),
         "subprotocols": [],
     }
-    asyncio.run(app(scope, receive, send))
+    run_on_test_loop(app(scope, receive, send))
 
     assert sent, "the endpoint sent nothing at all"
     assert sent[0]["type"] == "websocket.close", sent
@@ -862,9 +863,9 @@ def test_closed_session_persists_usage_event():
                     return row is not None and row.frames == 3 and row.action == "draw"
 
             deadline = time.monotonic() + 3
-            while time.monotonic() < deadline and not asyncio.run(persisted()):
+            while time.monotonic() < deadline and not db_client.portal.call(persisted):
                 time.sleep(0.05)
-            assert asyncio.run(persisted())
+            assert db_client.portal.call(persisted)
 
 
 @pytest.mark.db
@@ -1181,7 +1182,7 @@ def test_assign_timeout_sends_close_session(monkeypatch):
             realtime.workers.pop(worker.id, None)
             realtime.sessions.pop(session.id, None)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_assign_does_not_decrement_again_when_release_already_did(monkeypatch):
@@ -1219,7 +1220,7 @@ def test_assign_does_not_decrement_again_when_release_already_did(monkeypatch):
             realtime.workers.pop(worker.id, None)
             realtime.sessions.pop(session.id, None)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_reassign_retries_another_protocol_4_worker(monkeypatch):
@@ -1262,7 +1263,7 @@ def test_reassign_retries_another_protocol_4_worker(monkeypatch):
             realtime.workers.pop(spare.id, None)
             realtime.sessions.pop(session.id, None)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_reassign_moves_the_session_with_correct_accounting():
@@ -1294,7 +1295,7 @@ def test_reassign_moves_the_session_with_correct_accounting():
             realtime.workers.pop(replacement.id, None)
             realtime.sessions.pop(session.id, None)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_reassign_sends_the_same_seed_to_the_replacement_worker():
@@ -1326,7 +1327,7 @@ def test_reassign_sends_the_same_seed_to_the_replacement_worker():
             realtime.workers.pop(replacement.id, None)
             realtime.sessions.pop(session.id, None)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_reaper_closes_silent_workers():
@@ -1335,7 +1336,7 @@ def test_reaper_closes_silent_workers():
     fresh = realtime.Worker(id="w-fresh", ws=FakeSocket(), manifests=[], realtime_slots=1)
     realtime.workers.update({stale.id: stale, fresh.id: fresh})
     try:
-        asyncio.run(realtime.reap_once())
+        run_on_test_loop(realtime.reap_once())
         assert stale.ws.close_code is not None
         assert fresh.ws.close_code is None
     finally:
@@ -1480,16 +1481,16 @@ def test_session_closed_from_another_worker_is_ignored():
                                 "category": "other"})
             deadline = time.monotonic() + 1.5
             while time.monotonic() < deadline:
-                assert 9999 not in asyncio.run(recorded()), "a stranger closed the session"
+                assert 9999 not in db_client.portal.call(recorded), "a stranger closed the session"
                 time.sleep(0.05)
 
             owner_ws.send_json({"type": "session_closed", "session_id": session_id,
                                 "frames": 7, "gpu_ms": 70, "duration_ms": 700,
                                 "category": "other"})
             deadline = time.monotonic() + 3
-            while time.monotonic() < deadline and 7 not in asyncio.run(recorded()):
+            while time.monotonic() < deadline and 7 not in db_client.portal.call(recorded):
                 time.sleep(0.05)
-            assert 7 in asyncio.run(recorded()), "the owner's close was not recorded"
+            assert 7 in db_client.portal.call(recorded), "the owner's close was not recorded"
 
 
 def test_cost_admission_keeps_mixed_load_inside_the_bar():
@@ -1705,7 +1706,7 @@ def test_session_refused_reassigns_to_another_protocol_4_worker():
             realtime.workers.pop(spare.id, None)
             realtime.sessions.pop(session.id, None)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_session_refused_with_no_other_worker_closes_4003():
@@ -1826,7 +1827,7 @@ def test_stale_close_generation_is_not_sent_after_reassign():
             realtime.workers.update(saved_workers)
             realtime.sessions.update(saved_sessions)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_over_capacity_drops_newest_protocol_4_session():
@@ -1938,7 +1939,7 @@ def test_heartbeat_p95_increase_reassigns_newest_protocol_4_session():
             realtime.workers.update(saved_workers)
             realtime.sessions.update(saved_sessions)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_schedule_reassign_starts_only_one_placement():
@@ -1983,7 +1984,7 @@ def test_schedule_reassign_starts_only_one_placement():
             realtime.workers.update(saved_workers)
             realtime.sessions.update(saved_sessions)
 
-    asyncio.run(scenario())
+    run_on_test_loop(scenario())
 
 
 def test_ended_absorbs_transitions():

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import threading
 import struct
 import uuid
 import zlib
@@ -871,3 +872,48 @@ def test_local_delete_does_not_block_the_event_loop(tmp_path):
 
     assert asyncio.run(drive()) == ["loop kept running", "delete returned"]
     assert not (tmp_path / "u" / "j.png").exists()
+
+
+def _wedged_local(tmp_path, release):
+    class WedgedRoot:
+        def is_dir(self) -> bool:
+            release.wait(10)
+            return True
+
+    storage = LocalStorage(str(tmp_path), "http://browser", "http://worker")
+    storage.root = WedgedRoot()
+    return storage
+
+
+def _wedged_s3(_tmp_path, release):
+    class WedgedClient:
+        def head_bucket(self, **_kwargs) -> None:
+            release.wait(10)
+
+    storage = S3Storage.__new__(S3Storage)
+    storage.bucket = "bucket"
+    storage.client = WedgedClient()
+    return storage
+
+
+@pytest.mark.parametrize("build", [_wedged_local, _wedged_s3])
+def test_readiness_probes_cannot_starve_other_off_loop_work(tmp_path, build):
+    """/api/v1/ready takes no principal, so its probe rate is attacker paced.
+
+    A wedged store abandons one thread per probe for good, and in the shared
+    default executor that eventually starves every other off-loop call the app
+    makes: uploads, image inspection, promotion copies, purges.
+    """
+    release = threading.Event()
+    storage = build(tmp_path, release)
+
+    async def drive() -> str:
+        probes = [asyncio.ensure_future(storage.ready()) for _ in range(64)]
+        await asyncio.sleep(0.2)
+        try:
+            return await asyncio.wait_for(asyncio.to_thread(lambda: "other work ran"), 2)
+        finally:
+            release.set()
+            await asyncio.gather(*probes, return_exceptions=True)
+
+    assert asyncio.run(drive()) == "other work ran"

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 import uuid
@@ -55,7 +54,7 @@ def test_telemetry_preview_is_exact_daily_aggregate():
             await session.commit()
 
     with TestClient(app) as client:
-        asyncio.run(seed())
+        client.portal.call(seed)
         response = client.get("/api/v1/telemetry/preview")
         assert response.status_code == 200
         payload = response.json()
@@ -91,8 +90,8 @@ def test_failed_telemetry_send_is_marked_and_dropped(monkeypatch):
             expected = datetime.now(timezone.utc).date() - timedelta(days=1)
             assert state.last_report_day == expected
 
-    with TestClient(app):
-        asyncio.run(exercise())
+    with TestClient(app) as client:
+        client.portal.call(exercise)
 
 
 @pytest.mark.db
@@ -125,5 +124,5 @@ def test_usage_events_are_hard_deleted_with_user():
         async with db.session_factory() as session:
             assert await session.get(UsageEvent, event_id) is None
 
-    with TestClient(app):
-        asyncio.run(exercise())
+    with TestClient(app) as client:
+        client.portal.call(exercise)

--- a/docs/api.md
+++ b/docs/api.md
@@ -23,6 +23,7 @@ Every call a customer's browser makes, from first page load to account deletion.
 | Method and path | Status | Purpose |
 |---|---|---|
 | GET `/api/v1/health` | implemented | process liveness for the load balancer |
+| GET `/api/v1/ready` | implemented | PostgreSQL and asset-storage readiness |
 | GET `/api/v1/config` | implemented | runtime configuration for the SPA |
 | WS `/api/v1/realtime` | implemented (prototype) | realtime drawing sessions |
 | WS `/api/v1/fleet` | implemented (prototype) | worker fleet connection, not for browsers: a handshake carrying a non-allowlisted `Origin` is refused, as is one without the `X-Fleet-Token` shared secret |
@@ -65,6 +66,12 @@ Answers from process state only, so a database incident cannot convince the load
 ```json
 {"status": "ok"}
 ```
+
+### GET /api/v1/ready
+
+Checks PostgreSQL and the configured asset store. It returns `200` when both
+are available and `503` otherwise. Use `/api/v1/health` for process liveness;
+this endpoint reports whether required data services are ready.
 
 ### GET /api/v1/config
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -135,6 +135,9 @@ An exported `DATABASE_URL` opts out of that: it is shared by every run in the
 shell, and the suite will migrate it and write to it, though it never drops,
 rebuilds or empties it. Give it a database name of its own.
 
+The database test harness keeps setup, routes, and disposal on one event loop.
+The runtime database engine uses a bounded connection pool.
+
 ```bash
 
 # worker, from worker/


### PR DESCRIPTION
# Description

Add a readiness probe, a bounded database connection pool, and a one-way guard that stops an installation with accounts enabled from restarting without them.

# Motivation

The load balancer had only a liveness route, which answers from process state and cannot tell whether PostgreSQL and the asset store are usable. The database engine used no pool, so every request opened a new connection. An installation also had no persistent record of the authentication mode it had already adopted, so a configuration change could silently return it to unauthenticated operation.

# Functionality

`GET /api/v1/ready` checks PostgreSQL and the configured asset store and returns 200 or 503 with an empty body. The runtime engine uses a bounded pool. A new `installation_auth_state` table records that an installation enabled accounts; startup refuses to continue if the configured mode contradicts that record. A dependency guard rejects account-dependent requests with 503 while the database is unavailable, and a PostgreSQL advisory lock keeps two account startups from running at the same time.

# Details

Base is `security/auth-r1-endpoint-hardening` (PR #358); it retargets to `main` after that merges.

The mode literal is now `none` or `accounts`, and `auth_methods` reports `password`, `google`, and `github`. Unknown OAuth provider names are dropped instead of forwarded. `accounts` still refuses to boot because no account route exists yet, so the guard and the advisory lock are inert rails for the rounds that add sign-up and sign-in.

The database test harness now keeps setup, routes, and disposal on one event loop, which the bounded pool requires. Local verification passed 391 backend tests, 194 worker tests, the frontend suite, Ruff, mypy, Svelte checks, the production build, and CSP verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a readiness endpoint that reports database and asset-storage availability.
  - Added persistent account-mode tracking and coordinated startup handling.
  - Limited authentication modes to `none` and `accounts`, with password and supported OAuth providers.

- **Bug Fixes**
  - Improved startup validation and prevented inconsistent authentication configuration.
  - Added bounded readiness checks for local and S3 storage.

- **Documentation**
  - Documented readiness responses and local development behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->