### PR TITLE
Measure shipped realtime frames through Engine.frame

### DIFF
--- a/scripts/profile-realtime-frame.py
+++ b/scripts/profile-realtime-frame.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Shipped Engine.frame() p95 and GPU-lock stages, with a real PromptCache.
+
+Not CI. Replaces the prototype-batch-sweep 160.2 / 219.8 pair as a baseline:
+that script passes prompts as strings and times sketch map plus WebP with the
+pipeline call. This script times DiffusersEngine.frame() the way the worker
+runs it. gpu_ms is occupancy under the GPU lock; wall_ms includes codec work
+off that lock.
+
+  worker/.venv/bin/python scripts/profile-realtime-frame.py
+  worker/.venv/bin/python scripts/profile-realtime-frame.py --models vega-rt
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import math
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "worker"))
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(1, math.ceil(pct / 100.0 * len(ordered)))
+    return ordered[min(len(ordered), rank) - 1]
+
+
+def mean_stages(rows: list[dict[str, int] | None]) -> dict[str, float] | None:
+    present = [row for row in rows if row is not None]
+    if not present:
+        return None
+    keys = present[0].keys()
+    return {
+        key: round(sum(row[key] for row in present) / len(present), 1)
+        for key in keys
+    }
+
+
+def canvas_bytes() -> bytes:
+    image = Image.new("RGB", (512, 512), "white")
+    pen = ImageDraw.Draw(image)
+    pen.line(
+        [(10, 210), (150, 140), (300, 180), (500, 150)],
+        fill=(17, 24, 39),
+        width=5,
+    )
+    pen.ellipse([(150, 300), (360, 380)], outline=(17, 24, 39), width=5)
+    buffer = io.BytesIO()
+    image.save(buffer, "PNG")
+    return buffer.getvalue()
+
+
+def defaults(manifest, prompt: str, seed: int) -> dict:
+    properties = manifest.parameters.get("properties", {})
+    return {
+        "prompt": prompt,
+        "steps": int(properties.get("steps", {}).get("default", 2)),
+        "structure_strength": float(
+            properties.get("structure_strength", {}).get("default", 1.0)
+        ),
+        "seed": seed,
+        "guidance": 0.0,
+    }
+
+
+async def profile_model(
+    device: str,
+    models_dir: str,
+    manifest,
+    samples: int,
+    prompt: str,
+    seed: int,
+) -> dict:
+    os.environ.setdefault("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "1")
+    from worker.engine import DiffusersEngine, PromptCache
+
+    engine = DiffusersEngine(device, memory_mode="full", models_dir=models_dir)
+    await engine.load_model(manifest)
+    await engine.ensure_realtime_resident(manifest)
+    payload = canvas_bytes()
+    params = defaults(manifest, prompt, seed)
+    cache = PromptCache()
+    await engine.frame(manifest, params, payload, prompt_cache=cache)
+    miss_cache = PromptCache()
+    miss_params = dict(params)
+    miss_params["prompt"] = f"{prompt} cache miss"
+    miss = await engine.frame(
+        manifest, miss_params, payload, prompt_cache=miss_cache, profile=True,
+    )
+    gpu_ms: list[int] = []
+    wall_ms: list[float] = []
+    stages: list[dict[str, int] | None] = []
+    for _ in range(samples):
+        started = time.perf_counter()
+        result = await engine.frame(
+            manifest, params, payload, prompt_cache=cache, profile=True,
+        )
+        wall_ms.append((time.perf_counter() - started) * 1000.0)
+        gpu_ms.append(result.gpu_ms)
+        stages.append(result.stages)
+    await engine.unload_all()
+    p95_gpu_ms = percentile([float(value) for value in gpu_ms], 95.0)
+    return {
+        "model": manifest.id,
+        "samples": samples,
+        "warmup_discarded": True,
+        "cache_miss": {
+            "gpu_ms": miss.gpu_ms,
+            "stages": miss.stages,
+        },
+        "hit_stages_mean": mean_stages(stages),
+        "samples_gpu_ms": gpu_ms,
+        "samples_wall_ms": [round(value, 1) for value in wall_ms],
+        "gpu_median_ms": statistics.median(gpu_ms) if gpu_ms else None,
+        "gpu_p95_ms": p95_gpu_ms,
+        "wall_median_ms": statistics.median(wall_ms) if wall_ms else None,
+        "wall_p95_ms": percentile(wall_ms, 95.0),
+        "slots_at_500": math.floor(500 / p95_gpu_ms) if p95_gpu_ms else 0,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models-dir", default=str(ROOT / "worker" / "models"))
+    parser.add_argument("--device", default="rocm", choices=("rocm", "cuda", "cpu"))
+    parser.add_argument("--models", default="sdxl-turbo,vega-rt")
+    parser.add_argument("--samples", type=int, default=20)
+    parser.add_argument("--prompt", default="a red cube on a table, studio light")
+    parser.add_argument("--out", default="")
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+    from worker.manifests import load_manifests
+
+    if args.samples <= 0:
+        raise SystemExit("--samples must be positive")
+
+    manifests = {manifest.id: manifest for manifest in load_manifests(args.models_dir)}
+    wanted = [item.strip() for item in args.models.split(",") if item.strip()]
+    missing = [item for item in wanted if item not in manifests]
+    if missing:
+        raise SystemExit(f"unknown models: {missing}")
+    cases = [
+        asyncio.run(profile_model(
+            args.device, args.models_dir, manifests[model_id], args.samples,
+            args.prompt, args.seed,
+        ))
+        for model_id in wanted
+    ]
+    text = json.dumps({"cases": cases}, indent=2)
+    print(text)
+    if args.out:
+        Path(args.out).write_text(text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worker/tests/test_frame_profile.py
+++ b/worker/tests/test_frame_profile.py
@@ -1,0 +1,286 @@
+import asyncio
+import io
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from worker.engine import (
+    CODEC_CONCURRENCY_LIMIT,
+    DiffusersEngine,
+    GeneratedFrame,
+    PromptCache,
+    SimulatedEngine,
+)
+from worker.manifests import Manifest, SIMULATED_MANIFEST
+
+
+PROFILE_KEYS = {
+    "adapter_ms",
+    "text_encode_ms",
+    "unet_ms",
+    "taesd_ms",
+    "overhead_ms",
+    "text_encode_cache_hit",
+    "unet_forwards",
+}
+
+
+class _FakeTensor:
+    def __init__(self, shape, *, values=None):
+        self.shape = tuple(shape)
+        self.values = values
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    def __getitem__(self, index):
+        if type(index) is not int:
+            raise TypeError("fake tensor only implements integer indexing")
+        return _FakeTensor(self.shape[1:])
+
+
+class _FakeTorch:
+    class OutOfMemoryError(RuntimeError):
+        pass
+
+    class _Context:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    @staticmethod
+    def no_grad():
+        return _FakeTorch._Context()
+
+    @staticmethod
+    def inference_mode():
+        return _FakeTorch._Context()
+
+    @staticmethod
+    def tensor(values, *, device):
+        assert device == "cpu"
+        return _FakeTensor((len(values), len(values[0])), values=values)
+
+    @staticmethod
+    def cat(tensors, dim):
+        shape = list(tensors[0].shape)
+        axis = dim if dim >= 0 else len(shape) + dim
+        shape[axis] = sum(tensor.shape[axis] for tensor in tensors)
+        return _FakeTensor(shape)
+
+    @staticmethod
+    def zeros_like(tensor):
+        return _FakeTensor(tensor.shape)
+
+
+class _FakeTokenizer:
+    pad_token_id = 0
+    bos_token_id = 1
+    eos_token_id = 2
+
+    def __call__(self, prompt, *, add_special_tokens, truncation):
+        assert add_special_tokens is False
+        assert truncation is False
+        return {"input_ids": [10 + int(word[1:]) for word in prompt.split()]}
+
+    @staticmethod
+    def num_special_tokens_to_add(*, pair):
+        assert pair is False
+        return 2
+
+
+class _FakeEncoderOutput:
+    def __init__(self, hidden):
+        self.hidden_states = [hidden, hidden]
+
+    def __getitem__(self, index):
+        assert index == 0
+        return _FakeTensor((1, 4))
+
+
+class _FakeTextEncoder:
+    def __init__(self):
+        self.config = SimpleNamespace(use_attention_mask=True)
+
+    def __call__(self, input_ids, *, attention_mask, output_hidden_states=False):
+        assert attention_mask.shape == input_ids.shape
+        hidden = _FakeTensor((1, input_ids.shape[1], 4))
+        if output_hidden_states:
+            return _FakeEncoderOutput(hidden)
+        return (hidden,)
+
+
+class _HookModule:
+    def __init__(self):
+        self._pre_hooks = []
+        self._hooks = []
+
+    def register_forward_pre_hook(self, hook):
+        self._pre_hooks.append(hook)
+        return SimpleNamespace(remove=lambda: self._pre_hooks.remove(hook))
+
+    def register_forward_hook(self, hook):
+        self._hooks.append(hook)
+        return SimpleNamespace(remove=lambda: self._hooks.remove(hook))
+
+    def __call__(self, *args, **kwargs):
+        for hook in tuple(self._pre_hooks):
+            hook(self, args)
+        result = SimpleNamespace()
+        for hook in tuple(self._hooks):
+            hook(self, args, result)
+        return result
+
+
+class _FakeVae:
+    config = SimpleNamespace(scaling_factor=1.0)
+
+    def encode(self, image):
+        raise AssertionError("realtime adapter path called vae.encode")
+
+
+class _ProfilePipeline:
+    def __init__(self):
+        self.tokenizer = _FakeTokenizer()
+        self.text_encoder = _FakeTextEncoder()
+        self.tokenizer_2 = None
+        self.text_encoder_2 = None
+        self.config = SimpleNamespace(force_zeros_for_empty_prompt=True)
+        self.adapter = _HookModule()
+        self.unet = _HookModule()
+        self.vae = _FakeVae()
+        self.image_processor = SimpleNamespace(
+            postprocess=lambda decoded, output_type: [Image.new("RGB", (32, 32), (1, 2, 3))]
+        )
+        self.calls = 0
+
+    def __call__(self, **kwargs):
+        self.calls += 1
+        self.adapter()
+        self.unet()
+        self.unet()
+        if kwargs.get("output_type") == "latent":
+            return SimpleNamespace(images=_FakeTensor((1, 4, 8, 8)))
+        return SimpleNamespace(images=[Image.new("RGB", (32, 32), (1, 2, 3))])
+
+
+def _payload():
+    buffer = io.BytesIO()
+    Image.new("RGB", (24, 16), (1, 2, 3)).save(buffer, "PNG")
+    return buffer.getvalue()
+
+
+def _manifest():
+    return Manifest(
+        id="vega-rt",
+        name="VegaRT",
+        capabilities=["text_to_image", "image_to_image", "realtime"],
+        prompt_token_limit=77,
+        t2i_adapter="org/vega-sketch",
+        preview_decoder="madebyollin/taesdxl",
+    )
+
+
+def _engine(pipeline):
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = _FakeTorch()
+    engine.device = "cpu"
+    engine.dtype = object()
+    engine._gpu = asyncio.Lock()
+    engine._codec = asyncio.Semaphore(CODEC_CONCURRENCY_LIMIT)
+    engine._pick_rung = MagicMock(return_value="full")
+    engine._evict_except = MagicMock()
+    engine._evict_poisoned = MagicMock()
+    engine._pipeline = MagicMock(return_value=pipeline)
+    return engine
+
+
+def _decoder_modules():
+    decoder = MagicMock()
+    decoder.to.return_value = decoder
+    decoder.decode.return_value = (_FakeTensor((1, 3, 32, 32)),)
+    autoencoder_tiny = MagicMock()
+    autoencoder_tiny.from_pretrained.return_value = decoder
+    diffusers = ModuleType("diffusers")
+    diffusers.AutoencoderTiny = autoencoder_tiny
+    return diffusers
+
+
+def _frame(engine, manifest, *, prompt_cache=None, profile=False):
+    return asyncio.run(
+        engine.frame(
+            manifest,
+            {"prompt": "w0 w1"},
+            _payload(),
+            prompt_cache=prompt_cache,
+            profile=profile,
+        )
+    )
+
+
+def test_default_frame_has_no_stages():
+    pipeline = _ProfilePipeline()
+    engine = _engine(pipeline)
+    with patch.dict("sys.modules", {"diffusers": _decoder_modules()}):
+        result = _frame(engine, _manifest())
+    assert result.stages is None
+
+
+def test_profile_returns_exact_stage_keys():
+    pipeline = _ProfilePipeline()
+    engine = _engine(pipeline)
+    with patch.dict("sys.modules", {"diffusers": _decoder_modules()}):
+        result = _frame(engine, _manifest(), profile=True)
+    assert set(result.stages) == PROFILE_KEYS
+    assert all(type(value) is int for value in result.stages.values())
+
+
+def test_adapter_frame_does_not_encode_vae():
+    pipeline = _ProfilePipeline()
+    engine = _engine(pipeline)
+    with patch.dict("sys.modules", {"diffusers": _decoder_modules()}):
+        result = _frame(engine, _manifest())
+    assert isinstance(result, GeneratedFrame)
+
+
+def test_prompt_cache_miss_then_hit():
+    pipeline = _ProfilePipeline()
+    engine = _engine(pipeline)
+    cache = PromptCache()
+    with patch.dict("sys.modules", {"diffusers": _decoder_modules()}):
+        first = _frame(engine, _manifest(), prompt_cache=cache, profile=True)
+        second = _frame(engine, _manifest(), prompt_cache=cache, profile=True)
+    assert first.stages["text_encode_cache_hit"] == 0
+    assert second.stages["text_encode_cache_hit"] == 1
+
+
+def test_simulated_engine_honors_profile():
+    engine = SimulatedEngine(0.0)
+    default = asyncio.run(engine.frame(SIMULATED_MANIFEST, {}, _payload()))
+    profiled = asyncio.run(
+        engine.frame(SIMULATED_MANIFEST, {}, _payload(), profile=True)
+    )
+    assert default.stages is None
+    assert set(profiled.stages) == PROFILE_KEYS
+    assert all(type(value) is int for value in profiled.stages.values())
+
+
+def test_profile_counts_unet_forwards():
+    pipeline = _ProfilePipeline()
+    engine = _engine(pipeline)
+    with patch.dict("sys.modules", {"diffusers": _decoder_modules()}):
+        result = _frame(engine, _manifest(), profile=True)
+    assert result.stages["unet_forwards"] == 2
+
+
+def test_profile_overhead_is_nonnegative_int():
+    pipeline = _ProfilePipeline()
+    engine = _engine(pipeline)
+    with patch.dict("sys.modules", {"diffusers": _decoder_modules()}):
+        result = _frame(engine, _manifest(), profile=True)
+    assert type(result.stages["overhead_ms"]) is int
+    assert result.stages["overhead_ms"] >= 0

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -110,10 +110,34 @@ def reject_degenerate_output(image: Image.Image, model_id: str) -> None:
         )
 
 
+def _empty_frame_stages() -> dict[str, int]:
+    return {
+        "adapter_ms": 0,
+        "text_encode_ms": 0,
+        "unet_ms": 0,
+        "taesd_ms": 0,
+        "overhead_ms": 0,
+        "text_encode_cache_hit": 0,
+        "unet_forwards": 0,
+    }
+
+
+def _finish_stage_overhead(stages: dict[str, int], gpu_ms: int) -> None:
+    stages["overhead_ms"] = max(
+        0,
+        gpu_ms
+        - stages["adapter_ms"]
+        - stages["text_encode_ms"]
+        - stages["unet_ms"]
+        - stages["taesd_ms"],
+    )
+
+
 @dataclass
 class GeneratedFrame:
     data: bytes
     gpu_ms: int
+    stages: dict[str, int] | None = None
 
 
 class NotResidentError(ValueError):
@@ -144,6 +168,7 @@ class Engine(Protocol):
     async def frame(
         self, manifest: Manifest, params: dict, payload: bytes,
         *, prompt_cache: PromptCache | None = None,
+        profile: bool = False,
     ) -> GeneratedFrame: ...
 
     def loaded_models(self) -> list[str]: ...
@@ -259,8 +284,9 @@ class SimulatedEngine:
             for request in requests:
                 if request.cancelled or request.future.done():
                     continue
+                stages = _empty_frame_stages() if request.profile else None
                 request.future.set_result(
-                    GeneratedFrame(request.payload, gpu_ms),
+                    GeneratedFrame(request.payload, gpu_ms, stages),
                 )
 
     def loaded_models(self) -> list[str]:
@@ -369,6 +395,7 @@ class SimulatedEngine:
     async def frame(
         self, manifest: Manifest, params: dict, payload: bytes,
         *, prompt_cache: PromptCache | None = None,
+        profile: bool = False,
     ) -> GeneratedFrame:
         session_key = (
             id(prompt_cache) if prompt_cache is not None
@@ -377,6 +404,7 @@ class SimulatedEngine:
         return await self._batch_collector.submit(
             session_key, manifest, params, payload, 0.0,
             prompt_cache=prompt_cache, resolution=REALTIME_SIZE,
+            profile=profile,
         )
 
 
@@ -1065,6 +1093,7 @@ class DiffusersEngine:
         pipeline_kwargs: dict[str, Any],
         *,
         preview_decoder: Any | None = None,
+        stages: dict[str, int] | None = None,
     ) -> Image.Image:
         if preview_decoder is None:
             preview_decoder = self._preview_decoder(pipeline, manifest)
@@ -1072,11 +1101,20 @@ class DiffusersEngine:
         if preview_decoder is not None:
             latents = pipeline(**pipeline_kwargs, output_type="latent").images
             try:
+                decode_started = 0.0
+                if stages is not None:
+                    self._sync_cuda()
+                    decode_started = time.perf_counter()
                 # AutoencoderTiny is trained to take the pipeline's SDXL latents
                 # directly. Unlike the full VAE path, dividing by
                 # pipeline.vae.config.scaling_factor here produces clipped noise.
                 with self.torch.inference_mode():
                     decoded = preview_decoder.decode(latents, return_dict=False)[0]
+                if stages is not None:
+                    self._sync_cuda()
+                    stages["taesd_ms"] += int(
+                        (time.perf_counter() - decode_started) * 1000
+                    )
                 image = pipeline.image_processor.postprocess(decoded, output_type="pil")[0]
             except Exception as error:
                 # A bad decoder is not a poisoned pipeline. Letting this reach
@@ -1162,11 +1200,15 @@ class DiffusersEngine:
         results: list[tuple[Image.Image, int]] = []
         for request in requests:
             started = time.monotonic()
+            stages = _empty_frame_stages() if request.profile else None
             image, _ = self._frame(
                 request.manifest, request.params, request.payload, request.strength,
-                prompt_cache=request.prompt_cache,
+                prompt_cache=request.prompt_cache, stages=stages,
             )
             gpu_ms = int((time.monotonic() - started) * 1000)
+            if stages is not None:
+                _finish_stage_overhead(stages, gpu_ms)
+                request.stages = stages
             results.append((image, gpu_ms))
         return results
 
@@ -1239,20 +1281,26 @@ class DiffusersEngine:
         async with self._codec:
             data = await self._run_to_completion(encode_webp, image)
         if not request.cancelled and not request.future.done():
-            request.future.set_result(GeneratedFrame(data, gpu_ms))
+            request.future.set_result(GeneratedFrame(data, gpu_ms, request.stages))
 
     def _frame_batch(
         self, requests: list[FrameRequest],
     ) -> list[tuple[Image.Image, int]]:
         started = time.monotonic()
         manifest = requests[0].manifest
-        if len(requests) == 1:
+        if len(requests) == 1 or any(request.profile for request in requests):
+            if len(requests) > 1:
+                return self._frame_batch_sequential(requests)
             request = requests[0]
+            stages = _empty_frame_stages() if request.profile else None
             image, _ = self._frame(
                 manifest, request.params, request.payload, request.strength,
-                prompt_cache=request.prompt_cache,
+                prompt_cache=request.prompt_cache, stages=stages,
             )
             gpu_ms = int((time.monotonic() - started) * 1000)
+            if stages is not None:
+                _finish_stage_overhead(stages, gpu_ms)
+                request.stages = stages
             return [(image, gpu_ms)]
         if manifest.t2i_adapter:
             pipeline = self._pipeline(
@@ -1535,6 +1583,7 @@ class DiffusersEngine:
         negative_prompt: str | None,
         *,
         prompt_cache: PromptCache | None = None,
+        stages: dict[str, int] | None = None,
     ) -> dict[str, Any]:
         # A realtime session calls this for every frame with the same prompt, and
         # encoding is a full pass through each text encoder: measured at 322 ms
@@ -1545,6 +1594,8 @@ class DiffusersEngine:
         cache_key = (manifest.id, prompt, negative_prompt)
         if prompt_cache is not None:
             if prompt_cache.entry is not None and prompt_cache.entry[0] == cache_key:
+                if stages is not None:
+                    stages["text_encode_cache_hit"] = 1
                 return prompt_cache.entry[1]
 
         prompt_kwargs: dict[str, Any] = {"prompt": prompt}
@@ -1842,9 +1893,87 @@ class DiffusersEngine:
         loop.call_soon_threadsafe(progress, 1.0)
         return GeneratedImage(encode_png(image), image.width, image.height, gpu_ms, load_ms)
 
+    def _sync_cuda(self) -> None:
+        if self.device != "cuda":
+            return
+        cuda = getattr(self.torch, "cuda", None)
+        synchronize = getattr(cuda, "synchronize", None)
+        if callable(synchronize):
+            synchronize()
+
+    def _timed_prompt_kwargs(
+        self,
+        pipeline: Any,
+        manifest: Manifest,
+        params: dict,
+        prompt_cache: PromptCache | None,
+        stages: dict[str, int] | None,
+    ) -> dict[str, Any]:
+        negative_prompt = params.get("negative_prompt")
+        prompt_started = 0.0
+        if stages is not None:
+            self._sync_cuda()
+            prompt_started = time.perf_counter()
+        prompt_kwargs = self._prompt_kwargs(
+            pipeline,
+            manifest,
+            str(params.get("prompt", "")),
+            str(negative_prompt) if negative_prompt is not None else None,
+            prompt_cache=prompt_cache,
+            stages=stages,
+        )
+        if stages is not None:
+            self._sync_cuda()
+            stages["text_encode_ms"] = int(
+                (time.perf_counter() - prompt_started) * 1000
+            )
+        return prompt_kwargs
+
+    def _attach_stage_hooks(
+        self, pipeline: Any, stages: dict[str, int],
+    ) -> list[Any]:
+        handles: list[Any] = []
+        for name in ("adapter", "unet"):
+            module = getattr(pipeline, name, None)
+            pre_register = getattr(module, "register_forward_pre_hook", None)
+            post_register = getattr(module, "register_forward_hook", None)
+            if not callable(pre_register) or not callable(post_register):
+                continue
+            started_at: dict[str, float] = {}
+
+            def before(_module: Any, _inputs: Any, *, module_name: str = name) -> None:
+                self._sync_cuda()
+                started_at[module_name] = time.perf_counter()
+
+            def after(
+                _module: Any, _inputs: Any, _output: Any, *,
+                module_name: str = name,
+            ) -> None:
+                self._sync_cuda()
+                elapsed = (
+                    time.perf_counter()
+                    - started_at.pop(module_name, time.perf_counter())
+                ) * 1000
+                stages[f"{module_name}_ms"] += int(elapsed)
+                if module_name == "unet":
+                    stages["unet_forwards"] += 1
+
+            module_handles: list[Any] = []
+            try:
+                module_handles.append(pre_register(before))
+                module_handles.append(post_register(after))
+                handles.extend(module_handles)
+            except (AttributeError, TypeError):
+                for handle in module_handles:
+                    remove = getattr(handle, "remove", None)
+                    if callable(remove):
+                        remove()
+        return handles
+
     async def frame(
         self, manifest: Manifest, params: dict, payload: bytes,
         *, prompt_cache: PromptCache | None = None,
+        profile: bool = False,
     ) -> GeneratedFrame:
         if "realtime" not in manifest.capabilities:
             raise ValueError(f"model {manifest.id} does not support realtime frames")
@@ -1869,6 +1998,7 @@ class DiffusersEngine:
         return await self._batch_collector_or_create().submit(
             session_key, manifest, frame_params, canvas, strength,
             prompt_cache=prompt_cache, resolution=REALTIME_SIZE,
+            profile=profile,
         )
 
     def _frame(
@@ -1879,6 +2009,7 @@ class DiffusersEngine:
         strength: float,
         *,
         prompt_cache: PromptCache | None = None,
+        stages: dict[str, int] | None = None,
     ) -> tuple[Image.Image, int]:
         # The GPU lock already surrounds this call. Start the clock here so
         # GeneratedFrame.gpu_ms and calibration measure the same occupancy
@@ -1893,13 +2024,8 @@ class DiffusersEngine:
             pipeline = self._pipeline(
                 manifest, "realtime", allow_demotion=False,
             )
-            negative_prompt = params.get("negative_prompt")
-            prompt_kwargs = self._prompt_kwargs(
-                pipeline,
-                manifest,
-                str(params.get("prompt", "")),
-                str(negative_prompt) if negative_prompt is not None else None,
-                prompt_cache=prompt_cache,
+            prompt_kwargs = self._timed_prompt_kwargs(
+                pipeline, manifest, params, prompt_cache, stages,
             )
             properties = manifest.parameters.get("properties", {})
             structure_strength = float(params.get(
@@ -1929,36 +2055,36 @@ class DiffusersEngine:
                 "guidance_scale": 0.0,
                 "generator": generator,
             }
+        else:
+            pipeline = self._pipeline(
+                manifest, "i2i", allow_demotion=False,
+            )
+            prompt_kwargs = self._timed_prompt_kwargs(
+                pipeline, manifest, params, prompt_cache, stages,
+            )
+            preview_decoder = self._preview_decoder(pipeline, manifest)
+            pipeline_kwargs = {
+                **prompt_kwargs,
+                "image": canvas,
+                # Few-step img2img: diffusers runs ceil(steps * strength) steps,
+                # so keep the product at one or above.
+                "num_inference_steps": max(2, math.ceil(1 / strength)),
+                "strength": strength,
+                "guidance_scale": 0.0,
+            }
+        handles = (
+            self._attach_stage_hooks(pipeline, stages) if stages is not None else []
+        )
+        try:
             image = self._render_with_preview_decoder(
                 pipeline, manifest, pipeline_kwargs,
                 preview_decoder=preview_decoder,
+                stages=stages,
             )
-            gpu_ms = int((time.monotonic() - started) * 1000)
-            return image, gpu_ms
-        pipeline = self._pipeline(
-            manifest, "i2i", allow_demotion=False,
-        )
-        negative_prompt = params.get("negative_prompt")
-        prompt_kwargs = self._prompt_kwargs(
-            pipeline,
-            manifest,
-            str(params.get("prompt", "")),
-            str(negative_prompt) if negative_prompt is not None else None,
-            prompt_cache=prompt_cache,
-        )
-        preview_decoder = self._preview_decoder(pipeline, manifest)
-        pipeline_kwargs = {
-            **prompt_kwargs,
-            "image": canvas,
-            # Few-step img2img: diffusers runs ceil(steps * strength) steps,
-            # so keep the product at one or above.
-            "num_inference_steps": max(2, math.ceil(1 / strength)),
-            "strength": strength,
-            "guidance_scale": 0.0,
-        }
-        image = self._render_with_preview_decoder(
-            pipeline, manifest, pipeline_kwargs,
-            preview_decoder=preview_decoder,
-        )
+        finally:
+            for handle in handles:
+                remove = getattr(handle, "remove", None)
+                if callable(remove):
+                    remove()
         gpu_ms = int((time.monotonic() - started) * 1000)
         return image, gpu_ms

--- a/worker/worker/frame_batch.py
+++ b/worker/worker/frame_batch.py
@@ -52,6 +52,8 @@ class FrameRequest:
     payload: Any
     future: asyncio.Future
     cancelled: bool = False
+    profile: bool = False
+    stages: dict[str, int] | None = None
 
 
 class BatchExecutor(Protocol):
@@ -117,6 +119,7 @@ class FrameBatchCollector:
         *,
         prompt_cache: Any = None,
         resolution: int,
+        profile: bool = False,
     ) -> Any:
         self.start()
         compat = compat_key(manifest, params, resolution)
@@ -127,6 +130,7 @@ class FrameBatchCollector:
             existing.strength = strength
             existing.prompt_cache = prompt_cache
             existing.payload = payload
+            existing.profile = profile
             if existing.compat != compat:
                 self._rebucket(existing, compat)
             try:
@@ -138,7 +142,7 @@ class FrameBatchCollector:
         future = loop.create_future()
         request = FrameRequest(
             session_key, compat, manifest, dict(params), strength,
-            prompt_cache, payload, future,
+            prompt_cache, payload, future, profile=profile,
         )
         self._enqueue(request)
         try:


### PR DESCRIPTION
# Description

Opt-in `Engine.frame(..., profile=True)` records GPU-lock stage timings (adapter, text encode hit/miss, UNet, TAESD, leftover). `scripts/profile-realtime-frame.py` calls the shipped path with a real `PromptCache`. Default `profile=False` is unchanged.

# Motivation

The 160.2 / 219.8 ms sweep numbers mixed sketch-map work, WebP, and an uncached prompt. Slot math and issue #294 need a baseline that matches `GeneratedFrame.gpu_ms`.

# Functionality

- `GeneratedFrame.stages` is `None` unless `profile=True`.
- Profiled single frames (and any profiled request in a batch) run through `_frame` so hooks see adapter and UNet forwards.
- Tests lock the stage key set, cache hit flag, and `vae.encode` absence on the adapter path.

Closes #377.

# Details

On this desk a PromptCache-hit run gave sdxl-turbo gpu p95 139 ms (3 slots) and vega-rt 209 ms (2 slots). UNet is about 80 percent of occupancy. A fourth turbo slot still needs p95 under 125 ms.

Related: #294.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional realtime frame profiling with detailed stage timings, cache activity, and UNet execution counts.
  * Added profiling support across frame generation, batching, simulated engines, and realtime rendering.
  * Added a command-line benchmark that reports median and p95 performance metrics and can export JSON results.

* **Tests**
  * Added coverage for profiling metrics, cache behavior, batching, adapter rendering, simulated engines, and profiling overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->