### PR TITLE
Stop parallel CI jobs fighting over one port

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -25,9 +25,6 @@ jobs:
     # Self-hosted on the reference desktop when GitHub-hosted minutes are exhausted.
     # Switch back to ubuntu-latest when hosted quota is available (docs/self-hosted-runner.md).
     runs-on: [self-hosted, Linux, X64, potocolom]
-    env:
-      # 15432 avoids clashing with deploy/compose/dev.yml postgres on :5432.
-      DATABASE_URL: postgresql://potocolom:potocolom@localhost:15432/potocolom_test
     defaults:
       run:
         working-directory: backend
@@ -40,7 +37,11 @@ jobs:
           POSTGRES_PASSWORD: potocolom
           POSTGRES_DB: potocolom
         ports:
-          - 15432:5432
+          # No fixed host port. Four self-hosted runners share one machine, so
+          # two backend jobs at once both tried to bind the same port and the
+          # second died before a single test ran. Docker picks a free one and
+          # the step below reads it back.
+          - 5432
         options: >-
           --health-cmd "pg_isready -U potocolom"
           --health-interval 5s
@@ -53,3 +54,6 @@ jobs:
       # The Makefile target is the single definition of what the job checks.
       - run: make verify-backend
         working-directory: .
+        env:
+          DATABASE_URL: >-
+            postgresql://potocolom:potocolom@localhost:${{ job.services.postgres.ports['5432'] }}/potocolom_test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,12 +33,12 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: make verify-compose
-        env:
-          # Four self-hosted runners share one machine. The smoke test defaulted
-          # to one compose project name and one host port, so two deploy jobs at
-          # once tore down each other's containers mid-test.
-          COMPOSE_SMOKE_PROJECT: potocolom-smoke-${{ github.run_id }}-${{ github.run_attempt }}
       # Builds the api and worker-sim images and drives a real generation
       # through them; the script cleans up its containers and volumes.
       - run: scripts/compose-smoke.sh
         timeout-minutes: 20
+        env:
+          # Four self-hosted runners share one machine, so two deploy jobs can
+          # run at once. With one project name they reused and then removed
+          # each other's containers mid-test.
+          COMPOSE_SMOKE_PROJECT: potocolom-smoke-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - run: make verify-compose
+        env:
+          # Four self-hosted runners share one machine. The smoke test defaulted
+          # to one compose project name and one host port, so two deploy jobs at
+          # once tore down each other's containers mid-test.
+          COMPOSE_SMOKE_PROJECT: potocolom-smoke-${{ github.run_id }}-${{ github.run_attempt }}
       # Builds the api and worker-sim images and drives a real generation
       # through them; the script cleans up its containers and volumes.
       - run: scripts/compose-smoke.sh

--- a/scripts/compose-smoke.sh
+++ b/scripts/compose-smoke.sh
@@ -6,7 +6,6 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 COMPOSE_DIR="$ROOT/deploy/compose"
 cd "$COMPOSE_DIR"
 
-PORT="${COMPOSE_SMOKE_PORT:-18080}"
 PROJECT="${COMPOSE_SMOKE_PROJECT:-potocolom-smoke}"
 COMPOSE=(docker compose -p "$PROJECT" -f compose.smoke.yml)
 
@@ -14,9 +13,31 @@ if [[ ! -f .env ]]; then
   cp .env.example .env
 fi
 
-if (echo >/dev/tcp/127.0.0.1/"$PORT") 2>/dev/null; then
-  echo "port ${PORT} is already in use; stop the conflicting service or set COMPOSE_SMOKE_PORT" >&2
-  exit 1
+port_free() {
+  ! (echo >/dev/tcp/127.0.0.1/"$1") 2>/dev/null
+}
+
+if [[ -n "${COMPOSE_SMOKE_PORT:-}" ]]; then
+  # Asked for explicitly, so a clash is the operator's to resolve.
+  PORT="$COMPOSE_SMOKE_PORT"
+  if ! port_free "$PORT"; then
+    echo "port ${PORT} is already in use; stop the conflicting service or set COMPOSE_SMOKE_PORT" >&2
+    exit 1
+  fi
+else
+  # Several self-hosted runners share one machine, so a fixed default meant two
+  # smoke tests at once fought over one port. Take 18080 when it is free and
+  # let the OS name one when it is not.
+  PORT=18080
+  if ! port_free "$PORT"; then
+    PORT="$(python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+")"
+  fi
 fi
 
 export COMPOSE_SMOKE_PORT="$PORT"

--- a/scripts/compose-smoke.sh
+++ b/scripts/compose-smoke.sh
@@ -27,7 +27,8 @@ s.close()
 "
 }
 
-if [[ -n "${COMPOSE_SMOKE_PORT:-}" ]]; then
+REQUESTED_PORT="${COMPOSE_SMOKE_PORT:-}"
+if [[ -n "$REQUESTED_PORT" ]]; then
   # Asked for explicitly, so a clash is the operator's to resolve.
   PORT="$COMPOSE_SMOKE_PORT"
   if ! port_free "$PORT"; then
@@ -64,8 +65,15 @@ for attempt in 1 2 3; do
     echo "could not start the smoke stack after 3 attempts" >&2
     exit 1
   fi
-  echo "start failed on port ${PORT}; taking another and retrying" >&2
   "${COMPOSE[@]}" down -v --remove-orphans || true
+  if [[ -n "$REQUESTED_PORT" ]]; then
+    # The probe at the top already refused a busy requested port. Moving off it
+    # now would pass the smoke test on a port the caller never asked for, and
+    # whatever took it would go unreported.
+    echo "could not start the smoke stack on requested port ${PORT}" >&2
+    exit 1
+  fi
+  echo "start failed on port ${PORT}; taking another and retrying" >&2
   PORT="$(free_port)"
   export COMPOSE_SMOKE_PORT="$PORT"
   base="http://localhost:${PORT}"

--- a/scripts/compose-smoke.sh
+++ b/scripts/compose-smoke.sh
@@ -17,6 +17,16 @@ port_free() {
   ! (echo >/dev/tcp/127.0.0.1/"$1") 2>/dev/null
 }
 
+free_port() {
+  python3 -c "
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+"
+}
+
 if [[ -n "${COMPOSE_SMOKE_PORT:-}" ]]; then
   # Asked for explicitly, so a clash is the operator's to resolve.
   PORT="$COMPOSE_SMOKE_PORT"
@@ -30,26 +40,37 @@ else
   # let the OS name one when it is not.
   PORT=18080
   if ! port_free "$PORT"; then
-    PORT="$(python3 -c "
-import socket
-s = socket.socket()
-s.bind(('127.0.0.1', 0))
-print(s.getsockname()[1])
-s.close()
-")"
+    PORT="$(free_port)"
   fi
 fi
 
 export COMPOSE_SMOKE_PORT="$PORT"
+base="http://localhost:${PORT}"
 
 cleanup() {
   "${COMPOSE[@]}" down -v --remove-orphans || true
 }
 trap cleanup EXIT
 
-"${COMPOSE[@]}" up -d --build --remove-orphans
+# Probing a port and then binding it are two steps, and another job can take
+# it in between. Retry on the bind failure rather than pretending the probe
+# was a reservation. PUBLIC_URL has to be settled before the API starts,
+# because it reads it at boot, so the port cannot simply be left to Docker.
+for attempt in 1 2 3; do
+  if "${COMPOSE[@]}" up -d --build --remove-orphans; then
+    break
+  fi
+  if [[ "$attempt" == 3 ]]; then
+    echo "could not start the smoke stack after 3 attempts" >&2
+    exit 1
+  fi
+  echo "start failed on port ${PORT}; taking another and retrying" >&2
+  "${COMPOSE[@]}" down -v --remove-orphans || true
+  PORT="$(free_port)"
+  export COMPOSE_SMOKE_PORT="$PORT"
+  base="http://localhost:${PORT}"
+done
 
-base="http://localhost:${PORT}"
 for _ in $(seq 1 90); do
   if curl -sf "${base}/api/v1/health" >/dev/null; then
     break


### PR DESCRIPTION
# Description

Give each CI job its own host port and its own compose project, so two jobs of the same workflow can run at once.

# Motivation

Four self-hosted runners now share one machine, and CI runs jobs in parallel across them. Two workflows were still written as though only one copy of themselves could ever run.

Both failed on #365 for this reason, with nothing wrong in the code under test:

- `backend` died in `Initialize containers` with `Bind for 0.0.0.0:15432 failed: port is already allocated`, before a single test ran.
- `deploy` failed decoding an empty response, after its containers were torn down underneath it.

# Functionality

The backend job no longer publishes PostgreSQL on a fixed host port. Docker picks a free one and the step reads it back through `job.services.postgres.ports`.

The compose smoke test takes a project name per run from CI, so two runs cannot share containers. The script also takes a free port when its default is busy, instead of refusing. A port asked for explicitly still refuses on a clash, because that one is the operator's to resolve.

# Details

The smoke test's fixed project name was the harder of the two. The port guard did not catch it: with the same project name, the second run reused and then removed the first run's containers rather than binding a second port, which is why the failure surfaced as a JSON decode error rather than as a port clash.

There is no arithmetic in GitHub Actions expressions, so the port could not be derived from the run number in the workflow. Choosing it in the script is also better for anyone running two smoke tests locally.

Recorded as #384 (shipped).\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated backend verification by selecting available database ports dynamically, reducing failures caused by port conflicts.
  * Enhanced smoke tests to validate explicitly configured ports, retry transient startup failures, and automatically choose an available local port when needed.
  * Prevented concurrent deployment checks from interfering with one another by isolating their temporary environments.

* **Reliability**
  * Increased consistency of deployment and integration checks, especially when multiple workflows run simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->