### PR TITLE
Sign in and stay signed in

### DIFF
--- a/backend/app/accounts.py
+++ b/backend/app/accounts.py
@@ -1,0 +1,135 @@
+"""Signing in, signing out, and what an account can see about itself."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from sqlalchemy import select
+from starlette.responses import Response
+
+from app import db, sessions
+from app.auth import current_principal, require_accounts_mode
+from app.passwords import verify_password
+from app.settings import get_settings
+from app.tables import AuthIdentity, Session, User
+
+router = APIRouter(dependencies=[Depends(require_accounts_mode)])
+
+# One answer for an address nobody holds and a password that does not match,
+# so the response cannot be used to learn which accounts exist.
+REFUSED = HTTPException(status_code=401, detail="invalid email or password")
+
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str
+    remember_me: bool = False
+
+
+def issue_session(response: Response, issued: sessions.Issued) -> None:
+    public_url = get_settings().public_url
+    session_name, csrf_name = sessions.cookie_names(public_url)
+    secure = public_url.startswith("https")
+    # Host-only on purpose: no domain, so a sibling host cannot be handed it.
+    response.set_cookie(session_name, issued.token, path="/", samesite="lax",
+                        secure=secure, httponly=True)
+    # The browser has to read this one to echo it back on unsafe requests.
+    response.set_cookie(csrf_name, issued.csrf, path="/", samesite="lax",
+                        secure=secure, httponly=False)
+
+
+def _clear(response: Response) -> None:
+    session_name, csrf_name = sessions.cookie_names(get_settings().public_url)
+    response.delete_cookie(session_name, path="/")
+    response.delete_cookie(csrf_name, path="/")
+
+
+@router.post("/api/v1/auth/login", status_code=204)
+async def login(request: LoginRequest) -> Response:
+    if db.session_factory is None:
+        raise HTTPException(status_code=503, detail="database unavailable")
+    subject = request.email.strip().lower()
+    async with db.session_factory() as session:
+        found = (await session.execute(
+            select(AuthIdentity, User)
+            .join(User, User.id == AuthIdentity.user_id)
+            .where(AuthIdentity.provider == "password", AuthIdentity.subject == subject)
+        )).first()
+    if found is None:
+        raise REFUSED
+    identity, user = found
+    if identity.password_hash is None or not verify_password(identity.password_hash,
+                                                             request.password):
+        raise REFUSED
+    if user.state in {"disabled", "deletion_pending", "purging"}:
+        raise REFUSED
+    # Everything this account already held is retired: authentication is the
+    # boundary a session before it must not cross.
+    await sessions.revoke_all(user.id)
+    issued = await sessions.mint(user, remember_me=request.remember_me, authenticated=True)
+    response = Response(status_code=204)
+    issue_session(response, issued)
+    return response
+
+
+@router.post("/api/v1/auth/logout", status_code=204)
+async def logout(principal: sessions.Resolved = Depends(current_principal)) -> Response:
+    await sessions.revoke(principal.session.id)
+    response = Response(status_code=204)
+    _clear(response)
+    return response
+
+
+@router.get("/api/v1/account")
+async def account(principal: sessions.Resolved = Depends(current_principal)) -> dict:
+    if db.session_factory is None:
+        raise HTTPException(status_code=503, detail="database unavailable")
+    async with db.session_factory() as session:
+        rows = (await session.execute(
+            select(Session)
+            .where(Session.user_id == principal.user.id, Session.revoked_at.is_(None))
+            .order_by(Session.created_at)
+        )).scalars().all()
+    return {
+        "id": str(principal.user.id),
+        "email": principal.user.email,
+        "role": principal.user.role,
+        "state": principal.user.state,
+        "mail_verified": principal.user.mail_verified,
+        "recent_auth": sessions.is_recent(principal.session),
+        "sessions": [
+            {
+                "id": str(row.id),
+                "current": row.id == principal.session.id,
+                "remember_me": row.remember_me,
+                "created_at": row.created_at.isoformat(),
+                "last_seen_at": row.last_seen_at.isoformat() if row.last_seen_at else None,
+                "absolute_expires_at": row.absolute_expires_at.isoformat(),
+            }
+            for row in rows
+        ],
+    }
+
+
+@router.delete("/api/v1/account/sessions/{session_id}", status_code=204)
+async def revoke_session(
+    session_id: uuid.UUID,
+    request: Request,
+    principal: sessions.Resolved = Depends(current_principal),
+) -> Response:
+    if db.session_factory is None:
+        raise HTTPException(status_code=503, detail="database unavailable")
+    async with db.session_factory() as session:
+        row = (await session.execute(
+            select(Session).where(Session.id == session_id,
+                                  Session.user_id == principal.user.id)
+        )).scalar_one_or_none()
+    # 404 rather than 403: whether a session id exists is not this caller's
+    # business unless it is theirs.
+    if row is None:
+        raise HTTPException(status_code=404, detail="Not Found")
+    await sessions.revoke(row.id)
+    response = Response(status_code=204)
+    if row.id == principal.session.id:
+        _clear(response)
+    return response

--- a/backend/app/accounts.py
+++ b/backend/app/accounts.py
@@ -4,12 +4,13 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
+from anyio import to_thread
 from sqlalchemy import select
 from starlette.responses import Response
 
 from app import db, sessions
 from app.auth import current_principal, require_accounts_mode
-from app.passwords import verify_password
+from app.passwords import ABSENT_ACCOUNT_HASH, verify_password
 from app.settings import get_settings
 from app.tables import AuthIdentity, Session, User
 
@@ -18,6 +19,12 @@ router = APIRouter(dependencies=[Depends(require_accounts_mode)])
 # One answer for an address nobody holds and a password that does not match,
 # so the response cannot be used to learn which accounts exist.
 REFUSED = HTTPException(status_code=401, detail="invalid email or password")
+
+
+async def _presented_session(http: Request) -> sessions.Resolved | None:
+    session_name, _ = sessions.cookie_names(get_settings().public_url)
+    token = http.cookies.get(session_name)
+    return await sessions.resolve(token) if token else None
 
 
 class LoginRequest(BaseModel):
@@ -45,7 +52,8 @@ def _clear(response: Response) -> None:
 
 
 @router.post("/api/v1/auth/login", status_code=204)
-async def login(request: LoginRequest) -> Response:
+async def login(request: LoginRequest, http: Request) -> Response:
+    presented = await _presented_session(http)
     if db.session_factory is None:
         raise HTTPException(status_code=503, detail="database unavailable")
     subject = request.email.strip().lower()
@@ -55,17 +63,18 @@ async def login(request: LoginRequest) -> Response:
             .join(User, User.id == AuthIdentity.user_id)
             .where(AuthIdentity.provider == "password", AuthIdentity.subject == subject)
         )).first()
-    if found is None:
+    stored = ABSENT_ACCOUNT_HASH if found is None else (found[0].password_hash or "")
+    matched = await to_thread.run_sync(verify_password, stored, request.password)
+    if found is None or not matched:
         raise REFUSED
-    identity, user = found
-    if identity.password_hash is None or not verify_password(identity.password_hash,
-                                                             request.password):
-        raise REFUSED
+    _, user = found
     if user.state in {"disabled", "deletion_pending", "purging"}:
         raise REFUSED
-    # Everything this account already held is retired: authentication is the
-    # boundary a session before it must not cross.
-    await sessions.revoke_all(user.id)
+    # Session fixation: a token planted in this browser before authentication
+    # must not be the token that comes out of it. Only the session presented
+    # here is retired, so signing in on one device does not sign out another.
+    if presented is not None:
+        await sessions.revoke(presented.session.id)
     issued = await sessions.mint(user, remember_me=request.remember_me, authenticated=True)
     response = Response(status_code=204)
     issue_session(response, issued)

--- a/backend/app/accounts.py
+++ b/backend/app/accounts.py
@@ -39,16 +39,22 @@ def issue_session(response: Response, issued: sessions.Issued) -> None:
     secure = public_url.startswith("https")
     # Host-only on purpose: no domain, so a sibling host cannot be handed it.
     response.set_cookie(session_name, issued.token, path="/", samesite="lax",
-                        secure=secure, httponly=True)
+                        secure=secure, httponly=True, max_age=issued.max_age)
     # The browser has to read this one to echo it back on unsafe requests.
     response.set_cookie(csrf_name, issued.csrf, path="/", samesite="lax",
-                        secure=secure, httponly=False)
+                        secure=secure, httponly=False, max_age=issued.max_age)
 
 
 def _clear(response: Response) -> None:
-    session_name, csrf_name = sessions.cookie_names(get_settings().public_url)
-    response.delete_cookie(session_name, path="/")
-    response.delete_cookie(csrf_name, path="/")
+    public_url = get_settings().public_url
+    session_name, csrf_name = sessions.cookie_names(public_url)
+    # Secure matters on the way out too: a __Host- cookie cleared without it
+    # breaks the prefix rules, so the browser drops the whole Set-Cookie and
+    # the credential the user asked to remove stays on disk.
+    secure = public_url.startswith("https")
+    response.delete_cookie(session_name, path="/", samesite="lax", secure=secure,
+                           httponly=True)
+    response.delete_cookie(csrf_name, path="/", samesite="lax", secure=secure)
 
 
 @router.post("/api/v1/auth/login", status_code=204)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -52,7 +52,12 @@ def _check_csrf(request: Request, csrf_cookie: str | None) -> None:
     if origin is None or origin.rstrip("/") not in _allowed_origins():
         raise HTTPException(status_code=403, detail="origin not allowed")
     sent = request.headers.get("x-csrf-token")
-    if not csrf_cookie or not sent or not secrets.compare_digest(sent, csrf_cookie):
+    # Compared as bytes: compare_digest refuses non-ASCII strings, and headers
+    # and cookies decode as latin-1, so a planted value would raise here and
+    # turn every unsafe request that browser sends into a 500.
+    if not csrf_cookie or not sent or not secrets.compare_digest(
+        sent.encode("latin-1", "replace"), csrf_cookie.encode("latin-1", "replace")
+    ):
         raise HTTPException(status_code=403, detail="missing or mismatched CSRF token")
 
 

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,25 +1,98 @@
-"""Request identity. Only AUTH_MODE=none exists so far: every request acts as
-the single local user. The local and oauth providers land with the accounts
-milestone behind the same dependency (docs/blueprint.md, the mode seam)."""
+"""Request identity, in both modes.
 
+AUTH_MODE=none resolves every request to the single implicit local user.
+AUTH_MODE=accounts resolves a session, presented as a bearer or as a cookie,
+and applies the role and account-state policy (docs/blueprint.md, the mode
+seam).
+"""
+
+import secrets
 from collections.abc import Awaitable, Callable
 from typing import Literal
 
 from fastapi import Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import audit, db
+from app import audit, db, sessions
 from app.settings import get_settings
 from app.tables import User
 
 
-async def current_user(session: AsyncSession = Depends(db.get_session)) -> User:
+async def require_accounts_mode() -> None:
+    """An install that never enabled accounts does not answer account routes."""
+    if get_settings().auth_mode != "accounts":
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+CANNOT_SIGN_IN = frozenset({"disabled", "deletion_pending", "purging"})
+UNAUTHENTICATED = HTTPException(status_code=401, detail="authentication required")
+
+
+def _allowed_origins() -> set[str]:
+    settings = get_settings()
+    allowed = {settings.public_url.rstrip("/")}
+    allowed.update(
+        candidate.strip().rstrip("/")
+        for candidate in settings.allowed_origins.split(",")
+        if candidate.strip()
+    )
+    return allowed
+
+
+def _check_csrf(request: Request, csrf_cookie: str | None) -> None:
+    """Only for cookies: a cookie rides along on any request a page can cause.
+
+    A bearer is presented deliberately, so it needs neither check. An absent
+    Origin is refused rather than waved through, because browsers send one on
+    every unsafe request and only a non-browser caller can omit it.
+    """
+    if request.method in SAFE_METHODS:
+        return
+    origin = request.headers.get("origin")
+    if origin is None or origin.rstrip("/") not in _allowed_origins():
+        raise HTTPException(status_code=403, detail="origin not allowed")
+    sent = request.headers.get("x-csrf-token")
+    if not csrf_cookie or not sent or not secrets.compare_digest(sent, csrf_cookie):
+        raise HTTPException(status_code=403, detail="missing or mismatched CSRF token")
+
+
+async def current_principal(request: Request) -> sessions.Resolved:
+    """The authenticated session behind this request, in accounts mode.
+
+    A bearer wins outright: a caller presenting one is making a claim about who
+    they are, and falling back to the cookie would let a page borrow the
+    browser's ambient credential after its own claim was rejected.
+    """
+    header = request.headers.get("authorization", "")
+    if header[:7].lower() == "bearer ":
+        resolved = await sessions.resolve(header[7:].strip())
+        if resolved is None:
+            raise UNAUTHENTICATED
+    else:
+        session_name, csrf_name = sessions.cookie_names(get_settings().public_url)
+        token = request.cookies.get(session_name)
+        if not token:
+            raise UNAUTHENTICATED
+        resolved = await sessions.resolve(token)
+        if resolved is None:
+            raise UNAUTHENTICATED
+        _check_csrf(request, request.cookies.get(csrf_name))
+    if resolved.user.state in CANNOT_SIGN_IN:
+        raise UNAUTHENTICATED
+    return resolved
+
+
+async def current_user(
+    request: Request,
+    session: AsyncSession = Depends(db.get_session),
+) -> User:
     if get_settings().auth_mode != "none":
-        # Accounts mode has no session yet, and the implicit local user is an
-        # administrator. Resolving to it here would hand every caller the
-        # owner's account, which is the one outcome enabling accounts must
-        # never produce. Sign-in arrives with sessions.
-        raise HTTPException(status_code=401, detail="authentication required")
+        principal = await current_principal(request)
+        if principal.user.state == "suspended" and request.method not in SAFE_METHODS:
+            # A pause, not a deletion: they may read their own work and settle
+            # their account, and may change nothing.
+            raise HTTPException(status_code=403, detail="account suspended")
+        return principal.user
     if db.local_user_id is None:
         raise HTTPException(status_code=503, detail="database unavailable")
     user = await session.get(User, db.local_user_id)

--- a/backend/app/enable.py
+++ b/backend/app/enable.py
@@ -10,13 +10,15 @@ import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from anyio import to_thread
 from sqlalchemy import delete, func, select, update
 from starlette.responses import Response
 
-from app import audit, db
+from app import audit, db, sessions
+from app.accounts import issue_session
+from app.auth import require_accounts_mode
 from app.passwords import PasswordRejected, hash_password
 from app.settings import get_settings
 from app.tables import AuthIdentity, AuthToken, User
@@ -131,15 +133,23 @@ class SetupRequest(BaseModel):
     password: str
 
 
-@router.post("/api/v1/auth/setup", status_code=204)
+@router.post("/api/v1/auth/setup", status_code=204,
+             dependencies=[Depends(require_accounts_mode)])
 async def setup(request: SetupRequest) -> Response:
-    if get_settings().auth_mode != "accounts":
-        # An install that never enabled accounts has no link to claim it with,
-        # and should not answer as though it might.
-        raise HTTPException(status_code=404, detail="Not Found")
     adopted = await claim(request.token, request.email, request.password)
     await audit.record("POST /api/v1/auth/setup", target_user_id=adopted)
-    return Response(status_code=204)
+    if db.session_factory is None:
+        raise HTTPException(status_code=503, detail="database unavailable")
+    async with db.session_factory() as session:
+        owner = await session.get(User, adopted)
+    if owner is None:
+        raise HTTPException(status_code=503, detail="database unavailable")
+    # A clean session, and deliberately no recent-authentication grant: the
+    # link proved a capability, not a person, so it must not open the window
+    # that guards credential changes.
+    response = Response(status_code=204)
+    issue_session(response, await sessions.mint(owner, remember_me=False))
+    return response
 
 
 async def _enable() -> str:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.logs import setup_logging
 from app.metrics import router as metrics_router
 from app.realtime import reap_dead_workers
 from app.realtime import router as realtime_router
+from app.accounts import router as accounts_router
 from app.enable import router as enable_router
 from app.registry import router as registry_router
 from app.security import SecurityHeadersMiddleware, unhandled_exception_response
@@ -111,6 +112,7 @@ if get_settings().benchmark_api:
     app.include_router(benchmark_router)
 
 app.include_router(benchmark_sessions_router)
+app.include_router(accounts_router)
 app.include_router(enable_router)
 app.include_router(registry_router)
 app.include_router(jobs_router)

--- a/backend/app/passwords.py
+++ b/backend/app/passwords.py
@@ -17,6 +17,15 @@ MAX_LENGTH = 128
 _BLOCKLIST_FILE = Path(__file__).with_name("password_blocklist.txt")
 _HASHER = PasswordHasher(memory_cost=19456, time_cost=2, parallelism=1)
 
+# Verified against when no account holds the address, so that answering an
+# unknown address costs the same as answering a wrong password. Without it the
+# response time says which addresses exist. It hashes a value nobody can
+# present, and is a constant so startup does not pay to derive it.
+ABSENT_ACCOUNT_HASH = (
+    "$argon2id$v=19$m=19456,t=2,p=1$5FGPgcOuWsn+UfdGOcCR4w$"
+    "6e2EuqoQru8Lt94M3CDXgJ+41TbosnBsRzpe3yboRZU"
+)
+
 
 class PasswordRejected(Exception):
     pass

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -1,0 +1,149 @@
+"""Browser sessions. The row keeps the SHA-256 of the token and nothing else.
+
+An administrator session is the most valuable thing in the install, so it takes
+the short idle window and never the remember-me convenience.
+"""
+
+import hashlib
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select, update
+
+from app import db
+from app.tables import Session, User
+
+ABSOLUTE = timedelta(hours=12)
+REMEMBER_ABSOLUTE = timedelta(days=30)
+REMEMBER_IDLE = timedelta(days=7)
+ADMIN_IDLE = timedelta(minutes=30)
+RECENT_AUTH = timedelta(minutes=30)
+TOKEN_BYTES = 32
+TOUCH_INTERVAL = timedelta(minutes=1)
+
+
+@dataclass
+class Issued:
+    token: str
+    csrf: str
+
+
+@dataclass
+class Resolved:
+    session: Session
+    user: User
+
+
+def token_hash(token: str) -> bytes:
+    return hashlib.sha256(token.encode()).digest()
+
+
+def cookie_names(public_url: str) -> tuple[str, str]:
+    """__Host- requires Secure, which a browser refuses to set over plain HTTP,
+    and LAN self-hosting is plain HTTP."""
+    prefix = "__Host-" if public_url.startswith("https://") else ""
+    return f"{prefix}potocolom_session", f"{prefix}potocolom_csrf"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+async def mint(user: User, remember_me: bool, authenticated: bool = False) -> Issued:
+    """authenticated defaults to False because setup proves a link, not a
+    person, and must not open the window that guards credential changes."""
+    if db.session_factory is None:
+        raise RuntimeError("database unavailable")
+    if user.role == "admin":
+        remembered, idle = False, ADMIN_IDLE
+    elif remember_me:
+        remembered, idle = True, REMEMBER_IDLE
+    else:
+        remembered, idle = False, None
+    now = _now()
+    issued = Issued(token=secrets.token_urlsafe(TOKEN_BYTES),
+                    csrf=secrets.token_urlsafe(TOKEN_BYTES))
+    async with db.session_factory() as session:
+        session.add(Session(
+            user_id=user.id,
+            token_hash=token_hash(issued.token),
+            remember_me=remembered,
+            absolute_expires_at=now + (REMEMBER_ABSOLUTE if remembered else ABSOLUTE),
+            idle_expires_at=now + idle if idle is not None else None,
+            recent_auth_at=now if authenticated else None,
+        ))
+        await session.commit()
+    return issued
+
+
+async def resolve(token: str) -> Resolved | None:
+    if db.session_factory is None:
+        raise RuntimeError("database unavailable")
+    now = _now()
+    async with db.session_factory() as session:
+        found = (await session.execute(
+            select(Session, User)
+            .join(User, User.id == Session.user_id)
+            .where(Session.token_hash == token_hash(token))
+        )).first()
+        if found is None:
+            return None
+        row, user = found
+        if row.revoked_at is not None or row.absolute_expires_at <= now:
+            return None
+        if row.idle_expires_at is not None and row.idle_expires_at <= now:
+            return None
+        if row.last_seen_at is None or now - row.last_seen_at >= TOUCH_INTERVAL:
+            # Sliding on every request would make each authenticated call a
+            # SELECT, an UPDATE and a COMMIT on a fifteen connection pool, to
+            # move a window that is measured in minutes.
+            if row.idle_expires_at is not None:
+                row.idle_expires_at = now + (
+                    ADMIN_IDLE if user.role == "admin" else REMEMBER_IDLE)
+            row.last_seen_at = now
+            await session.commit()
+        return Resolved(session=row, user=user)
+
+
+async def revoke(session_id: uuid.UUID) -> None:
+    if db.session_factory is None:
+        raise RuntimeError("database unavailable")
+    async with db.session_factory() as session:
+        await session.execute(
+            update(Session)
+            .where(Session.id == session_id, Session.revoked_at.is_(None))
+            .values(revoked_at=_now())
+        )
+        await session.commit()
+
+
+async def revoke_all(user_id: uuid.UUID) -> None:
+    if db.session_factory is None:
+        raise RuntimeError("database unavailable")
+    async with db.session_factory() as session:
+        await session.execute(
+            update(Session)
+            .where(Session.user_id == user_id, Session.revoked_at.is_(None))
+            .values(revoked_at=_now())
+        )
+        await session.commit()
+
+
+async def rotate(session_id: uuid.UUID, user: User) -> Issued:
+    if db.session_factory is None:
+        raise RuntimeError("database unavailable")
+    async with db.session_factory() as session:
+        remembered = (await session.execute(
+            update(Session)
+            .where(Session.id == session_id, Session.revoked_at.is_(None))
+            .values(revoked_at=_now())
+            .returning(Session.remember_me)
+        )).scalar_one_or_none()
+        await session.commit()
+    return await mint(user, remember_me=bool(remembered))
+
+
+def is_recent(session: Session) -> bool:
+    return session.recent_auth_at is not None and session.recent_auth_at > _now() - RECENT_AUTH

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -28,6 +28,10 @@ TOUCH_INTERVAL = timedelta(minutes=1)
 class Issued:
     token: str
     csrf: str
+    # Seconds for the cookie, or None for one that dies with the browser. A
+    # remembered row is worthless if the cookie carrying it does not outlive
+    # the browser process.
+    max_age: int | None = None
 
 
 @dataclass
@@ -63,8 +67,11 @@ async def mint(user: User, remember_me: bool, authenticated: bool = False) -> Is
     else:
         remembered, idle = False, None
     now = _now()
-    issued = Issued(token=secrets.token_urlsafe(TOKEN_BYTES),
-                    csrf=secrets.token_urlsafe(TOKEN_BYTES))
+    issued = Issued(
+        token=secrets.token_urlsafe(TOKEN_BYTES),
+        csrf=secrets.token_urlsafe(TOKEN_BYTES),
+        max_age=int(REMEMBER_ABSOLUTE.total_seconds()) if remembered else None,
+    )
     async with db.session_factory() as session:
         session.add(Session(
             user_id=user.id,

--- a/backend/tests/test_first_admin_setup.py
+++ b/backend/tests/test_first_admin_setup.py
@@ -207,13 +207,17 @@ def test_a_weak_password_is_refused_and_claims_nothing(accounts):
 
 
 @pytest.mark.db
-def test_setup_grants_no_session_and_no_recent_authentication(accounts):
-    """Setup proves a capability, not a person, so it must not hand out the
-    recent-authentication window that guards credential changes."""
+def test_setup_grants_a_clean_session_and_no_recent_authentication(accounts):
+    """Setup proves a capability, not a person. It signs the claimant in, and
+    withholds the recent-authentication window that guards credential
+    changes."""
     token = accounts(enable.mint_setup_token())
     with TestClient(app) as client:
         assert _claim(client, token).status_code == 204
-        assert client.portal.call(_sessions) == []
+        live = client.portal.call(_sessions)
+        assert len(live) == 1
+        assert live[0].recent_auth_at is None
+        assert live[0].remember_me is False
 
 
 @pytest.mark.db

--- a/backend/tests/test_session_policy.py
+++ b/backend/tests/test_session_policy.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 
+from app import accounts as accounts_module
 from app import db, sessions
 from app.main import app
 from app.passwords import hash_password
@@ -246,14 +247,51 @@ async def _session_id(token: str):
 
 
 @pytest.mark.db
-def test_a_login_rotates_onto_a_new_session(accounts):
-    """A session that existed before authentication must not survive it."""
-    user = _account(accounts, "rotate@example.com")
+def test_a_session_planted_before_a_login_does_not_survive_it(accounts):
+    """Session fixation: a token planted in this browser before authentication
+    must not be the token that comes out of it."""
+    user = _account(accounts, "fixate@example.com")
     with TestClient(app) as client:
-        stale = client.portal.call(sessions.mint, user, False)
-        assert _login(client, "rotate@example.com").status_code == 204
+        planted = client.portal.call(sessions.mint, user, False)
+        client.cookies.set("potocolom_session", planted.token)
+        assert _login(client, "fixate@example.com").status_code == 204
         assert client.get("/api/v1/account",
-                          headers={"Authorization": f"Bearer {stale.token}"}).status_code == 401
+                          headers={"Authorization": f"Bearer {planted.token}"}).status_code == 401
+
+
+@pytest.mark.db
+def test_signing_in_on_one_device_does_not_sign_out_another(accounts):
+    """The account page exists to let people revoke their own sessions, so a
+    login must not do it for them."""
+    user = _account(accounts, "twodevices@example.com")
+    with TestClient(app) as client:
+        phone = client.portal.call(sessions.mint, user, False)
+        assert _login(client, "twodevices@example.com").status_code == 204
+        assert client.get("/api/v1/account",
+                          headers={"Authorization": f"Bearer {phone.token}"}).status_code == 200
+
+
+@pytest.mark.db
+def test_an_unknown_address_costs_the_same_as_a_wrong_password(accounts):
+    """Answering an unknown address without hashing would let the response
+    time say which addresses exist."""
+    _account(accounts, "timed@example.com")
+    calls = []
+    real = accounts_module.verify_password
+
+    def counting(stored, password):
+        calls.append(stored)
+        return real(stored, password)
+
+    with TestClient(app) as client:
+        accounts_module.verify_password = counting
+        try:
+            _login(client, "nobody@example.com")
+            _login(client, "timed@example.com", password="a-different-long-password")
+        finally:
+            accounts_module.verify_password = real
+    assert len(calls) == 2
+    assert calls[0] == accounts_module.ABSENT_ACCOUNT_HASH
 
 
 @pytest.mark.db

--- a/backend/tests/test_session_policy.py
+++ b/backend/tests/test_session_policy.py
@@ -1,0 +1,295 @@
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from app import db, sessions
+from app.main import app
+from app.passwords import hash_password
+from app.settings import get_settings
+from app.tables import AuthIdentity, User
+
+PASSWORD = "a-long-enough-account-password"
+ORIGIN = "http://localhost:8000"
+
+
+@pytest.fixture
+def accounts(portal_runner, monkeypatch):
+    monkeypatch.setenv("ROOT_KEYS", "1:" + "A" * 43 + "=")
+    monkeypatch.setenv("PUBLIC_URL", ORIGIN)
+    get_settings.cache_clear()
+    assert portal_runner(db.connect()) is True
+    portal_runner(db.enable_accounts_mode(db.session_factory))
+    portal_runner(db.dispose())
+    monkeypatch.setenv("AUTH_MODE", "accounts")
+    get_settings.cache_clear()
+    assert portal_runner(db.connect()) is True
+    original = db.local_user_id
+
+    async def clear() -> None:
+        async with db.session_factory() as session:
+            for table in ("sessions", "auth_identities", "auth_tokens", "audit_events",
+                          "installation_auth_state"):
+                await session.execute(text(f"DELETE FROM {table}"))
+            await session.execute(text("DELETE FROM users WHERE id <> :id"), {"id": original})
+            await session.execute(
+                text("UPDATE users SET email = :local, role = 'admin', state = 'active' "
+                     "WHERE id = :id"),
+                {"local": db.LOCAL_USER_EMAIL, "id": original})
+            await session.commit()
+
+    try:
+        yield portal_runner
+    finally:
+        if db.session_factory is None:
+            portal_runner(db.connect())
+        portal_runner(clear())
+        portal_runner(db.dispose())
+        get_settings.cache_clear()
+
+
+def _account(portal_runner, email, role="user", state="active", password=PASSWORD) -> User:
+    async def go():
+        async with db.session_factory() as session:
+            user = User(id=uuid.uuid4(), email=email, role=role, state=state)
+            session.add(user)
+            await session.flush()
+            session.add(AuthIdentity(id=uuid.uuid4(), user_id=user.id, provider="password",
+                                     subject=email.lower(), password_hash=hash_password(password)))
+            await session.commit()
+            return user
+
+    return portal_runner(go())
+
+
+def _login(client, email, password=PASSWORD, remember_me=False):
+    return client.post("/api/v1/auth/login", headers={"Origin": ORIGIN},
+                       json={"email": email, "password": password, "remember_me": remember_me})
+
+
+@pytest.mark.db
+def test_a_password_login_sets_a_session_and_a_readable_csrf_cookie(accounts):
+    _account(accounts, "member@example.com")
+    with TestClient(app) as client:
+        response = _login(client, "member@example.com")
+        assert response.status_code == 204
+        jar = {cookie.name: cookie for cookie in client.cookies.jar}
+        assert "potocolom_session" in jar and "potocolom_csrf" in jar
+        raw = response.headers.get_list("set-cookie")
+        session_header = next(h for h in raw if h.startswith("potocolom_session="))
+        csrf_header = next(h for h in raw if h.startswith("potocolom_csrf="))
+        assert "HttpOnly" in session_header
+        assert "samesite=lax" in session_header.lower()
+        assert "Path=/" in session_header
+        # Plain HTTP: a Secure cookie would simply be dropped by the browser.
+        assert "Secure" not in session_header
+        # The browser has to read the CSRF value to echo it back.
+        assert "HttpOnly" not in csrf_header
+
+
+@pytest.mark.db
+def test_the_session_cookie_authenticates_a_later_request(accounts):
+    _account(accounts, "member2@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "member2@example.com").status_code == 204
+        me = client.get("/api/v1/account")
+        assert me.status_code == 200
+        assert me.json()["email"] == "member2@example.com"
+        assert me.json()["role"] == "user"
+
+
+@pytest.mark.db
+def test_without_a_cookie_nothing_authenticates(accounts):
+    with TestClient(app) as client:
+        assert client.get("/api/v1/account").status_code == 401
+
+
+@pytest.mark.db
+def test_an_unknown_address_and_a_wrong_password_answer_identically(accounts):
+    _account(accounts, "real@example.com")
+    with TestClient(app) as client:
+        unknown = _login(client, "ghost@example.com")
+        wrong = _login(client, "real@example.com", password="a-different-long-password")
+    assert unknown.status_code == wrong.status_code == 401
+    assert unknown.json() == wrong.json()
+
+
+@pytest.mark.db
+def test_a_login_is_case_insensitive_about_the_address(accounts):
+    _account(accounts, "mixed@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "  MiXeD@Example.COM ").status_code == 204
+
+
+@pytest.mark.db
+@pytest.mark.parametrize("state", ["disabled", "deletion_pending", "purging"])
+def test_an_account_that_cannot_sign_in_is_refused(accounts, state):
+    _account(accounts, f"{state}@example.com", state=state)
+    with TestClient(app) as client:
+        assert _login(client, f"{state}@example.com").status_code == 401
+
+
+@pytest.mark.db
+def test_a_suspended_account_signs_in_read_only(accounts):
+    """Suspended is a pause, not a deletion: they may read their own work and
+    settle their account, and may change nothing."""
+    _account(accounts, "paused@example.com", state="suspended")
+    with TestClient(app) as client:
+        assert _login(client, "paused@example.com").status_code == 204
+        assert client.get("/api/v1/account").status_code == 200
+        blocked = client.post("/api/v1/generations", headers=_csrf(client), json={})
+        assert blocked.status_code == 403
+
+
+def _csrf(client) -> dict:
+    value = next(c.value for c in client.cookies.jar if c.name.endswith("potocolom_csrf"))
+    return {"Origin": ORIGIN, "X-CSRF-Token": value}
+
+
+@pytest.mark.db
+def test_an_unsafe_cookie_request_needs_the_csrf_header(accounts):
+    _account(accounts, "csrf@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "csrf@example.com").status_code == 204
+        assert client.post("/api/v1/auth/logout", headers={"Origin": ORIGIN}).status_code == 403
+        wrong = client.post("/api/v1/auth/logout",
+                            headers={"Origin": ORIGIN, "X-CSRF-Token": "not-the-value"})
+        assert wrong.status_code == 403
+        assert client.post("/api/v1/auth/logout", headers=_csrf(client)).status_code == 204
+
+
+@pytest.mark.db
+def test_an_unsafe_cookie_request_needs_an_exact_origin(accounts):
+    _account(accounts, "origin@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "origin@example.com").status_code == 204
+        headers = _csrf(client)
+        for forged in ("http://evil.example", ORIGIN + ".evil.example", "null"):
+            assert client.post("/api/v1/auth/logout",
+                               headers={**headers, "Origin": forged}).status_code == 403
+
+
+@pytest.mark.db
+def test_a_safe_request_needs_no_csrf(accounts):
+    _account(accounts, "safe@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "safe@example.com").status_code == 204
+        assert client.get("/api/v1/account").status_code == 200
+
+
+@pytest.mark.db
+def test_a_bearer_credential_wins_and_never_falls_back_to_the_cookie(accounts):
+    """A caller who presents a bearer is making a claim about who they are.
+    Falling back would let a stolen page borrow the browser's cookie."""
+    user = _account(accounts, "bearer@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "bearer@example.com").status_code == 204
+        issued = client.portal.call(sessions.mint, user, False)
+        good = client.get("/api/v1/account",
+                          headers={"Authorization": f"Bearer {issued.token}"})
+        assert good.status_code == 200
+        bad = client.get("/api/v1/account", headers={"Authorization": "Bearer nonsense"})
+        assert bad.status_code == 401
+
+
+@pytest.mark.db
+def test_a_bearer_request_needs_no_csrf_header(accounts):
+    user = _account(accounts, "bearer2@example.com")
+    with TestClient(app) as client:
+        issued = client.portal.call(sessions.mint, user, False)
+        assert client.post("/api/v1/auth/logout",
+                           headers={"Authorization": f"Bearer {issued.token}"}).status_code == 204
+
+
+@pytest.mark.db
+def test_logging_out_kills_the_session_it_used(accounts):
+    _account(accounts, "bye@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "bye@example.com").status_code == 204
+        assert client.post("/api/v1/auth/logout", headers=_csrf(client)).status_code == 204
+        assert client.get("/api/v1/account").status_code == 401
+
+
+@pytest.mark.db
+def test_an_account_lists_and_revokes_its_other_sessions(accounts):
+    user = _account(accounts, "many@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "many@example.com").status_code == 204
+        other = client.portal.call(sessions.mint, user, False)
+        listed = client.get("/api/v1/account").json()["sessions"]
+        assert len(listed) == 2
+        target = next(row for row in listed if not row["current"])
+        assert client.delete(f"/api/v1/account/sessions/{target['id']}",
+                             headers=_csrf(client)).status_code == 204
+        assert client.get("/api/v1/account",
+                          headers={"Authorization": f"Bearer {other.token}"}).status_code == 401
+
+
+@pytest.mark.db
+def test_one_account_cannot_revoke_another_account_session(accounts):
+    victim = _account(accounts, "victim@example.com")
+    _account(accounts, "attacker@example.com")
+    with TestClient(app) as client:
+        theirs = client.portal.call(sessions.mint, victim, False)
+        theirs_id = client.portal.call(_session_id, theirs.token)
+        assert _login(client, "attacker@example.com").status_code == 204
+        assert client.delete(f"/api/v1/account/sessions/{theirs_id}",
+                             headers=_csrf(client)).status_code == 404
+        assert client.get("/api/v1/account",
+                          headers={"Authorization": f"Bearer {theirs.token}"}).status_code == 200
+
+
+async def _session_id(token: str):
+    resolved = await sessions.resolve(token)
+    return str(resolved.session.id)
+
+
+@pytest.mark.db
+def test_a_login_rotates_onto_a_new_session(accounts):
+    """A session that existed before authentication must not survive it."""
+    user = _account(accounts, "rotate@example.com")
+    with TestClient(app) as client:
+        stale = client.portal.call(sessions.mint, user, False)
+        assert _login(client, "rotate@example.com").status_code == 204
+        assert client.get("/api/v1/account",
+                          headers={"Authorization": f"Bearer {stale.token}"}).status_code == 401
+
+
+@pytest.mark.db
+def test_claiming_the_installation_hands_back_a_session_with_no_recent_auth(accounts):
+    from app import enable
+
+    token = accounts(enable.mint_setup_token())
+    with TestClient(app) as client:
+        claimed = client.post("/api/v1/auth/setup", headers={"Origin": ORIGIN}, json={
+            "token": token, "email": "owner@example.com", "password": PASSWORD})
+        assert claimed.status_code == 204
+        assert client.get("/api/v1/account").status_code == 200
+        current = client.get("/api/v1/account").json()
+        assert current["recent_auth"] is False
+
+
+@pytest.mark.db
+def test_a_password_login_grants_recent_authentication(accounts):
+    _account(accounts, "recent@example.com")
+    with TestClient(app) as client:
+        assert _login(client, "recent@example.com").status_code == 204
+        assert client.get("/api/v1/account").json()["recent_auth"] is True
+
+
+@pytest.mark.db
+def test_the_host_prefix_appears_when_the_install_is_served_over_https(accounts, monkeypatch):
+    _account(accounts, "secure@example.com")
+    monkeypatch.setenv("PUBLIC_URL", "https://studio.example.com")
+    get_settings.cache_clear()
+    with TestClient(app, base_url="https://studio.example.com") as client:
+        response = client.post("/api/v1/auth/login",
+                               headers={"Origin": "https://studio.example.com"},
+                               json={"email": "secure@example.com", "password": PASSWORD,
+                                     "remember_me": False})
+        assert response.status_code == 204
+        header = next(h for h in response.headers.get_list("set-cookie")
+                      if h.startswith("__Host-potocolom_session="))
+        assert "Secure" in header and "HttpOnly" in header and "Path=/" in header
+        assert "Domain" not in header

--- a/backend/tests/test_session_policy.py
+++ b/backend/tests/test_session_policy.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from fastapi import Request
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 
@@ -331,3 +332,85 @@ def test_the_host_prefix_appears_when_the_install_is_served_over_https(accounts,
                       if h.startswith("__Host-potocolom_session="))
         assert "Secure" in header and "HttpOnly" in header and "Path=/" in header
         assert "Domain" not in header
+
+
+@pytest.mark.db
+def test_logging_out_over_https_actually_clears_the_cookies(accounts, monkeypatch):
+    """A __Host- cookie cleared without Secure breaks the prefix rules, so the
+    browser drops the whole Set-Cookie and the credential stays on disk."""
+    _account(accounts, "httpsout@example.com")
+    monkeypatch.setenv("PUBLIC_URL", "https://studio.example.com")
+    get_settings.cache_clear()
+    secure_origin = "https://studio.example.com"
+    with TestClient(app, base_url=secure_origin) as client:
+        assert client.post("/api/v1/auth/login", headers={"Origin": secure_origin},
+                           json={"email": "httpsout@example.com", "password": PASSWORD,
+                                 "remember_me": False}).status_code == 204
+        csrf = next(c.value for c in client.cookies.jar if c.name.endswith("potocolom_csrf"))
+        out = client.post("/api/v1/auth/logout",
+                          headers={"Origin": secure_origin, "X-CSRF-Token": csrf})
+        assert out.status_code == 204
+        cleared = out.headers.get_list("set-cookie")
+        assert len(cleared) == 2
+        for header in cleared:
+            assert header.startswith("__Host-")
+            assert "Secure" in header
+            assert "Max-Age=0" in header
+
+
+@pytest.mark.db
+def test_remember_me_outlives_the_browser_session(accounts):
+    """The thirty day row is worthless if the cookie carrying it dies when the
+    browser process does."""
+    _account(accounts, "remembered@example.com")
+    with TestClient(app) as client:
+        response = _login(client, "remembered@example.com", remember_me=True)
+        assert response.status_code == 204
+        session_header = next(h for h in response.headers.get_list("set-cookie")
+                              if h.startswith("potocolom_session="))
+        assert "Max-Age=" in session_header
+        age = int(session_header.split("Max-Age=")[1].split(";")[0])
+        assert age == int(sessions.REMEMBER_ABSOLUTE.total_seconds())
+
+
+@pytest.mark.db
+def test_a_plain_login_stays_a_browser_session_cookie(accounts):
+    _account(accounts, "plain@example.com")
+    with TestClient(app) as client:
+        response = _login(client, "plain@example.com")
+        session_header = next(h for h in response.headers.get_list("set-cookie")
+                              if h.startswith("potocolom_session="))
+        assert "Max-Age=" not in session_header
+
+
+@pytest.mark.db
+def test_an_administrator_cookie_is_never_remembered(accounts):
+    _account(accounts, "boss@example.com", role="admin")
+    with TestClient(app) as client:
+        response = _login(client, "boss@example.com", remember_me=True)
+        session_header = next(h for h in response.headers.get_list("set-cookie")
+                              if h.startswith("potocolom_session="))
+        assert "Max-Age=" not in session_header
+
+
+def test_a_non_ascii_csrf_value_is_refused_rather_than_crashing():
+    """compare_digest raises on non-ASCII strings, and Starlette decodes both
+    headers and cookies as latin-1, so a value httpx will not even send but a
+    raw client will would turn every unsafe request into a 500."""
+    from fastapi import HTTPException
+
+    from app.auth import _check_csrf
+
+    request = Request({
+        "type": "http", "http_version": "1.1", "method": "POST", "scheme": "http",
+        "path": "/api/v1/auth/logout", "raw_path": b"/api/v1/auth/logout",
+        "query_string": b"", "root_path": "", "server": ("testserver", 80), "client": None,
+        "headers": [(b"origin", ORIGIN.encode()), (b"x-csrf-token", "caf\xe9".encode("latin-1"))],
+    })
+    with pytest.raises(HTTPException) as refused:
+        _check_csrf(request, "cafe")
+    assert refused.value.status_code == 403
+
+    # And a value that genuinely matches still passes, rather than raising
+    # TypeError on its way to becoming a 500.
+    assert _check_csrf(Request({**request.scope}), "caf\xe9") is None

--- a/backend/tests/test_sessions.py
+++ b/backend/tests/test_sessions.py
@@ -1,0 +1,275 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select, text
+
+from app import db, sessions
+from app.tables import Session, User
+
+PLAIN = "http://box.lan:8080"
+SECURE = "https://studio.example.com"
+
+
+@pytest.fixture
+def connected(portal_runner):
+    assert portal_runner(db.connect()) is True
+
+    async def clear() -> None:
+        async with db.session_factory() as session:
+            await session.execute(text("DELETE FROM sessions"))
+            await session.execute(text("DELETE FROM users WHERE email <> :local"),
+                                  {"local": db.LOCAL_USER_EMAIL})
+            await session.commit()
+
+    portal_runner(clear())
+    try:
+        yield portal_runner
+    finally:
+        portal_runner(clear())
+        portal_runner(db.dispose())
+
+
+def _user(portal_runner, role="user", state="active") -> User:
+    async def go():
+        async with db.session_factory() as session:
+            row = User(id=uuid.uuid4(), email=f"{uuid.uuid4()}@example.com",
+                       role=role, state=state)
+            session.add(row)
+            await session.commit()
+            return row
+
+    return portal_runner(go())
+
+
+async def _row(token: str) -> Session | None:
+    async with db.session_factory() as session:
+        return (await session.execute(
+            select(Session).where(Session.token_hash == sessions.token_hash(token))
+        )).scalar_one_or_none()
+
+
+def test_the_locked_lifetimes_are_what_the_contract_says():
+    assert sessions.ABSOLUTE == timedelta(hours=12)
+    assert sessions.REMEMBER_ABSOLUTE == timedelta(days=30)
+    assert sessions.REMEMBER_IDLE == timedelta(days=7)
+    assert sessions.ADMIN_IDLE == timedelta(minutes=30)
+    assert sessions.RECENT_AUTH == timedelta(minutes=30)
+    assert sessions.TOKEN_BYTES == 32
+
+
+def test_cookie_names_carry_the_host_prefix_only_where_it_is_legal():
+    """__Host- requires Secure, which a browser refuses to set over plain
+    HTTP, and LAN self-hosting is plain HTTP."""
+    assert sessions.cookie_names(SECURE) == (
+        "__Host-potocolom_session", "__Host-potocolom_csrf")
+    assert sessions.cookie_names(PLAIN) == ("potocolom_session", "potocolom_csrf")
+
+
+@pytest.mark.db
+def test_a_minted_session_keeps_only_the_hash(connected):
+    user = _user(connected)
+    issued = connected(sessions.mint(user, remember_me=False))
+    assert len(issued.token) >= 43 and len(issued.csrf) >= 43
+    assert issued.token != issued.csrf
+    row = connected(_row(issued.token))
+    assert row is not None
+    assert row.token_hash == sessions.token_hash(issued.token)
+    assert issued.token.encode() not in row.token_hash
+
+
+@pytest.mark.db
+def test_two_mints_never_collide(connected):
+    user = _user(connected)
+    first = connected(sessions.mint(user, remember_me=False))
+    second = connected(sessions.mint(user, remember_me=False))
+    assert first.token != second.token and first.csrf != second.csrf
+
+
+@pytest.mark.db
+def test_a_plain_session_lasts_twelve_hours_with_no_idle_limit(connected):
+    user = _user(connected)
+    issued = connected(sessions.mint(user, remember_me=False))
+    row = connected(_row(issued.token))
+    assert _about(row.absolute_expires_at, sessions.ABSOLUTE)
+    assert row.idle_expires_at is None
+    assert row.remember_me is False
+
+
+@pytest.mark.db
+def test_remember_me_lasts_thirty_days_and_idles_after_seven(connected):
+    user = _user(connected)
+    issued = connected(sessions.mint(user, remember_me=True))
+    row = connected(_row(issued.token))
+    assert _about(row.absolute_expires_at, sessions.REMEMBER_ABSOLUTE)
+    assert _about(row.idle_expires_at, sessions.REMEMBER_IDLE)
+    assert row.remember_me is True
+
+
+@pytest.mark.db
+def test_an_administrator_idles_out_in_thirty_minutes_and_cannot_be_remembered(connected):
+    """An administrator session is the most valuable thing in the install, so
+    it does not get the convenience the other roles get."""
+    admin = _user(connected, role="admin")
+    issued = connected(sessions.mint(admin, remember_me=True))
+    row = connected(_row(issued.token))
+    assert _about(row.absolute_expires_at, sessions.ABSOLUTE)
+    assert _about(row.idle_expires_at, sessions.ADMIN_IDLE)
+    assert row.remember_me is False
+
+
+def _about(moment: datetime, window: timedelta) -> bool:
+    return abs((moment - datetime.now(timezone.utc)) - window) < timedelta(minutes=1)
+
+
+@pytest.mark.db
+def test_resolving_a_session_returns_its_account_and_moves_the_idle_window(connected):
+    admin = _user(connected, role="admin")
+    issued = connected(sessions.mint(admin, remember_me=False))
+    before = connected(_row(issued.token)).idle_expires_at
+
+    async def older() -> None:
+        async with db.session_factory() as session:
+            await session.execute(
+                text("UPDATE sessions SET idle_expires_at = :soon, last_seen_at = :then"),
+                {"soon": datetime.now(timezone.utc) + timedelta(minutes=5),
+                 "then": datetime.now(timezone.utc) - timedelta(minutes=25)},
+            )
+            await session.commit()
+
+    connected(older())
+    resolved = connected(sessions.resolve(issued.token))
+    assert resolved is not None and resolved.user.id == admin.id
+    assert connected(_row(issued.token)).idle_expires_at > before - timedelta(minutes=1)
+
+
+@pytest.mark.db
+def test_an_unknown_token_resolves_to_nothing(connected):
+    assert connected(sessions.resolve("not-a-session")) is None
+
+
+@pytest.mark.db
+@pytest.mark.parametrize("column", ["absolute_expires_at", "idle_expires_at"])
+def test_an_expired_session_resolves_to_nothing(connected, column):
+    user = _user(connected, role="admin")
+    issued = connected(sessions.mint(user, remember_me=False))
+
+    async def expire() -> None:
+        async with db.session_factory() as session:
+            await session.execute(
+                text(f"UPDATE sessions SET {column} = :past"),
+                {"past": datetime.now(timezone.utc) - timedelta(seconds=1)},
+            )
+            await session.commit()
+
+    connected(expire())
+    assert connected(sessions.resolve(issued.token)) is None
+
+
+@pytest.mark.db
+def test_a_revoked_session_resolves_to_nothing(connected):
+    user = _user(connected)
+    issued = connected(sessions.mint(user, remember_me=False))
+    connected(sessions.revoke(connected(_row(issued.token)).id))
+    assert connected(sessions.resolve(issued.token)) is None
+
+
+@pytest.mark.db
+def test_revoking_every_session_leaves_none_of_them_usable(connected):
+    user = _user(connected)
+    other = _user(connected)
+    mine = [connected(sessions.mint(user, remember_me=False)) for _ in range(3)]
+    theirs = connected(sessions.mint(other, remember_me=False))
+    connected(sessions.revoke_all(user.id))
+    assert all(connected(sessions.resolve(issued.token)) is None for issued in mine)
+    assert connected(sessions.resolve(theirs.token)) is not None
+
+
+@pytest.mark.db
+def test_rotation_replaces_the_session_rather_than_adding_one(connected):
+    """A credential or role change must not leave the old cookie working."""
+    user = _user(connected)
+    first = connected(sessions.mint(user, remember_me=True))
+    row = connected(_row(first.token))
+    second = connected(sessions.rotate(row.id, user))
+    assert connected(sessions.resolve(first.token)) is None
+    assert connected(sessions.resolve(second.token)) is not None
+    # Remembered stays remembered across a rotation.
+    assert connected(_row(second.token)).remember_me is True
+
+
+@pytest.mark.db
+def test_a_fresh_session_carries_no_recent_authentication_by_default(connected):
+    """Setup proves a link, not a person, so it must not open the window that
+    guards credential changes."""
+    user = _user(connected)
+    issued = connected(sessions.mint(user, remember_me=False))
+    assert connected(_row(issued.token)).recent_auth_at is None
+    assert sessions.is_recent(connected(_row(issued.token))) is False
+
+
+@pytest.mark.db
+def test_a_password_login_opens_the_recent_window_for_thirty_minutes(connected):
+    user = _user(connected)
+    issued = connected(sessions.mint(user, remember_me=False, authenticated=True))
+    row = connected(_row(issued.token))
+    assert row.recent_auth_at is not None
+    assert sessions.is_recent(row) is True
+
+    async def age() -> None:
+        async with db.session_factory() as session:
+            await session.execute(
+                text("UPDATE sessions SET recent_auth_at = :past"),
+                {"past": datetime.now(timezone.utc) - sessions.RECENT_AUTH
+                 - timedelta(seconds=1)},
+            )
+            await session.commit()
+
+    connected(age())
+    assert sessions.is_recent(connected(_row(issued.token))) is False
+
+
+@pytest.mark.db
+def test_a_session_record_keeps_no_address_and_no_user_agent(connected):
+    """Locked acceptance: durable records carry neither."""
+    user = _user(connected)
+    connected(sessions.mint(user, remember_me=False))
+    columns = {column.name for column in Session.__table__.columns}
+    assert not columns & {"ip", "ip_address", "remote_addr", "user_agent"}
+
+
+@pytest.mark.db
+def test_resolving_does_not_write_on_every_single_request(connected):
+    """Every authenticated request would otherwise be a SELECT plus an UPDATE
+    plus a COMMIT on a fifteen connection pool, to move a window by
+    milliseconds."""
+    admin = _user(connected, role="admin")
+    issued = connected(sessions.mint(admin, remember_me=False))
+    first = connected(_row(issued.token))
+    connected(sessions.resolve(issued.token))
+    touched = connected(_row(issued.token))
+    assert touched.last_seen_at is not None
+    seen = touched.last_seen_at
+    connected(sessions.resolve(issued.token))
+    assert connected(_row(issued.token)).last_seen_at == seen
+    assert first.idle_expires_at is not None
+
+
+@pytest.mark.db
+def test_a_stale_session_still_slides_before_it_idles_out(connected):
+    admin = _user(connected, role="admin")
+    issued = connected(sessions.mint(admin, remember_me=False))
+    connected(sessions.resolve(issued.token))
+
+    async def go_quiet() -> None:
+        async with db.session_factory() as session:
+            await session.execute(
+                text("UPDATE sessions SET last_seen_at = :then, idle_expires_at = :soon"),
+                {"then": datetime.now(timezone.utc) - timedelta(minutes=20),
+                 "soon": datetime.now(timezone.utc) + timedelta(minutes=10)},
+            )
+            await session.commit()
+
+    connected(go_quiet())
+    assert connected(sessions.resolve(issued.token)) is not None
+    assert _about(connected(_row(issued.token)).idle_expires_at, sessions.ADMIN_IDLE)

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,6 +13,10 @@ Every call a customer's browser makes, from first page load to account deletion.
   its own work, `viewer` is read-only. Write endpoints require `user` or `admin` and
   answer 403 for a `viewer`. The code calls the `user` tier "member" in
   `require_role("member")`; the stored value is `user`.
+- In `AUTH_MODE=accounts` a request authenticates with a session: 32 random bytes, kept only as a SHA-256 hash. Over HTTPS the cookies are `__Host-potocolom_session` and `__Host-potocolom_csrf`; over plain HTTP, which is what LAN self-hosting uses, they are `potocolom_session` and `potocolom_csrf`, because the `__Host-` prefix requires `Secure` and a browser drops a `Secure` cookie on plain HTTP. The session cookie is `HttpOnly`, `SameSite=Lax`, host-only and `Path=/`. The CSRF cookie is readable, because the browser has to echo it back.
+- An unsafe request authenticated by cookie needs an exact `Origin` and an `X-CSRF-Token` header matching the CSRF cookie, or it answers 403. An absent `Origin` is refused. A request authenticated by `Authorization: Bearer` needs neither, because a bearer is presented deliberately rather than sent along by the browser. A bearer wins outright: an invalid one answers 401 and never falls back to the cookie.
+- Sessions last 12 hours. Remember-me lasts 30 days with a 7 day idle window. An administrator gets 12 hours with a 30 minute idle window and cannot be remembered. Recent authentication lasts 30 minutes, is granted by signing in, and is never granted by claiming the installation.
+- `disabled`, `deletion_pending` and `purging` accounts cannot sign in, and their existing sessions stop resolving. A `suspended` account signs in read-only: safe methods answer normally and anything else answers 403.
 - A route requiring `admin` with an unsafe method is audited before it runs, with the actor, the role, and the route template as the action name. Admin reads are not audited; a read that reaches another user's data will record its own target when those routes exist. The record is durable in PostgreSQL and kept 90 days. Audit fails open: an action still proceeds when only its record fails, and the gap becomes visible instead of silent (see [SECURITY.md](../SECURITY.md)). No audit route is exposed yet.
 - REST errors use FastAPI's shape: `{"detail": "..."}` with a conventional status code.
 - Responses under `/api/v1/` include `Cache-Control: no-store`.
@@ -45,12 +49,13 @@ Every call a customer's browser makes, from first page load to account deletion.
 | GET `/api/v1/assets/{id}` | implemented | owner- or admin-checked asset bytes; missing and unauthorized assets return 404 |
 | POST `/api/v1/auth/register` | issue #5 | email and password signup |
 | GET `/api/v1/auth/verify` | issue #5 | email verification link target |
-| POST `/api/v1/auth/login` | issue #5 | session cookie issuance |
-| POST `/api/v1/auth/logout` | issue #5 | revoke the current session |
+| POST `/api/v1/auth/setup` | implemented | claim the installation with the one-use link; returns a clean session |
+| POST `/api/v1/auth/login` | implemented | password sign-in; sets the session and CSRF cookies |
+| POST `/api/v1/auth/logout` | implemented | revoke the session this request used |
 | GET `/api/v1/auth/redirect/{provider}` | issue #5 | OAuth authorization redirect |
 | GET `/api/v1/auth/callback/{provider}` | issue #5 | OAuth code exchange, then a session cookie |
-| GET `/api/v1/account` | issue #10 | profile, active sessions list |
-| DELETE `/api/v1/account/sessions/{id}` | issue #10 | revoke another session |
+| GET `/api/v1/account` | implemented | this account, and its live sessions |
+| DELETE `/api/v1/account/sessions/{id}` | implemented | revoke one of this account's own sessions |
 | GET `/api/v1/account/export` | issue #10 | GDPR data export (JSON plus image archive) |
 | DELETE `/api/v1/account` | issue #10 | deactivate now, hard delete within 30 days |
 | POST `/api/v1/assets/{id}/share` | issue #17 | mint a public share token |

--- a/docs/deployment-profiles.md
+++ b/docs/deployment-profiles.md
@@ -33,7 +33,7 @@ flowchart LR
 
 | Setting | Local dev | Self-hosted | Scaled self-hosted | cloud-sim | Cloud |
 |---|---|---|---|---|---|
-| AUTH_MODE | none | none or local | local | local | oauth |
+| AUTH_MODE | none | none or accounts | accounts | accounts | accounts |
 | OAUTH_PROVIDERS | | | | | google,github |
 | BILLING_ENABLED | false | false | false | true (fake) | true |
 | SAFETY_CHECKS | false | false | false | false | true |
@@ -48,7 +48,7 @@ flowchart LR
 
 The scaled self-hosted column deserves a note: it is not a separately designed product. Setting `REDIS_URL` switches dispatch and the frame relay to the Redis implementations, and additional worker containers simply dial the same fleet endpoint. A lab or studio with three GPU machines gets multi-worker scheduling with the exact scheduler the cloud runs (issue #20), for the cost of one Redis container.
 
-The `AUTH_MODE` row is target state. Only `none` is implemented; the API refuses to start with `local` until issue #5 lands it and with `oauth` until issue #9 lands it.
+`AUTH_MODE` is `none` or `accounts`; the retired `local` and `oauth` names are gone, and Google and GitHub are options within `accounts` rather than modes of their own. Both modes are implemented for REST. `accounts` still refuses the realtime socket, which has no principal of its own until issue #19 gives it one, so the studio needs `none` today.
 
 > Shipped status (2026-07-30): **not yet implemented.** Setting `REDIS_URL` currently changes neither job dispatch nor realtime relay, and the backend has no Redis dependency. This remains the migration target under "Redis-optional Queues and FrameBus contracts" and issue #20, "Multi-Worker Scheduling".
 
@@ -119,7 +119,9 @@ Every path below is possible because the schema, storage keys and API are identi
 
 ### Enabling accounts on an install that ran without them
 
-`AUTH_MODE=none` runs everything as one implicit local user who owns every row. Switching to `local` is the config change plus one ownership step: the first registered account adopts the existing library. That adoption command ships with issue #9 (it is a one-statement update behind a confirmation). Going further to `oauth` is purely additive: local identities remain valid, providers appear beside them.
+`AUTH_MODE=none` runs everything as one implicit local user who owns every row. `make auth-enable` is the switch: it writes the root key ring, records the change in PostgreSQL, and prints a one-use link valid for an hour. The first claimant adopts that implicit user, keeping its UUID, so the existing library comes with them rather than being copied or stranded.
+
+The switch is one way. An install that has enabled accounts refuses to start in `none` mode again, because falling back would return a multi-user install to answering every request as an administrator. Undoing it needs an offline destructive reset. Google and GitHub are additive within `accounts`: password identities stay valid and providers appear beside them.
 
 ### Adding Redis and more workers (self-hosted scale-out)
 


### PR DESCRIPTION
# Description

Give accounts mode a way to stay signed in: opaque sessions, cookies, CSRF, bearer precedence, and the account-state policy.

# Motivation

The previous round made `AUTH_MODE=accounts` bootable and left it answering 401 to everything except the one-use setup call. An installation that can be claimed and then not used is not usable. This is the round that closes that.

# Functionality

A session is 32 random bytes, kept only as a SHA-256 hash. Over HTTPS the cookies are `__Host-potocolom_session` and `__Host-potocolom_csrf`; over plain HTTP, which is what LAN self-hosting is, they are the unprefixed names, because the `__Host-` prefix requires `Secure` and a browser drops a `Secure` cookie on plain HTTP. The session cookie is `HttpOnly`, `SameSite=Lax`, host-only and `Path=/`; the CSRF cookie is readable, because the browser has to echo it back.

An unsafe request authenticated by cookie needs an exact `Origin` and a matching `X-CSRF-Token`. An absent `Origin` is refused rather than waved through. A bearer needs neither, because it is presented deliberately rather than sent along by the browser, and a bearer wins outright: an invalid one answers 401 and never falls back to the cookie.

Sessions last 12 hours. Remember-me lasts 30 days with a 7 day idle window. An administrator gets 12 hours with a 30 minute idle window and cannot be remembered, because an administrator session is the most valuable thing in the install. Recent authentication lasts 30 minutes, is granted by signing in, and is never granted by claiming the installation.

`disabled`, `deletion_pending` and `purging` accounts cannot sign in and their existing sessions stop resolving. `suspended` is a pause rather than a deletion: they sign in read-only, may read their own work and settle their account, and may change nothing.

`POST /api/v1/auth/login`, `POST /api/v1/auth/logout`, `GET /api/v1/account` and `DELETE /api/v1/account/sessions/{id}` are the routes. Claiming the installation now hands back a clean session too.

# Details

Base is `feat/auth-r5-first-admin-setup` (PR #362); it retargets upward as the stack merges.

The realtime socket still refuses accounts mode. It has no principal of its own, and `docs/connection-handling.md` assigns browser realtime authentication and its close codes to issue #19. So this round makes the REST API usable and deliberately stops at the socket: the studio still needs `AUTH_MODE=none`.

Signing in retires only the session presented on that request, which is what session fixation actually requires. Retiring every session an account holds would sign out the phone whenever someone signs in on the laptop, and the account page exists precisely so people can do that themselves.

Argon2id runs whether or not an address matches an account, verifying against a constant hash nobody can present when it does not. Otherwise the response time says which addresses exist, which makes guessing cheaper than the password itself.

Resolving a session slides its idle window at most once a minute. Sliding on every request would make each authenticated call a select, an update and a commit on a fifteen connection pool, to move a window measured in minutes.

`docs/deployment-profiles.md` also drops the retired `local` and `oauth` modes, which it still described as the target state.

Local verification passed 545 backend tests, 194 worker tests, the frontend suite, Ruff, mypy, Svelte checks, the production build and CSP verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added account login, logout, account details, and session-revocation capabilities.
  - Added persistent browser sessions with optional “remember me” support.
  - Added setup-time session creation for the initial account.
- **Security**
  - Added CSRF and origin validation for cookie-based requests.
  - Added protections for inactive or suspended accounts and secure session rotation.
- **Documentation**
  - Documented account authentication, session policies, supported endpoints, and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->