### PR TITLE
Add the account schema and the root key ring

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import (
 )
 from sqlalchemy.pool import NullPool
 
+from app.keyring import KeyRingError, get_key_ring
 from app.settings import get_settings
 from app.tables import InstallationAuthState, User
 
@@ -89,6 +90,7 @@ async def connect() -> bool:
     engine = create_async_engine(async_url(settings.database_url), pool_size=5, max_overflow=10)
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
     await validate_startup_auth_mode(settings.auth_mode)
+    await validate_startup_key_ring()
     local_user_id = await _ensure_local_user(session_factory)
     return True
 
@@ -149,6 +151,32 @@ async def enable_accounts_mode(
                     "VALUES (1, 'accounts') ON CONFLICT (id) DO NOTHING"
                 )
             )
+
+
+async def read_installation_root_key_version() -> int | None:
+    if session_factory is None:
+        raise RuntimeError("database unavailable")
+    async with session_factory() as session:
+        state = await session.get(InstallationAuthState, 1)
+        return state.root_key_version if state is not None else None
+
+
+async def validate_startup_key_ring() -> None:
+    """PostgreSQL is the authority on the version this installation writes with.
+
+    A ring that no longer holds it cannot read anything written since, so
+    refusing to start is the only honest outcome: coming up would answer with
+    an installation that silently lost every encrypted secret.
+    """
+    recorded = await read_installation_root_key_version()
+    if recorded is None:
+        return
+    try:
+        ring = get_key_ring()
+    except KeyRingError as error:
+        raise RuntimeError(f"root key ring is unusable: {error}") from error
+    if recorded not in ring.versions:
+        raise RuntimeError(f"root key version {recorded} is missing from the key ring")
 
 
 async def validate_startup_auth_mode(configured: str) -> None:

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -147,9 +147,10 @@ async def enable_accounts_mode(
         async with session.begin():
             await session.execute(
                 text(
-                    "INSERT INTO installation_auth_state (id, auth_mode) "
-                    "VALUES (1, 'accounts') ON CONFLICT (id) DO NOTHING"
-                )
+                    "INSERT INTO installation_auth_state (id, auth_mode, root_key_version) "
+                    "VALUES (1, 'accounts', :version) ON CONFLICT (id) DO NOTHING"
+                ),
+                {"version": get_key_ring().active_version},
             )
 
 

--- a/backend/app/keyring.py
+++ b/backend/app/keyring.py
@@ -15,7 +15,7 @@ _KEY_BYTES = 32
 _VERSION_BYTES = 2
 _NONCE_BYTES = 12
 _TAG_BYTES = 16
-_MAX_VERSION = 2 ** (_VERSION_BYTES * 8) - 1
+_MAX_VERSION = 32767
 
 
 class KeyRingError(Exception):
@@ -31,6 +31,7 @@ def parse_root_keys(raw: str) -> list[tuple[int, bytes]]:
     """Refuses every entry it cannot fully trust, so a misread ring never becomes a weaker one."""
     entries: list[tuple[int, bytes]] = []
     seen: set[int] = set()
+    seen_keys: set[bytes] = set()
     for item in raw.split(","):
         version_text, separator, key_text = item.strip().partition(":")
         if not separator:
@@ -49,12 +50,22 @@ def parse_root_keys(raw: str) -> list[tuple[int, bytes]]:
             raise KeyRingError("root key must be base64") from None
         if len(key) != _KEY_BYTES:
             raise KeyRingError("root key must decode to 32 bytes")
+        if key in seen_keys:
+            raise KeyRingError("root keys must be distinct")
         seen.add(version)
+        seen_keys.add(key)
         entries.append((version, key))
     return entries
 
 
 class KeyRing:
+    """Values are bound to a purpose and to a caller-named context.
+
+    aad has no default on purpose: a blob encrypted with nothing bound to it
+    verifies in any row of its purpose, so a caller with nothing to bind says
+    so rather than leaving it out.
+    """
+
     def __init__(self, entries: list[tuple[int, bytes]]) -> None:
         if not entries:
             raise KeyRingError("a key ring needs at least one root key")
@@ -65,6 +76,8 @@ class KeyRing:
                 raise KeyRingError("root key must be 32 bytes")
         if len({version for version, _ in entries}) != len(entries):
             raise KeyRingError("root key versions must be unique")
+        if len({key for _, key in entries}) != len(entries):
+            raise KeyRingError("root keys must be distinct")
         self._roots = dict(entries)
         self._active = entries[0][0]
 
@@ -91,7 +104,7 @@ class KeyRing:
         )
         return kdf.derive(self._root(version))
 
-    def encrypt(self, purpose: str, plaintext: bytes, aad: bytes = b"") -> bytes:
+    def encrypt(self, purpose: str, plaintext: bytes, aad: bytes) -> bytes:
         nonce = os.urandom(_NONCE_BYTES)
         ciphertext = AESGCM(self.derive(purpose)).encrypt(
             nonce, plaintext, _associated_data(purpose, aad)
@@ -103,7 +116,7 @@ class KeyRing:
             raise KeyRingError("blob is too short to hold a version, a nonce and a tag")
         return int.from_bytes(blob[:_VERSION_BYTES], "big")
 
-    def decrypt(self, purpose: str, blob: bytes, aad: bytes = b"") -> bytes:
+    def decrypt(self, purpose: str, blob: bytes, aad: bytes) -> bytes:
         key = self.derive(purpose, self.version_of(blob))
         nonce = blob[_VERSION_BYTES:_VERSION_BYTES + _NONCE_BYTES]
         try:
@@ -113,7 +126,7 @@ class KeyRing:
         except InvalidTag:
             raise KeyRingError("blob does not verify under this purpose, aad and version") from None
 
-    def reencrypt(self, purpose: str, blob: bytes, aad: bytes = b"") -> bytes:
+    def reencrypt(self, purpose: str, blob: bytes, aad: bytes) -> bytes:
         return self.encrypt(purpose, self.decrypt(purpose, blob, aad), aad)
 
 

--- a/backend/app/keyring.py
+++ b/backend/app/keyring.py
@@ -1,0 +1,124 @@
+"""Versioned root key ring: HKDF purpose keys, AES-GCM values, rotation without downtime."""
+
+import base64
+import os
+import struct
+from functools import lru_cache
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+_APPLICATION = b"potocolom root key ring v1"
+_KEY_BYTES = 32
+_VERSION_BYTES = 2
+_NONCE_BYTES = 12
+_TAG_BYTES = 16
+_MAX_VERSION = 2 ** (_VERSION_BYTES * 8) - 1
+
+
+class KeyRingError(Exception):
+    pass
+
+
+def _associated_data(purpose: str, aad: bytes) -> bytes:
+    name = purpose.encode()
+    return struct.pack(">I", len(name)) + name + aad
+
+
+def parse_root_keys(raw: str) -> list[tuple[int, bytes]]:
+    """Refuses every entry it cannot fully trust, so a misread ring never becomes a weaker one."""
+    entries: list[tuple[int, bytes]] = []
+    seen: set[int] = set()
+    for item in raw.split(","):
+        version_text, separator, key_text = item.strip().partition(":")
+        if not separator:
+            raise KeyRingError("root key entry must be version:base64key")
+        try:
+            version = int(version_text)
+        except ValueError:
+            raise KeyRingError("root key version must be an integer") from None
+        if not 1 <= version <= _MAX_VERSION:
+            raise KeyRingError(f"root key version must be between 1 and {_MAX_VERSION}")
+        if version in seen:
+            raise KeyRingError("root key versions must be unique")
+        try:
+            key = base64.b64decode(key_text, validate=True)
+        except ValueError:
+            raise KeyRingError("root key must be base64") from None
+        if len(key) != _KEY_BYTES:
+            raise KeyRingError("root key must decode to 32 bytes")
+        seen.add(version)
+        entries.append((version, key))
+    return entries
+
+
+class KeyRing:
+    def __init__(self, entries: list[tuple[int, bytes]]) -> None:
+        if not entries:
+            raise KeyRingError("a key ring needs at least one root key")
+        for version, key in entries:
+            if not 1 <= version <= _MAX_VERSION:
+                raise KeyRingError(f"root key version must be between 1 and {_MAX_VERSION}")
+            if len(key) != _KEY_BYTES:
+                raise KeyRingError("root key must be 32 bytes")
+        if len({version for version, _ in entries}) != len(entries):
+            raise KeyRingError("root key versions must be unique")
+        self._roots = dict(entries)
+        self._active = entries[0][0]
+
+    @property
+    def active_version(self) -> int:
+        return self._active
+
+    @property
+    def versions(self) -> frozenset[int]:
+        return frozenset(self._roots)
+
+    def _root(self, version: int | None) -> bytes:
+        root = self._roots.get(self._active if version is None else version)
+        if root is None:
+            raise KeyRingError("root key version is not in the ring")
+        return root
+
+    def derive(self, purpose: str, version: int | None = None) -> bytes:
+        kdf = HKDF(
+            algorithm=hashes.SHA256(),
+            length=_KEY_BYTES,
+            salt=None,
+            info=_APPLICATION + b"|" + purpose.encode(),
+        )
+        return kdf.derive(self._root(version))
+
+    def encrypt(self, purpose: str, plaintext: bytes, aad: bytes = b"") -> bytes:
+        nonce = os.urandom(_NONCE_BYTES)
+        ciphertext = AESGCM(self.derive(purpose)).encrypt(
+            nonce, plaintext, _associated_data(purpose, aad)
+        )
+        return struct.pack(">H", self._active) + nonce + ciphertext
+
+    def version_of(self, blob: bytes) -> int:
+        if len(blob) < _VERSION_BYTES + _NONCE_BYTES + _TAG_BYTES:
+            raise KeyRingError("blob is too short to hold a version, a nonce and a tag")
+        return int.from_bytes(blob[:_VERSION_BYTES], "big")
+
+    def decrypt(self, purpose: str, blob: bytes, aad: bytes = b"") -> bytes:
+        key = self.derive(purpose, self.version_of(blob))
+        nonce = blob[_VERSION_BYTES:_VERSION_BYTES + _NONCE_BYTES]
+        try:
+            return AESGCM(key).decrypt(
+                nonce, blob[_VERSION_BYTES + _NONCE_BYTES:], _associated_data(purpose, aad)
+            )
+        except InvalidTag:
+            raise KeyRingError("blob does not verify under this purpose, aad and version") from None
+
+    def reencrypt(self, purpose: str, blob: bytes, aad: bytes = b"") -> bytes:
+        return self.encrypt(purpose, self.decrypt(purpose, blob, aad), aad)
+
+
+@lru_cache
+def get_key_ring() -> KeyRing:
+    from app.settings import get_settings
+
+    return KeyRing(parse_root_keys(get_settings().root_keys))

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -14,6 +14,11 @@ class Settings(BaseSettings):
     log_format: Literal["plain", "json"] = "plain"
     fleet_token_key: str = ""
 
+    # Versioned root key ring, comma separated version:base64key entries, newest first.
+    # The first entry is the active write key; every entry stays readable so rotation is
+    # active write, multi read, re-encrypt, then remove. Separate from FLEET_TOKEN_KEY.
+    root_keys: str = ""
+
     # PUBLIC_URL is where browsers reach this API; asset URLs in responses use it.
     public_url: str = "http://localhost:8000"
 

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -8,8 +8,8 @@ import uuid
 from datetime import date, datetime
 
 from sqlalchemy import (
-    BigInteger, Date, DateTime, Float, ForeignKey, Index, Integer, SmallInteger, Text,
-    text,
+    BigInteger, CheckConstraint, Date, DateTime, Float, ForeignKey, Index, Integer,
+    LargeBinary, SmallInteger, Text, UniqueConstraint, text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
@@ -19,13 +19,190 @@ class Base(DeclarativeBase):
     type_annotation_map = {datetime: DateTime(timezone=True)}  # timestamptz everywhere
 
 
+ROLES = ("viewer", "user", "admin")
+ACCOUNT_STATES = ("active", "suspended", "disabled", "deletion_pending", "purging")
+IDENTITY_PROVIDERS = ("password", "google", "github")
+AUTH_TOKEN_PURPOSES = ("setup", "reset", "recovery", "challenge")
+OUTBOX_STATES = ("pending", "sent", "failed")
+NORMALIZED_EMAIL = text("lower(btrim(email))")
+
+
+def _one_of(column: str, allowed: tuple[str, ...]) -> str:
+    return f"{column} IN (" + ", ".join(f"'{value}'" for value in allowed) + ")"
+
+
 class User(Base):
     __tablename__ = "users"
+    __table_args__ = (
+        CheckConstraint(_one_of("role", ROLES), name="users_role"),
+        CheckConstraint(_one_of("state", ACCOUNT_STATES), name="users_state"),
+        # Two addresses that differ only by case or padding are one account.
+        Index("users_email_normalized", NORMALIZED_EMAIL, unique=True),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     email: Mapped[str] = mapped_column(Text, unique=True)
+    mail_verified: Mapped[bool] = mapped_column(default=False, server_default=text("false"))
     role: Mapped[str] = mapped_column(Text, default="user")
+    state: Mapped[str] = mapped_column(Text, default="active", server_default=text("'active'"))
     deleted_at: Mapped[datetime | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class AuthIdentity(Base):
+    """One way to prove an account: a local password, or a provider subject.
+
+    A provider identity is the provider's proof and never carries a local
+    credential, so the two cannot be confused for one another.
+    """
+
+    __tablename__ = "auth_identities"
+    __table_args__ = (
+        CheckConstraint(_one_of("provider", IDENTITY_PROVIDERS), name="auth_identities_provider"),
+        CheckConstraint(
+            "(provider = 'password') = (password_hash IS NOT NULL)",
+            name="auth_identities_password_hash",
+        ),
+        UniqueConstraint("provider", "subject", name="auth_identities_provider_subject"),
+        Index("auth_identities_one_password", "user_id",
+              unique=True, postgresql_where=text("provider = 'password'")),
+        Index("auth_identities_user", "user_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    provider: Mapped[str] = mapped_column(Text)
+    subject: Mapped[str] = mapped_column(Text)
+    password_hash: Mapped[str | None] = mapped_column(Text)
+    last_login_at: Mapped[datetime | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class Session(Base):
+    """Only the SHA-256 of the 32 random bytes is kept, never the token itself.
+
+    No raw address and no full user agent: a durable record of who signed in
+    from where is a standing disclosure risk that login does not need.
+    """
+
+    __tablename__ = "sessions"
+    __table_args__ = (Index("sessions_user", "user_id"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    token_hash: Mapped[bytes] = mapped_column(LargeBinary, unique=True)
+    remember_me: Mapped[bool] = mapped_column(default=False, server_default=text("false"))
+    absolute_expires_at: Mapped[datetime]
+    idle_expires_at: Mapped[datetime | None]
+    recent_auth_at: Mapped[datetime | None]
+    revoked_at: Mapped[datetime | None]
+    last_seen_at: Mapped[datetime | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class AuthToken(Base):
+    """A one-use capability, not a principal: setup, reset, recovery, or the
+    pre-session challenge a primary login mints before TOTP is checked.
+
+    Setup carries no user because nobody has claimed the installation yet.
+    """
+
+    __tablename__ = "auth_tokens"
+    __table_args__ = (
+        CheckConstraint(_one_of("purpose", AUTH_TOKEN_PURPOSES), name="auth_tokens_purpose"),
+        Index("auth_tokens_user", "user_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"))
+    purpose: Mapped[str] = mapped_column(Text)
+    token_hash: Mapped[bytes] = mapped_column(LargeBinary, unique=True)
+    attempts: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
+    expires_at: Mapped[datetime]
+    consumed_at: Mapped[datetime | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class Invitation(Base):
+    __tablename__ = "invitations"
+    __table_args__ = (
+        CheckConstraint(_one_of("role", ROLES), name="invitations_role"),
+        # One open invitation per address; accepted and revoked ones stay as
+        # the record of what happened.
+        Index("invitations_one_open", NORMALIZED_EMAIL, unique=True,
+              postgresql_where=text("accepted_at IS NULL AND revoked_at IS NULL")),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(Text)
+    role: Mapped[str] = mapped_column(Text)
+    invited_by: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"))
+    accepted_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"))
+    token_hash: Mapped[bytes] = mapped_column(LargeBinary, unique=True)
+    expires_at: Mapped[datetime]
+    accepted_at: Mapped[datetime | None]
+    revoked_at: Mapped[datetime | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class AuthFactor(Base):
+    """A TOTP secret, encrypted under a root key ring purpose key.
+
+    key_version is what makes rotation a bounded indexed sweep rather than a
+    scan that parses every blob to find the ones still on the old key.
+    """
+
+    __tablename__ = "auth_factors"
+    __table_args__ = (
+        CheckConstraint("kind = 'totp'", name="auth_factors_kind"),
+        UniqueConstraint("user_id", "kind", name="auth_factors_one_per_kind"),
+        Index("auth_factors_key_version", "key_version"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    kind: Mapped[str] = mapped_column(Text)
+    secret_ciphertext: Mapped[bytes] = mapped_column(LargeBinary)
+    key_version: Mapped[int] = mapped_column(SmallInteger)
+    confirmed_at: Mapped[datetime | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class RecoveryCode(Base):
+    __tablename__ = "recovery_codes"
+    __table_args__ = (
+        UniqueConstraint("user_id", "code_hash", name="recovery_codes_unique"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    code_hash: Mapped[bytes] = mapped_column(LargeBinary)
+    consumed_at: Mapped[datetime | None]
+    created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
+
+
+class MailOutbox(Base):
+    """Every email capability is durable here before anyone tries to deliver it,
+    so a delivery outage queues and retries instead of losing the capability."""
+
+    __tablename__ = "mail_outbox"
+    __table_args__ = (
+        CheckConstraint(_one_of("state", OUTBOX_STATES), name="mail_outbox_state"),
+        Index("mail_outbox_due", "state", "next_attempt_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    to_email: Mapped[str] = mapped_column(Text)
+    template: Mapped[str] = mapped_column(Text)
+    payload: Mapped[dict] = mapped_column(JSONB)
+    state: Mapped[str] = mapped_column(Text, default="pending", server_default=text("'pending'"))
+    attempts: Mapped[int] = mapped_column(Integer, default=0, server_default=text("0"))
+    next_attempt_at: Mapped[datetime]
+    last_error: Mapped[str | None] = mapped_column(Text)
+    sent_at: Mapped[datetime | None]
     created_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
 
 
@@ -235,6 +412,7 @@ class InstallationAuthState(Base):
 
     id: Mapped[int] = mapped_column(SmallInteger, primary_key=True)
     auth_mode: Mapped[str] = mapped_column(Text)
+    root_key_version: Mapped[int | None] = mapped_column(SmallInteger)
     enabled_at: Mapped[datetime] = mapped_column(server_default=text("now()"))
 
 

--- a/backend/app/tables.py
+++ b/backend/app/tables.py
@@ -66,6 +66,10 @@ class AuthIdentity(Base):
         UniqueConstraint("provider", "subject", name="auth_identities_provider_subject"),
         Index("auth_identities_one_password", "user_id",
               unique=True, postgresql_where=text("provider = 'password'")),
+        # Accounts are one per normalized address, so their password identities
+        # are too: a byte-exact subject would let two rows answer one login.
+        Index("auth_identities_password_subject", text("lower(btrim(subject))"),
+              unique=True, postgresql_where=text("provider = 'password'")),
         Index("auth_identities_user", "user_id"),
     )
 
@@ -110,6 +114,8 @@ class AuthToken(Base):
     __tablename__ = "auth_tokens"
     __table_args__ = (
         CheckConstraint(_one_of("purpose", AUTH_TOKEN_PURPOSES), name="auth_tokens_purpose"),
+        CheckConstraint("(purpose = 'setup') = (user_id IS NULL)",
+                        name="auth_tokens_setup_has_no_user"),
         Index("auth_tokens_user", "user_id"),
     )
 

--- a/backend/migrations/versions/0015_auth_schema.py
+++ b/backend/migrations/versions/0015_auth_schema.py
@@ -66,6 +66,10 @@ def upgrade() -> None:
     )
     op.create_index("auth_identities_one_password", "auth_identities", ["user_id"], unique=True,
                     postgresql_where=sa.text("provider = 'password'"))
+    # Accounts are one per normalized address, so their password identities are
+    # too: a byte-exact subject would let two rows answer one login.
+    op.execute("CREATE UNIQUE INDEX auth_identities_password_subject ON auth_identities "
+               "(lower(btrim(subject))) WHERE provider = 'password'")
     op.create_index("auth_identities_user", "auth_identities", ["user_id"])
 
     op.create_table(
@@ -96,6 +100,8 @@ def upgrade() -> None:
         sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
         _created_at(),
         sa.CheckConstraint(f"purpose IN {AUTH_TOKEN_PURPOSES}", name="auth_tokens_purpose"),
+        sa.CheckConstraint("(purpose = 'setup') = (user_id IS NULL)",
+                           name="auth_tokens_setup_has_no_user"),
     )
     op.create_index("auth_tokens_user", "auth_tokens", ["user_id"])
 
@@ -176,6 +182,7 @@ def downgrade() -> None:
     op.drop_index("sessions_user", table_name="sessions")
     op.drop_table("sessions")
     op.drop_index("auth_identities_user", table_name="auth_identities")
+    op.drop_index("auth_identities_password_subject", table_name="auth_identities")
     op.drop_index("auth_identities_one_password", table_name="auth_identities")
     op.drop_table("auth_identities")
     op.drop_column("installation_auth_state", "root_key_version")

--- a/backend/migrations/versions/0015_auth_schema.py
+++ b/backend/migrations/versions/0015_auth_schema.py
@@ -1,0 +1,186 @@
+"""account schema and the installation root key version
+
+Revision ID: 0015
+Revises: 0014
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+ROLES = "('viewer', 'user', 'admin')"
+ACCOUNT_STATES = "('active', 'suspended', 'disabled', 'deletion_pending', 'purging')"
+IDENTITY_PROVIDERS = "('password', 'google', 'github')"
+AUTH_TOKEN_PURPOSES = "('setup', 'reset', 'recovery', 'challenge')"
+OUTBOX_STATES = "('pending', 'sent', 'failed')"
+
+
+def _uuid_pk() -> sa.Column:
+    return sa.Column("id", sa.Uuid(), primary_key=True)
+
+
+def _user_id(nullable: bool = False) -> sa.Column:
+    return sa.Column("user_id", sa.Uuid(),
+                     sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=nullable)
+
+
+def _created_at() -> sa.Column:
+    return sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                     server_default=sa.text("now()"))
+
+
+def upgrade() -> None:
+    # An install upgrading from AUTH_MODE=none holds one row, the implicit local
+    # user. Two rows whose emails differ only by case would fail this index,
+    # which is the correct outcome: the accounts release treats them as one
+    # account and nothing here may guess which one wins.
+    op.execute("CREATE UNIQUE INDEX users_email_normalized ON users (lower(btrim(email)))")
+    op.add_column("users", sa.Column("mail_verified", sa.Boolean(), nullable=False,
+                                     server_default=sa.text("false")))
+    op.add_column("users", sa.Column("state", sa.Text(), nullable=False,
+                                     server_default=sa.text("'active'")))
+    op.create_check_constraint("users_role", "users", f"role IN {ROLES}")
+    op.create_check_constraint("users_state", "users", f"state IN {ACCOUNT_STATES}")
+
+    op.add_column("installation_auth_state",
+                  sa.Column("root_key_version", sa.SmallInteger(), nullable=True))
+
+    op.create_table(
+        "auth_identities",
+        _uuid_pk(),
+        _user_id(),
+        sa.Column("provider", sa.Text(), nullable=False),
+        sa.Column("subject", sa.Text(), nullable=False),
+        sa.Column("password_hash", sa.Text(), nullable=True),
+        sa.Column("last_login_at", sa.DateTime(timezone=True), nullable=True),
+        _created_at(),
+        sa.CheckConstraint(f"provider IN {IDENTITY_PROVIDERS}", name="auth_identities_provider"),
+        sa.CheckConstraint("(provider = 'password') = (password_hash IS NOT NULL)",
+                           name="auth_identities_password_hash"),
+        sa.UniqueConstraint("provider", "subject", name="auth_identities_provider_subject"),
+    )
+    op.create_index("auth_identities_one_password", "auth_identities", ["user_id"], unique=True,
+                    postgresql_where=sa.text("provider = 'password'"))
+    op.create_index("auth_identities_user", "auth_identities", ["user_id"])
+
+    op.create_table(
+        "sessions",
+        _uuid_pk(),
+        _user_id(),
+        sa.Column("token_hash", sa.LargeBinary(), nullable=False, unique=True),
+        sa.Column("remember_me", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("absolute_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("idle_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("recent_auth_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        _created_at(),
+    )
+    # Revoking every session an account holds is a single indexed sweep, which
+    # is what a role change, a credential change or a suspension each trigger.
+    op.create_index("sessions_user", "sessions", ["user_id"])
+
+    op.create_table(
+        "auth_tokens",
+        _uuid_pk(),
+        _user_id(nullable=True),
+        sa.Column("purpose", sa.Text(), nullable=False),
+        sa.Column("token_hash", sa.LargeBinary(), nullable=False, unique=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        _created_at(),
+        sa.CheckConstraint(f"purpose IN {AUTH_TOKEN_PURPOSES}", name="auth_tokens_purpose"),
+    )
+    op.create_index("auth_tokens_user", "auth_tokens", ["user_id"])
+
+    op.create_table(
+        "invitations",
+        _uuid_pk(),
+        sa.Column("email", sa.Text(), nullable=False),
+        sa.Column("role", sa.Text(), nullable=False),
+        sa.Column("invited_by", sa.Uuid(),
+                  sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("accepted_user_id", sa.Uuid(),
+                  sa.ForeignKey("users.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("token_hash", sa.LargeBinary(), nullable=False, unique=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        _created_at(),
+        sa.CheckConstraint(f"role IN {ROLES}", name="invitations_role"),
+    )
+    # One open invitation per address, while an accepted or revoked one stays
+    # as the record of what happened.
+    op.execute("CREATE UNIQUE INDEX invitations_one_open ON invitations (lower(btrim(email))) "
+               "WHERE accepted_at IS NULL AND revoked_at IS NULL")
+
+    op.create_table(
+        "auth_factors",
+        _uuid_pk(),
+        _user_id(),
+        sa.Column("kind", sa.Text(), nullable=False),
+        sa.Column("secret_ciphertext", sa.LargeBinary(), nullable=False),
+        sa.Column("key_version", sa.SmallInteger(), nullable=False),
+        sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        _created_at(),
+        sa.CheckConstraint("kind = 'totp'", name="auth_factors_kind"),
+        sa.UniqueConstraint("user_id", "kind", name="auth_factors_one_per_kind"),
+    )
+    # Rotation re-encrypts by key version, so the sweep reads only the rows
+    # still on the version being removed.
+    op.create_index("auth_factors_key_version", "auth_factors", ["key_version"])
+
+    op.create_table(
+        "recovery_codes",
+        _uuid_pk(),
+        _user_id(),
+        sa.Column("code_hash", sa.LargeBinary(), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        _created_at(),
+        sa.UniqueConstraint("user_id", "code_hash", name="recovery_codes_unique"),
+    )
+
+    op.create_table(
+        "mail_outbox",
+        _uuid_pk(),
+        sa.Column("to_email", sa.Text(), nullable=False),
+        sa.Column("template", sa.Text(), nullable=False),
+        sa.Column("payload", JSONB(), nullable=False),
+        sa.Column("state", sa.Text(), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        _created_at(),
+        sa.CheckConstraint(f"state IN {OUTBOX_STATES}", name="mail_outbox_state"),
+    )
+    op.create_index("mail_outbox_due", "mail_outbox", ["state", "next_attempt_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("mail_outbox_due", table_name="mail_outbox")
+    op.drop_table("mail_outbox")
+    op.drop_table("recovery_codes")
+    op.drop_index("auth_factors_key_version", table_name="auth_factors")
+    op.drop_table("auth_factors")
+    op.drop_index("invitations_one_open", table_name="invitations")
+    op.drop_table("invitations")
+    op.drop_index("auth_tokens_user", table_name="auth_tokens")
+    op.drop_table("auth_tokens")
+    op.drop_index("sessions_user", table_name="sessions")
+    op.drop_table("sessions")
+    op.drop_index("auth_identities_user", table_name="auth_identities")
+    op.drop_index("auth_identities_one_password", table_name="auth_identities")
+    op.drop_table("auth_identities")
+    op.drop_column("installation_auth_state", "root_key_version")
+    op.drop_constraint("users_state", "users", type_="check")
+    op.drop_constraint("users_role", "users", type_="check")
+    op.drop_column("users", "state")
+    op.drop_column("users", "mail_verified")
+    op.drop_index("users_email_normalized", table_name="users")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "asyncpg>=0.29,<1",
     "alembic>=1.13,<2",
     "boto3>=1.34,<2",
+    "cryptography>=43,<48",
     "jsonschema>=4.21,<5",
     "referencing>=0.35,<1",  # manifests.py catches Unresolvable directly
 ]

--- a/backend/tests/test_auth_r2.py
+++ b/backend/tests/test_auth_r2.py
@@ -10,6 +10,7 @@ from sqlalchemy.pool import NullPool
 
 from app import auth
 from app import db
+from app.keyring import KeyRing
 import app.main as main_module
 from app.main import app
 from app.settings import Settings
@@ -130,7 +131,10 @@ def test_account_dependency_rejects_before_principal(monkeypatch):
 
 
 @pytest.mark.db
-def test_accounts_enable_persists_mode_and_existing_ownership(portal_runner):
+def test_accounts_enable_persists_mode_and_existing_ownership(portal_runner, monkeypatch):
+    # Enabling accounts records the root key version it writes with, so it
+    # needs a ring; test_auth_r3.py covers what happens without one.
+    monkeypatch.setattr(db, "get_key_ring", lambda: KeyRing([(1, bytes(range(32)))]))
     assert portal_runner(db.connect()) is True
     enabled = False
     try:

--- a/backend/tests/test_auth_r3.py
+++ b/backend/tests/test_auth_r3.py
@@ -1,0 +1,372 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import DBAPIError, IntegrityError
+
+from app import db
+from app.keyring import get_key_ring
+from app.settings import get_settings
+from app.keyring import KeyRing, KeyRingError
+from app.tables import (
+    AuthFactor,
+    AuthIdentity,
+    AuthToken,
+    Invitation,
+    MailOutbox,
+    RecoveryCode,
+    Session,
+    User,
+)
+
+TOTP_PURPOSE = "totp-factors"
+V1 = bytes(range(32))
+V2 = bytes(range(32, 64))
+
+
+@pytest.fixture
+def now():
+    return datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def connected(portal_runner):
+    """Every account this file makes goes at teardown.
+
+    These tables are this file's alone, and a row left behind is handed to the
+    next test as if it had created it: the rotation sweep reads by key version,
+    so one stale factor from an earlier test is enough to fail it.
+    """
+    assert portal_runner(db.connect()) is True
+
+    async def clear() -> None:
+        async with db.session_factory() as session:
+            await session.execute(text("DELETE FROM invitations"))
+            await session.execute(text("DELETE FROM mail_outbox"))
+            await session.execute(text("DELETE FROM auth_tokens"))
+            await session.execute(text("DELETE FROM users WHERE email <> :local"),
+                                  {"local": db.LOCAL_USER_EMAIL})
+            await session.commit()
+
+    try:
+        yield portal_runner
+    finally:
+        portal_runner(clear())
+        portal_runner(db.dispose())
+
+
+def _insert(portal_runner, *rows):
+    async def go():
+        async with db.session_factory() as session:
+            session.add_all(rows)
+            await session.commit()
+
+    portal_runner(go())
+
+
+def _expect_refusal(portal_runner, *rows):
+    with pytest.raises((IntegrityError, DBAPIError)):
+        _insert(portal_runner, *rows)
+
+
+def _user(portal_runner, email, **kwargs):
+    row = User(id=uuid.uuid4(), email=email, **kwargs)
+    _insert(portal_runner, row)
+    return row
+
+
+@pytest.mark.db
+def test_two_users_cannot_share_a_normalized_email(connected):
+    _user(connected, "Person@Example.com")
+    with pytest.raises((IntegrityError, DBAPIError)):
+        _user(connected, "  person@example.COM  ")
+
+
+@pytest.mark.db
+def test_account_state_is_constrained_to_the_designed_states(connected):
+    for state in ("active", "suspended", "disabled", "deletion_pending", "purging"):
+        _user(connected, f"{state}@example.com", state=state)
+    _expect_refusal(
+        connected,
+        User(id=uuid.uuid4(), email="x@example.com", state="banned"),
+    )
+
+
+@pytest.mark.db
+def test_role_is_constrained_to_viewer_user_and_admin(connected):
+    for role in ("viewer", "user", "admin"):
+        _user(connected, f"{role}@example.com", role=role)
+    _expect_refusal(
+        connected,
+        User(id=uuid.uuid4(), email="r@example.com", role="superuser"),
+    )
+
+
+@pytest.mark.db
+def test_a_user_has_at_most_one_password_identity(connected):
+    owner = _user(connected, "one-password@example.com")
+    _insert(connected, AuthIdentity(id=uuid.uuid4(), user_id=owner.id, provider="password",
+                                    subject=owner.email, password_hash="argon2-a"))
+    _expect_refusal(connected, AuthIdentity(id=uuid.uuid4(), user_id=owner.id,
+                                            provider="password", subject="other@example.com",
+                                            password_hash="argon2-b"))
+
+
+@pytest.mark.db
+def test_a_user_may_hold_several_provider_identities(connected):
+    owner = _user(connected, "linked@example.com")
+    _insert(
+        connected,
+        AuthIdentity(id=uuid.uuid4(), user_id=owner.id, provider="google", subject="g-1"),
+        AuthIdentity(id=uuid.uuid4(), user_id=owner.id, provider="github", subject="h-1"),
+    )
+
+
+@pytest.mark.db
+def test_one_provider_subject_belongs_to_one_account(connected):
+    first = _user(connected, "first@example.com")
+    second = _user(connected, "second@example.com")
+    _insert(connected, AuthIdentity(id=uuid.uuid4(), user_id=first.id, provider="google",
+                                    subject="shared-sub"))
+    _expect_refusal(connected, AuthIdentity(id=uuid.uuid4(), user_id=second.id,
+                                            provider="google", subject="shared-sub"))
+
+
+@pytest.mark.db
+def test_a_password_identity_without_a_hash_is_refused(connected):
+    owner = _user(connected, "no-hash@example.com")
+    _expect_refusal(connected, AuthIdentity(id=uuid.uuid4(), user_id=owner.id,
+                                            provider="password", subject="no-hash@example.com"))
+
+
+@pytest.mark.db
+def test_a_provider_identity_never_carries_a_password_hash(connected):
+    """A provider identity is proof from the provider, never a local credential."""
+    owner = _user(connected, "provider-hash@example.com")
+    _expect_refusal(connected, AuthIdentity(id=uuid.uuid4(), user_id=owner.id, provider="google",
+                                            subject="g-2", password_hash="argon2-c"))
+
+
+@pytest.mark.db
+def test_an_unknown_identity_provider_is_refused(connected):
+    owner = _user(connected, "unknown-provider@example.com")
+    _expect_refusal(connected, AuthIdentity(id=uuid.uuid4(), user_id=owner.id, provider="facebook",
+                                            subject="f-1"))
+
+
+@pytest.mark.db
+def test_a_session_token_hash_is_unique(connected, now):
+    owner = _user(connected, "session@example.com")
+    _insert(connected, Session(id=uuid.uuid4(), user_id=owner.id, token_hash=b"h" * 32,
+                               absolute_expires_at=now))
+    _expect_refusal(connected, Session(id=uuid.uuid4(), user_id=owner.id, token_hash=b"h" * 32,
+                                       absolute_expires_at=now))
+
+
+@pytest.mark.db
+def test_deleting_an_account_takes_its_authentication_rows_with_it(connected, now):
+    owner = _user(connected, "cascade@example.com")
+    _insert(
+        connected,
+        AuthIdentity(id=uuid.uuid4(), user_id=owner.id, provider="google", subject="g-cascade"),
+        Session(id=uuid.uuid4(), user_id=owner.id, token_hash=b"c" * 32,
+                absolute_expires_at=now),
+        AuthToken(id=uuid.uuid4(), user_id=owner.id, purpose="reset", token_hash=b"t" * 32,
+                  expires_at=now),
+        AuthFactor(id=uuid.uuid4(), user_id=owner.id, kind="totp", secret_ciphertext=b"blob",
+                   key_version=1),
+        RecoveryCode(id=uuid.uuid4(), user_id=owner.id, code_hash=b"r" * 32),
+    )
+
+    async def purge() -> dict:
+        async with db.session_factory() as session:
+            await session.execute(text("DELETE FROM users WHERE id = :id"), {"id": owner.id})
+            await session.commit()
+        async with db.session_factory() as session:
+            return {
+                table: (await session.execute(
+                    text(f"SELECT count(*) FROM {table} WHERE user_id = :id"), {"id": owner.id}
+                )).scalar_one()
+                for table in ("auth_identities", "sessions", "auth_tokens", "auth_factors",
+                              "recovery_codes")
+            }
+
+    assert set(connected(purge()).values()) == {0}
+
+
+@pytest.mark.db
+def test_an_unknown_auth_token_purpose_is_refused(connected, now):
+    owner = _user(connected, "token-purpose@example.com")
+    for purpose in ("setup", "reset", "recovery", "challenge"):
+        _insert(connected, AuthToken(id=uuid.uuid4(), user_id=owner.id, purpose=purpose,
+                                     token_hash=purpose.encode().ljust(32, b"."),
+                                     expires_at=now))
+    _expect_refusal(connected, AuthToken(id=uuid.uuid4(), user_id=owner.id, purpose="wire-transfer",
+                                         token_hash=b"w" * 32, expires_at=now))
+
+
+@pytest.mark.db
+def test_a_setup_token_needs_no_account(connected, now):
+    """Setup mints a capability before anyone has claimed the installation."""
+    _insert(connected, AuthToken(id=uuid.uuid4(), user_id=None, purpose="setup",
+                                 token_hash=b"s" * 32, expires_at=now))
+
+
+@pytest.mark.db
+def test_one_open_invitation_per_normalized_email(connected, now):
+    admin = _user(connected, "inviter@example.com", role="admin")
+
+    def invitation(email, **kwargs):
+        return Invitation(id=uuid.uuid4(), email=email, role="user", invited_by=admin.id,
+                          token_hash=uuid.uuid4().bytes * 2, expires_at=now, **kwargs)
+
+    _insert(connected, invitation("Guest@Example.com"))
+    _expect_refusal(connected, invitation(" guest@example.com "))
+    _insert(connected, invitation("later@example.com", revoked_at=now))
+    _insert(connected, invitation("later@example.com"))
+
+
+@pytest.mark.db
+def test_a_user_has_at_most_one_totp_factor(connected):
+    owner = _user(connected, "totp@example.com")
+    _insert(connected, AuthFactor(id=uuid.uuid4(), user_id=owner.id, kind="totp",
+                                  secret_ciphertext=b"blob-a", key_version=1))
+    _expect_refusal(connected, AuthFactor(id=uuid.uuid4(), user_id=owner.id, kind="totp",
+                                          secret_ciphertext=b"blob-b", key_version=1))
+
+
+@pytest.mark.db
+def test_a_recovery_code_is_recorded_once_per_account(connected):
+    owner = _user(connected, "recovery@example.com")
+    _insert(connected, RecoveryCode(id=uuid.uuid4(), user_id=owner.id, code_hash=b"k" * 32))
+    _expect_refusal(connected, RecoveryCode(id=uuid.uuid4(), user_id=owner.id,
+                                            code_hash=b"k" * 32))
+
+
+@pytest.mark.db
+def test_outbox_rows_start_pending_and_reject_an_unknown_state(connected, now):
+    _insert(connected, MailOutbox(id=uuid.uuid4(), to_email="Mail@Example.com",
+                                  template="invitation", payload={"token": "capability"},
+                                  next_attempt_at=now))
+
+    async def state_of() -> str:
+        async with db.session_factory() as session:
+            return (await session.execute(
+                select(MailOutbox.state).where(MailOutbox.template == "invitation")
+            )).scalar_one()
+
+    assert connected(state_of()) == "pending"
+    _expect_refusal(connected, MailOutbox(id=uuid.uuid4(), to_email="x@example.com",
+                                          template="reset", payload={}, next_attempt_at=now,
+                                          state="posted"))
+
+
+@pytest.mark.db
+def test_a_factor_secret_survives_rotation_and_the_old_key_being_removed(connected):
+    """Active write, multi read, re-encrypt, then remove, against real rows."""
+    owner = _user(connected, "rotate@example.com")
+    written = KeyRing([(1, V1)])
+    _insert(connected, AuthFactor(id=uuid.uuid4(), user_id=owner.id, kind="totp",
+                                  secret_ciphertext=written.encrypt(TOTP_PURPOSE, b"seed",
+                                                                    aad=owner.id.bytes),
+                                  key_version=written.active_version))
+
+    rotating = KeyRing([(2, V2), (1, V1)])
+
+    async def reencrypt() -> None:
+        async with db.session_factory() as session:
+            rows = (await session.execute(
+                select(AuthFactor).where(AuthFactor.key_version != rotating.active_version)
+            )).scalars().all()
+            for row in rows:
+                row.secret_ciphertext = rotating.reencrypt(
+                    TOTP_PURPOSE, row.secret_ciphertext, aad=row.user_id.bytes
+                )
+                row.key_version = rotating.active_version
+            await session.commit()
+
+    async def stored() -> AuthFactor:
+        async with db.session_factory() as session:
+            return (await session.execute(
+                select(AuthFactor).where(AuthFactor.user_id == owner.id)
+            )).scalar_one()
+
+    assert rotating.decrypt(TOTP_PURPOSE, connected(stored()).secret_ciphertext,
+                            aad=owner.id.bytes) == b"seed"
+    connected(reencrypt())
+    row = connected(stored())
+    assert row.key_version == 2
+    removed = KeyRing([(2, V2)])
+    assert removed.decrypt(TOTP_PURPOSE, row.secret_ciphertext, aad=owner.id.bytes) == b"seed"
+
+
+@pytest.mark.db
+def test_a_secret_still_on_a_removed_key_is_unreadable(connected):
+    """Removing a key before re-encrypting must lose the secret, not expose it."""
+    owner = _user(connected, "lost@example.com")
+    _insert(connected, AuthFactor(id=uuid.uuid4(), user_id=owner.id, kind="totp",
+                                  secret_ciphertext=KeyRing([(1, V1)]).encrypt(
+                                      TOTP_PURPOSE, b"seed", aad=owner.id.bytes),
+                                  key_version=1))
+
+    async def stored() -> bytes:
+        async with db.session_factory() as session:
+            return (await session.execute(
+                select(AuthFactor.secret_ciphertext).where(AuthFactor.user_id == owner.id)
+            )).scalar_one()
+
+    with pytest.raises(KeyRingError):
+        KeyRing([(2, V2)]).decrypt(TOTP_PURPOSE, connected(stored()), aad=owner.id.bytes)
+
+
+@pytest.mark.db
+def test_startup_refuses_when_the_installation_key_version_is_gone(connected, monkeypatch):
+    """PostgreSQL is the authority on which root version this install writes."""
+    async def record(version: int | None) -> None:
+        async with db.session_factory() as session:
+            await session.execute(
+                text("INSERT INTO installation_auth_state (id, auth_mode, root_key_version) "
+                     "VALUES (1, 'accounts', :v) "
+                     "ON CONFLICT (id) DO UPDATE SET root_key_version = :v"),
+                {"v": version},
+            )
+            await session.commit()
+
+    async def clear() -> None:
+        async with db.session_factory() as session:
+            await session.execute(text("DELETE FROM installation_auth_state"))
+            await session.commit()
+
+    connected(record(1))
+    try:
+        monkeypatch.setattr(db, "get_key_ring", lambda: KeyRing([(1, V1)]))
+        connected(db.validate_startup_key_ring())
+        monkeypatch.setattr(db, "get_key_ring", lambda: KeyRing([(2, V2)]))
+        with pytest.raises(RuntimeError, match="root key"):
+            connected(db.validate_startup_key_ring())
+    finally:
+        connected(clear())
+
+
+@pytest.mark.db
+def test_startup_key_ring_check_is_quiet_before_accounts_are_enabled(connected, monkeypatch):
+    def refuse() -> KeyRing:
+        raise AssertionError("the key ring must not be read before accounts are enabled")
+
+    monkeypatch.setattr(db, "get_key_ring", refuse)
+    connected(db.validate_startup_key_ring())
+
+
+def test_the_key_ring_never_falls_back_to_the_fleet_secret(monkeypatch):
+    """Acceptance: root keys and fleet keys are separate key material."""
+    monkeypatch.delenv("ROOT_KEYS", raising=False)
+    monkeypatch.setenv("FLEET_TOKEN_KEY", "a-fleet-shared-secret")
+    get_settings.cache_clear()
+    get_key_ring.cache_clear()
+    try:
+        with pytest.raises(KeyRingError):
+            get_key_ring()
+    finally:
+        get_settings.cache_clear()
+        get_key_ring.cache_clear()

--- a/backend/tests/test_auth_r3.py
+++ b/backend/tests/test_auth_r3.py
@@ -198,12 +198,39 @@ def test_deleting_an_account_takes_its_authentication_rows_with_it(connected, no
 @pytest.mark.db
 def test_an_unknown_auth_token_purpose_is_refused(connected, now):
     owner = _user(connected, "token-purpose@example.com")
-    for purpose in ("setup", "reset", "recovery", "challenge"):
+    for purpose in ("reset", "recovery", "challenge"):
         _insert(connected, AuthToken(id=uuid.uuid4(), user_id=owner.id, purpose=purpose,
                                      token_hash=purpose.encode().ljust(32, b"."),
                                      expires_at=now))
+    _insert(connected, AuthToken(id=uuid.uuid4(), user_id=None, purpose="setup",
+                                 token_hash=b"setup".ljust(32, b"."), expires_at=now))
     _expect_refusal(connected, AuthToken(id=uuid.uuid4(), user_id=owner.id, purpose="wire-transfer",
                                          token_hash=b"w" * 32, expires_at=now))
+
+
+@pytest.mark.db
+def test_only_a_setup_token_may_stand_without_an_account(connected, now):
+    """Setup mints the first administrator, so a consumer that reads a missing
+    account as "this is the setup flow" must not meet a reset row shaped
+    like one."""
+    owner = _user(connected, "setup-shape@example.com")
+    _expect_refusal(connected, AuthToken(id=uuid.uuid4(), user_id=owner.id, purpose="setup",
+                                         token_hash=b"S" * 32, expires_at=now))
+    _expect_refusal(connected, AuthToken(id=uuid.uuid4(), user_id=None, purpose="reset",
+                                         token_hash=b"R" * 32, expires_at=now))
+
+
+@pytest.mark.db
+def test_a_password_identity_is_unique_per_normalized_address(connected):
+    """Accounts are one per normalized address, so their password identities
+    must be too, or a login lookup has two rows to choose between."""
+    first = _user(connected, "Case@example.com")
+    second = _user(connected, "other@example.com")
+    _insert(connected, AuthIdentity(id=uuid.uuid4(), user_id=first.id, provider="password",
+                                    subject="Case@example.com", password_hash="argon2-a"))
+    _expect_refusal(connected, AuthIdentity(id=uuid.uuid4(), user_id=second.id,
+                                            provider="password", subject=" case@EXAMPLE.com ",
+                                            password_hash="argon2-b"))
 
 
 @pytest.mark.db
@@ -269,7 +296,7 @@ def test_a_factor_secret_survives_rotation_and_the_old_key_being_removed(connect
     written = KeyRing([(1, V1)])
     _insert(connected, AuthFactor(id=uuid.uuid4(), user_id=owner.id, kind="totp",
                                   secret_ciphertext=written.encrypt(TOTP_PURPOSE, b"seed",
-                                                                    aad=owner.id.bytes),
+                                                                    owner.id.bytes),
                                   key_version=written.active_version))
 
     rotating = KeyRing([(2, V2), (1, V1)])
@@ -318,6 +345,35 @@ def test_a_secret_still_on_a_removed_key_is_unreadable(connected):
 
     with pytest.raises(KeyRingError):
         KeyRing([(2, V2)]).decrypt(TOTP_PURPOSE, connected(stored()), aad=owner.id.bytes)
+
+
+@pytest.mark.db
+def test_enabling_accounts_records_the_key_version_it_writes_with(connected, monkeypatch):
+    """A guard nothing arms cannot fire, and the install that needed it is
+    exactly the one that finds out too late."""
+    monkeypatch.setattr(db, "get_key_ring", lambda: KeyRing([(7, V1)]))
+    try:
+        connected(db.enable_accounts_mode(db.session_factory))
+        assert connected(db.read_installation_root_key_version()) == 7
+    finally:
+        async def clear() -> None:
+            async with db.session_factory() as session:
+                await session.execute(text("DELETE FROM installation_auth_state"))
+                await session.commit()
+
+        connected(clear())
+
+
+@pytest.mark.db
+def test_enabling_accounts_without_a_usable_ring_is_refused(connected, monkeypatch):
+    """Enabling accounts with no ring would write secrets nothing can read."""
+    def unusable() -> KeyRing:
+        raise KeyRingError("root keys are not configured")
+
+    monkeypatch.setattr(db, "get_key_ring", unusable)
+    with pytest.raises(KeyRingError):
+        connected(db.enable_accounts_mode(db.session_factory))
+    assert connected(db.read_installation_root_key_version()) is None
 
 
 @pytest.mark.db

--- a/backend/tests/test_key_ring.py
+++ b/backend/tests/test_key_ring.py
@@ -1,0 +1,133 @@
+import pytest
+
+from app.keyring import KeyRing, KeyRingError, parse_root_keys
+
+V1 = bytes(range(32))
+V2 = bytes(range(32, 64))
+FLEET_SECRET = "a-fleet-shared-secret"
+
+
+def _ring(*entries: tuple[int, bytes]) -> KeyRing:
+    return KeyRing(list(entries))
+
+
+def test_parse_root_keys_reads_an_active_write_key_first():
+    import base64
+
+    raw = f"2:{base64.b64encode(V2).decode()},1:{base64.b64encode(V1).decode()}"
+    assert parse_root_keys(raw) == [(2, V2), (1, V1)]
+
+
+@pytest.mark.parametrize("raw", [
+    "",
+    "   ",
+    "2",
+    "two:AAAA",
+    "0:" + "A" * 44,
+    "-1:" + "A" * 44,
+    "1:not-base64!!",
+    "1:" + "A" * 43,
+    "1:QUJD",
+    "1:{k},1:{k}",
+])
+def test_parse_root_keys_fails_closed_on_anything_it_cannot_trust(raw):
+    """A misread key ring must refuse, never silently produce a weaker ring."""
+    import base64
+
+    raw = raw.format(k=base64.b64encode(V1).decode())
+    with pytest.raises(KeyRingError):
+        parse_root_keys(raw)
+
+
+def test_purpose_keys_are_domain_separated():
+    ring = _ring((1, V1))
+    sessions = ring.derive("sessions")
+    factors = ring.derive("totp-factors")
+    assert sessions != factors
+    assert sessions != V1 and factors != V1
+    assert len(sessions) == 32
+    assert sessions != FLEET_SECRET.encode()
+
+
+def test_purpose_keys_differ_per_root_version():
+    assert _ring((1, V1)).derive("sessions") != _ring((2, V2)).derive("sessions")
+
+
+def test_encryption_writes_with_the_active_version():
+    ring = _ring((2, V2), (1, V1))
+    assert ring.active_version == 2
+    assert ring.version_of(ring.encrypt("sessions", b"secret")) == 2
+
+
+def test_every_ring_version_stays_readable():
+    """Multi-read is what makes rotation possible without downtime."""
+    old = _ring((1, V1))
+    blob = old.encrypt("sessions", b"secret")
+    rotated = _ring((2, V2), (1, V1))
+    assert rotated.decrypt("sessions", blob) == b"secret"
+    assert rotated.decrypt("sessions", rotated.encrypt("sessions", b"secret")) == b"secret"
+
+
+def test_a_removed_version_fails_closed():
+    """Removing a key must lose the plaintext, not degrade to reading it."""
+    blob = _ring((1, V1)).encrypt("sessions", b"secret")
+    with pytest.raises(KeyRingError):
+        _ring((2, V2)).decrypt("sessions", blob)
+
+
+def test_ciphertext_is_bound_to_its_purpose():
+    ring = _ring((1, V1))
+    blob = ring.encrypt("sessions", b"secret")
+    with pytest.raises(KeyRingError):
+        ring.decrypt("totp-factors", blob)
+
+
+def test_ciphertext_is_bound_to_its_associated_data():
+    ring = _ring((1, V1))
+    blob = ring.encrypt("totp-factors", b"secret", aad=b"user-a")
+    assert ring.decrypt("totp-factors", blob, aad=b"user-a") == b"secret"
+    with pytest.raises(KeyRingError):
+        ring.decrypt("totp-factors", blob, aad=b"user-b")
+    with pytest.raises(KeyRingError):
+        ring.decrypt("totp-factors", blob)
+
+
+def test_a_tampered_ciphertext_is_refused():
+    ring = _ring((1, V1))
+    blob = bytearray(ring.encrypt("sessions", b"secret"))
+    blob[-1] ^= 0x01
+    with pytest.raises(KeyRingError):
+        ring.decrypt("sessions", bytes(blob))
+
+
+def test_truncated_ciphertext_is_refused():
+    ring = _ring((1, V1))
+    with pytest.raises(KeyRingError):
+        ring.decrypt("sessions", ring.encrypt("sessions", b"secret")[:6])
+
+
+def test_the_same_plaintext_never_encrypts_to_the_same_bytes():
+    """A repeated nonce under one key destroys AES-GCM confidentiality."""
+    ring = _ring((1, V1))
+    assert ring.encrypt("sessions", b"secret") != ring.encrypt("sessions", b"secret")
+
+
+def test_reencrypt_moves_a_blob_to_the_active_version():
+    """The re-encrypt step of active-write, multi-read, re-encrypt, remove."""
+    rotated = _ring((2, V2), (1, V1))
+    old = _ring((1, V1)).encrypt("sessions", b"secret")
+    fresh = rotated.reencrypt("sessions", old)
+    assert rotated.version_of(fresh) == 2
+    assert _ring((2, V2)).decrypt("sessions", fresh) == b"secret"
+
+
+def test_reencrypt_preserves_associated_data():
+    rotated = _ring((2, V2), (1, V1))
+    old = _ring((1, V1)).encrypt("totp-factors", b"secret", aad=b"user-a")
+    fresh = rotated.reencrypt("totp-factors", old, aad=b"user-a")
+    assert rotated.decrypt("totp-factors", fresh, aad=b"user-a") == b"secret"
+
+
+def test_an_empty_ring_is_refused():
+    with pytest.raises(KeyRingError):
+        KeyRing([])

--- a/backend/tests/test_key_ring.py
+++ b/backend/tests/test_key_ring.py
@@ -29,6 +29,9 @@ def test_parse_root_keys_reads_an_active_write_key_first():
     "1:" + "A" * 43,
     "1:QUJD",
     "1:{k},1:{k}",
+    "2:{k},1:{k}",
+    "32768:{k}",
+    "65535:{k}",
 ])
 def test_parse_root_keys_fails_closed_on_anything_it_cannot_trust(raw):
     """A misread key ring must refuse, never silently produce a weaker ring."""
@@ -37,6 +40,26 @@ def test_parse_root_keys_fails_closed_on_anything_it_cannot_trust(raw):
     raw = raw.format(k=base64.b64encode(V1).decode())
     with pytest.raises(KeyRingError):
         parse_root_keys(raw)
+
+
+def test_a_repeated_key_under_a_new_version_is_refused():
+    """Rotating onto the same bytes leaves every row on the key being retired,
+    and nothing downstream can tell: the ring shows two versions, the startup
+    check passes, and the re-encrypt sweep reports it finished."""
+    import base64
+
+    key = base64.b64encode(V1).decode()
+    with pytest.raises(KeyRingError):
+        parse_root_keys(f"2:{key},1:{key}")
+
+
+def test_a_version_wider_than_its_column_is_refused():
+    """key_version is a signed smallint, so a wider version fails on INSERT
+    after the secret it protects has already been generated."""
+    import base64
+
+    with pytest.raises(KeyRingError):
+        parse_root_keys(f"32768:{base64.b64encode(V1).decode()}")
 
 
 def test_purpose_keys_are_domain_separated():
@@ -56,30 +79,30 @@ def test_purpose_keys_differ_per_root_version():
 def test_encryption_writes_with_the_active_version():
     ring = _ring((2, V2), (1, V1))
     assert ring.active_version == 2
-    assert ring.version_of(ring.encrypt("sessions", b"secret")) == 2
+    assert ring.version_of(ring.encrypt("sessions", b"secret", b"")) == 2
 
 
 def test_every_ring_version_stays_readable():
     """Multi-read is what makes rotation possible without downtime."""
     old = _ring((1, V1))
-    blob = old.encrypt("sessions", b"secret")
+    blob = old.encrypt("sessions", b"secret", b"")
     rotated = _ring((2, V2), (1, V1))
-    assert rotated.decrypt("sessions", blob) == b"secret"
-    assert rotated.decrypt("sessions", rotated.encrypt("sessions", b"secret")) == b"secret"
+    assert rotated.decrypt("sessions", blob, b"") == b"secret"
+    assert rotated.decrypt("sessions", rotated.encrypt("sessions", b"secret", b""), b"") == b"secret"
 
 
 def test_a_removed_version_fails_closed():
     """Removing a key must lose the plaintext, not degrade to reading it."""
-    blob = _ring((1, V1)).encrypt("sessions", b"secret")
+    blob = _ring((1, V1)).encrypt("sessions", b"secret", b"")
     with pytest.raises(KeyRingError):
-        _ring((2, V2)).decrypt("sessions", blob)
+        _ring((2, V2)).decrypt("sessions", blob, b"")
 
 
 def test_ciphertext_is_bound_to_its_purpose():
     ring = _ring((1, V1))
-    blob = ring.encrypt("sessions", b"secret")
+    blob = ring.encrypt("sessions", b"secret", b"")
     with pytest.raises(KeyRingError):
-        ring.decrypt("totp-factors", blob)
+        ring.decrypt("totp-factors", blob, b"")
 
 
 def test_ciphertext_is_bound_to_its_associated_data():
@@ -89,36 +112,46 @@ def test_ciphertext_is_bound_to_its_associated_data():
     with pytest.raises(KeyRingError):
         ring.decrypt("totp-factors", blob, aad=b"user-b")
     with pytest.raises(KeyRingError):
-        ring.decrypt("totp-factors", blob)
+        ring.decrypt("totp-factors", blob, b"")
 
 
 def test_a_tampered_ciphertext_is_refused():
     ring = _ring((1, V1))
-    blob = bytearray(ring.encrypt("sessions", b"secret"))
+    blob = bytearray(ring.encrypt("sessions", b"secret", b""))
     blob[-1] ^= 0x01
     with pytest.raises(KeyRingError):
-        ring.decrypt("sessions", bytes(blob))
+        ring.decrypt("sessions", bytes(blob), b"")
 
 
 def test_truncated_ciphertext_is_refused():
     ring = _ring((1, V1))
     with pytest.raises(KeyRingError):
-        ring.decrypt("sessions", ring.encrypt("sessions", b"secret")[:6])
+        ring.decrypt("sessions", ring.encrypt("sessions", b"secret", b"")[:6], b"")
+
+
+def test_every_call_states_what_the_ciphertext_is_bound_to():
+    """An omitted binding is a blob that verifies in any row of its purpose,
+    so there is no default: a caller with nothing to bind says so."""
+    ring = _ring((1, V1))
+    with pytest.raises(TypeError):
+        ring.encrypt("sessions", b"secret")
+    with pytest.raises(TypeError):
+        ring.decrypt("sessions", b"blob")
 
 
 def test_the_same_plaintext_never_encrypts_to_the_same_bytes():
     """A repeated nonce under one key destroys AES-GCM confidentiality."""
     ring = _ring((1, V1))
-    assert ring.encrypt("sessions", b"secret") != ring.encrypt("sessions", b"secret")
+    assert ring.encrypt("sessions", b"secret", b"") != ring.encrypt("sessions", b"secret", b"")
 
 
 def test_reencrypt_moves_a_blob_to_the_active_version():
     """The re-encrypt step of active-write, multi-read, re-encrypt, remove."""
     rotated = _ring((2, V2), (1, V1))
-    old = _ring((1, V1)).encrypt("sessions", b"secret")
-    fresh = rotated.reencrypt("sessions", old)
+    old = _ring((1, V1)).encrypt("sessions", b"secret", b"")
+    fresh = rotated.reencrypt("sessions", old, b"")
     assert rotated.version_of(fresh) == 2
-    assert _ring((2, V2)).decrypt("sessions", fresh) == b"secret"
+    assert _ring((2, V2)).decrypt("sessions", fresh, b"") == b"secret"
 
 
 def test_reencrypt_preserves_associated_data():

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -23,6 +23,7 @@ STORAGE_LOCAL_PATH   = /data/assets              # local backend
 STORAGE_S3_BUCKET    = ...                       # s3 backend, plus region and credentials
 QUOTA_SERVICE_URL    = ""                        # empty: unlimited default implementation
 FLEET_TOKEN_KEY      = ...                       # verifies worker tokens; self-host uses a static shared secret
+ROOT_KEYS            = "2:<base64>,1:<base64>"     # versioned root key ring, newest first; separate from FLEET_TOKEN_KEY
 EMAIL_BACKEND        = none | smtp | ses
 PUBLIC_URL           = https://app.potocolom.com
 ALLOWED_ORIGINS      = ""                      # extra browser origins for the WebSocket endpoints; PUBLIC_URL is always allowed

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1061,6 +1061,18 @@ Retrying forever costs one delete call an hour per stuck key, and the row is the
 
 Rejected alternatives: dropping the row at a bounded attempt count, which is what the issue asked for and which loses the object silently; unscheduling the row and re-arming it at startup, which makes recovery depend on a restart nobody will perform for a cleanup failure; an operator endpoint to re-arm, which is a surface with one caller for a case that a retry already handles; and an S3 lifecycle rule instead of any of this, which is the better answer for the cloud profile and covers only it, so it belongs with issue #278 rather than replacing the retry a self-hosted install needs.
 
+## Secrets at rest: one versioned root key ring, purpose keys derived per use
+
+Account secrets are encrypted under keys derived from a versioned root key ring, never under a root key directly. `ROOT_KEYS` carries comma separated `version:base64key` entries with the newest first: the first entry is the active write key and every entry stays readable. A purpose key comes from HKDF-SHA256 over the root key with the purpose in the info string, so one subsystem's key is useless against another's data. Values are sealed with AES-GCM and carry their key version, and the purpose and any row binding go into the associated data, so a blob cannot be replayed under a different purpose or a different row. Rotation is therefore active write, multi read, re-encrypt, then remove, with no downtime and no flag day. A key that leaves the ring before its rows are re-encrypted makes those rows unreadable, and every refusal raises rather than returning a value: losing a secret is the correct outcome, and silently reading one under a fallback key is not. The ring is separate key material from `FLEET_TOKEN_KEY`, which authenticates workers.
+
+Rejected alternatives: one static key from the environment (no rotation story at all, and every subsystem shares one blast radius); encrypting with the root key directly (rotation then rewrites every row for every purpose at once, and one leaked key exposes everything); a key management service (a hard dependency the self-hosted profile cannot take, for a threat the self-hoster's own disk encryption already bounds); storing the key version only inside the blob (finding the rows still on an old key then means scanning and parsing the whole table instead of reading an index).
+
+## Password and email uniqueness: a functional index, not a second column
+
+Accounts are unique on `lower(btrim(email))` through a unique functional index, and invitations use the same expression in a partial index that admits one open invitation per address. There is no stored normalized column to keep in step.
+
+Rejected alternative: a normalized column filled on write. It duplicates a value the database can compute, adds a backfill to the migration, and goes stale the moment one write path forgets it, which is exactly the write path that also decides who owns an account.
+
 ## Supporting defaults
 
 Chosen as conventional defaults rather than debated decisions:


### PR DESCRIPTION
# Description

Add the account schema and the versioned root key ring the accounts release is built on.

# Motivation

Everything the accounts release does needs a place to put it and a way to keep its secrets. Without a schema there is nowhere to record an identity, a session, a capability or a queued email, and without a key ring every stored secret would sit under one static environment variable with no way to rotate it and one blast radius for every subsystem.

# Functionality

`ROOT_KEYS` holds comma separated `version:base64key` entries, newest first. The first entry is the active write key and every entry stays readable, so rotation is active write, multi read, re-encrypt, then remove, with no downtime. Purpose keys come from HKDF-SHA256 with the purpose in the info string. Values are sealed with AES-GCM and carry their key version, and the purpose plus any row binding go into the associated data. Every refusal raises: a key that has left the ring loses its plaintext rather than falling back to another key. The ring is separate key material from `FLEET_TOKEN_KEY`.

The schema adds `auth_identities`, `sessions`, `auth_tokens`, `invitations`, `auth_factors`, `recovery_codes` and `mail_outbox`, and gives `users` a `state` and a `mail_verified`. PostgreSQL holds every rule rather than the application: one password identity per account, one provider subject per account, a provider identity that can never carry a local credential, one open invitation per address, one TOTP factor per account, and role and state constrained to the designed values. Deleting an account takes its identities, sessions, tokens, factors and recovery codes with it.

`installation_auth_state` now records the root key version the installation writes with, and startup refuses when the ring no longer holds it.

# Details

Base is `feat/auth-r2-foundation-guard` (PR #359); it retargets upward as the stack merges.

This round is schema and key material only. There are no routes, no login flow, no password hashing and no TOTP verification; those belong to the rounds that add them, and `AUTH_MODE=accounts` still refuses to boot.

Accounts are unique on `lower(btrim(email))` through a unique functional index, and invitations use the same expression in a partial index, so there is no stored normalized column to fall out of step with the address it was derived from.

Deleting an administrator does not revoke the invitations they minted, because an invitation is open while `accepted_at` and `revoked_at` are both null and deleting the inviter sets neither. That is a cross-row rule no constraint can express, so it belongs to the round that implements account deletion; it is recorded here because the `SET NULL` on `invited_by` is what makes it easy to miss later.

`cryptography` is a new dependency and supplies both HKDF and AES-GCM. Nothing here is hand rolled.

Migration 0015 was checked to round trip to 0014 and back, and its schema was compared against the ORM metadata with no difference. Local verification passed 447 backend tests, 194 worker tests, the frontend suite, Ruff, mypy, Svelte checks, the production build and CSP verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added secure, versioned encryption for account secrets, including key rotation and re-encryption.
  - Added authentication data storage for identities, sessions, tokens, invitations, security factors, recovery codes, and email delivery.
  - Added account verification, account-state tracking, normalized email uniqueness, and validation rules.
  - Added startup checks to detect missing or unusable encryption keys.

- **Documentation**
  - Documented the new `ROOT_KEYS` configuration and encryption design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->