### PR TITLE
Measure Stream Batch on vega-rt before wiring it in

### DIFF
--- a/scripts/prototype-stream-batch.py
+++ b/scripts/prototype-stream-batch.py
@@ -1,0 +1,377 @@
+"""Measure serial and staggered Stream Batch inference on the GPU.
+
+The worker does not use this prototype. It records the cost and pixel error of
+the proposed queue math before that path is connected to realtime rendering.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import math
+import os
+import pathlib
+import statistics
+import sys
+import time
+from typing import Any
+
+os.environ.setdefault("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "1")
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "worker"))
+
+stream_batch = importlib.import_module("worker.stream_batch")
+assemble_batch = stream_batch.assemble_batch
+commit_latent_buffer = stream_batch.commit_latent_buffer
+predicted_x0 = stream_batch.predicted_x0
+shift_condition_buffer = stream_batch.shift_condition_buffer
+stack_adapter_states = stream_batch.stack_adapter_states
+
+MODELS_DIR = pathlib.Path(__file__).resolve().parents[1] / "worker" / "models"
+BAR_MS = 500.0
+
+
+def sketch_map(size: int, draw_offset: int) -> Any:
+    from PIL import Image, ImageDraw, ImageOps
+
+    canvas = Image.new("RGB", (size, size), "white")
+    pen = ImageDraw.Draw(canvas)
+    pen.line(
+        [(10, 210 + draw_offset), (150, 140), (300, 180), (size - 12, 150)],
+        fill=(17, 24, 39),
+        width=5,
+    )
+    pen.ellipse([(150, 300), (360, 380)], outline=(17, 24, 39), width=5)
+    grey = ImageOps.invert(canvas.convert("L"))
+    return grey.point(lambda value: 255 if value >= 128 else 0).convert("RGB")
+
+
+def build(manifest: dict, dtype: Any, device: str) -> Any:
+    from diffusers import (
+        AutoencoderKL,
+        LCMScheduler,
+        StableDiffusionXLAdapterPipeline,
+        StableDiffusionXLPipeline,
+        T2IAdapter,
+    )
+
+    kwargs: dict[str, Any] = {"torch_dtype": dtype}
+    if manifest.get("vae"):
+        kwargs["vae"] = AutoencoderKL.from_pretrained(
+            manifest["vae"], torch_dtype=dtype
+        )
+    try:
+        base = StableDiffusionXLPipeline.from_pretrained(
+            manifest["source"], variant="fp16", **kwargs
+        )
+    except Exception:
+        base = StableDiffusionXLPipeline.from_pretrained(manifest["source"], **kwargs)
+    if manifest.get("lora"):
+        repo, _, weight = manifest["lora"].rpartition("/")
+        base.load_lora_weights(repo, weight_name=weight)
+        base.fuse_lora()
+    base.to(device)
+    for module in (base.unet, base.vae):
+        module.to(memory_format=__import__("torch").channels_last)
+    if manifest.get("scheduler") == "lcm":
+        base.scheduler = LCMScheduler.from_config(base.scheduler.config)
+    base.set_progress_bar_config(disable=True)
+    adapter = T2IAdapter.from_pretrained(manifest["t2i_adapter"], torch_dtype=dtype)
+    pipeline = StableDiffusionXLAdapterPipeline.from_pipe(
+        base, adapter=adapter, torch_dtype=dtype
+    )
+    pipeline.to(device)
+    pipeline.set_progress_bar_config(disable=True)
+    return pipeline
+
+
+def nearest_rank(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    rank = max(1, math.ceil(percentile / 100.0 * len(ordered)))
+    return ordered[min(rank, len(ordered)) - 1]
+
+
+def stats(values: list[float]) -> dict[str, float]:
+    return {
+        "p50_ms": statistics.median(values),
+        "p95_ms": nearest_rank(values, 95.0),
+        "max_ms": max(values),
+    }
+
+
+def prompt_embeds(pipeline: Any, prompt: str, device: str) -> dict[str, Any]:
+    positive, _, pooled, _ = pipeline.encode_prompt(
+        prompt=prompt,
+        device=device,
+        num_images_per_prompt=1,
+        do_classifier_free_guidance=False,
+    )
+    return {"prompt_embeds": positive, "pooled_prompt_embeds": pooled}
+
+
+def adapter_state(pipeline: Any, image: Any, size: int, scale: float) -> list[Any]:
+    from diffusers.pipelines.t2i_adapter.pipeline_stable_diffusion_xl_adapter import (
+        _preprocess_adapter_image,
+    )
+
+    tensor = _preprocess_adapter_image(image, size, size).to(
+        device=pipeline._execution_device, dtype=pipeline.adapter.dtype
+    )
+    return [state * scale for state in pipeline.adapter(tensor)]
+
+
+def time_decode(pipeline: Any, decoder: Any, latent: Any) -> Any:
+    import torch
+
+    with torch.inference_mode():
+        decoded = decoder.decode(latent, return_dict=False)[0]
+    decoded = decoded.detach()
+    return pipeline.image_processor.postprocess(decoded, output_type="pil")[0]
+
+
+def lcm_scalings(scheduler: Any, timestep: Any) -> tuple[Any, Any]:
+    method = getattr(scheduler, "get_scalings_for_boundary_condition_discrete", None)
+    if method is not None:
+        return method(timestep)
+    sigma_data = 0.5
+    scaled = timestep * scheduler.config.timestep_scaling
+    denominator = scaled**2 + sigma_data**2
+    return sigma_data**2 / denominator, scaled / denominator**0.5
+
+
+def stream_frame(
+    pipeline: Any,
+    decoder: Any,
+    embeds: dict[str, Any],
+    current_map: Any,
+    adapter_buffer: list[list[Any]],
+    latent_buffer: list[Any],
+    timesteps: Any,
+    noise_sequence: list[Any],
+    size: int,
+    scale: float,
+    is_lcm: bool,
+) -> tuple[Any, list[list[Any]], list[Any]]:
+    import torch
+
+    current_adapter = adapter_state(pipeline, current_map, size, scale)
+    if not adapter_buffer:
+        adapter_buffer = [
+            [torch.zeros_like(state) for state in current_adapter]
+            for _ in latent_buffer
+        ]
+    adapter_batch = [current_adapter, *adapter_buffer]
+    latent = noise_sequence[0]
+    noise_sequence.pop(0)
+    latent_batch = assemble_batch(latent, latent_buffer)
+    model_inputs = [
+        pipeline.scheduler.scale_model_input(item, timestep)
+        for item, timestep in zip(latent_batch, timesteps, strict=True)
+    ]
+    model_input = torch.cat(model_inputs, dim=0)
+    batch_size = len(latent_batch)
+    prompt = embeds["prompt_embeds"].repeat(batch_size, 1, 1)
+    pooled = embeds["pooled_prompt_embeds"].repeat(batch_size, 1)
+    time_ids = pipeline._get_add_time_ids(
+        (size, size),
+        (0, 0),
+        (size, size),
+        dtype=prompt.dtype,
+        text_encoder_projection_dim=pipeline.text_encoder_2.config.projection_dim,
+    ).to(model_input.device).repeat(batch_size, 1)
+    residuals = stack_adapter_states(
+        adapter_batch, lambda states: torch.cat(states, dim=0)
+    )
+    noise_pred = pipeline.unet(
+        model_input,
+        torch.stack(list(timesteps)),
+        encoder_hidden_states=prompt,
+        added_cond_kwargs={"text_embeds": pooled, "time_ids": time_ids},
+        down_intrablock_additional_residuals=residuals,
+        return_dict=False,
+    )[0]
+    if is_lcm:
+        x0_batch = []
+        alphas = []
+        betas = []
+        for index, timestep in enumerate(timesteps):
+            alpha_bar = pipeline.scheduler.alphas_cumprod[timestep.long()]
+            alpha = alpha_bar**0.5
+            beta = (1 - alpha_bar) ** 0.5
+            c_skip, c_out = lcm_scalings(pipeline.scheduler, timestep)
+            x0_batch.append(
+                predicted_x0(
+                    latent_batch[index],
+                    noise_pred[index : index + 1],
+                    alpha,
+                    beta,
+                    c_skip,
+                    c_out,
+                )
+            )
+            alphas.append(alpha)
+            betas.append(beta)
+        noises = [torch.randn_like(item) for item in latent_batch[:-1]]
+        finished, next_latents = commit_latent_buffer(
+            x0_batch,
+            alphas[1:],
+            betas[1:],
+            noises,
+            do_add_noise=True,
+        )
+    else:
+        pipeline.scheduler.set_timesteps(len(timesteps), device=timesteps.device)
+        stepped = [
+            pipeline.scheduler.step(
+                noise_pred[index : index + 1],
+                timestep,
+                latent_batch[index],
+                return_dict=False,
+            )[0]
+            for index, timestep in enumerate(timesteps)
+        ]
+        finished, next_latents = stepped[-1], stepped[:-1]
+    next_adapters = shift_condition_buffer(current_adapter, adapter_buffer)
+    return time_decode(pipeline, decoder, finished), next_adapters, next_latents
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    import numpy as np
+    import torch
+
+    manifest = json.loads((MODELS_DIR / f"{args.model}.json").read_text())
+    properties = manifest["parameters"]["properties"]
+    steps = args.steps or int(properties["steps"]["default"])
+    scale = float(properties["structure_strength"]["default"])
+    size = args.size
+    device = "cuda"
+    dtype = torch.float16
+    pipeline = build(manifest, dtype, device)
+    decoder = (
+        __import__("diffusers")
+        .AutoencoderTiny.from_pretrained(
+            "madebyollin/taesdxl", torch_dtype=dtype
+        ).to(device)
+        if args.tiny_vae
+        else pipeline.vae
+    )
+    prompt = "mountains in the alps, a lake, photorealistic"
+    embeds = prompt_embeds(pipeline, prompt, device)
+    maps = [sketch_map(size, index * 7) for index in range(args.frames + steps - 1)]
+    generators = [
+        torch.Generator(device=device).manual_seed(args.seed + index)
+        for index in range(args.frames + steps)
+    ]
+    stream_generators = [
+        torch.Generator(device=device).manual_seed(args.seed + index)
+        for index in range(args.frames + steps)
+    ]
+    serial_images: list[Any] = []
+    serial_times: list[float] = []
+    for index, image in enumerate(maps):
+        torch.cuda.synchronize()
+        started = time.perf_counter()
+        with torch.inference_mode():
+            latent = pipeline(
+                **embeds,
+                image=image,
+                num_inference_steps=steps,
+                guidance_scale=0.0,
+                adapter_conditioning_scale=scale,
+                generator=generators[index],
+                height=size,
+                width=size,
+                output_type="latent",
+            ).images
+            serial_images.append(time_decode(pipeline, decoder, latent))
+        torch.cuda.synchronize()
+        elapsed = (time.perf_counter() - started) * 1000
+        if index < args.frames:
+            serial_times.append(elapsed)
+    pipeline.scheduler.set_timesteps(steps, device=device)
+    timesteps = pipeline.scheduler.timesteps
+    shape = (
+        1,
+        pipeline.unet.config.in_channels,
+        size // pipeline.vae_scale_factor,
+        size // pipeline.vae_scale_factor,
+    )
+    noise = [
+        torch.randn(shape, generator=generator, device=device, dtype=dtype)
+        * pipeline.scheduler.init_noise_sigma
+        for generator in stream_generators
+    ]
+    latent_buffer: list[Any] = [
+        torch.zeros_like(noise[0]) for _ in range(max(0, steps - 1))
+    ]
+    adapter_buffer: list[list[Any]] = []
+    stream_times: list[float] = []
+    paired: list[float] = []
+    fill_started = time.perf_counter()
+    for index in range(args.frames + steps - 1):
+        torch.cuda.synchronize()
+        started = time.perf_counter()
+        with torch.inference_mode():
+            output, adapter_buffer, latent_buffer = stream_frame(
+                pipeline,
+                decoder,
+                embeds,
+                maps[index],
+                adapter_buffer,
+                latent_buffer,
+                timesteps,
+                noise[index:],
+                size,
+                scale,
+                manifest.get("scheduler") == "lcm",
+            )
+        torch.cuda.synchronize()
+        elapsed = (time.perf_counter() - started) * 1000
+        discard_count = max(0, steps - 1)
+        if index < discard_count:
+            if index == discard_count - 1:
+                fill_ms = (time.perf_counter() - fill_started) * 1000
+            continue
+        stream_times.append(elapsed)
+        serial_index = index - (steps - 1)
+        if 0 <= serial_index < len(serial_images):
+            actual = np.asarray(output).astype(np.float32)
+            expected = np.asarray(serial_images[serial_index]).astype(np.float32)
+            paired.append(float(np.abs(actual - expected).mean() / 255.0))
+    fill_ms = 0.0 if discard_count == 0 else fill_ms
+    serial_stats = stats(serial_times)
+    stream_stats = stats(stream_times)
+    result = {
+        "model": manifest["id"],
+        "steps": steps,
+        "serial": serial_stats,
+        "stream": stream_stats,
+        "ratio_serial_p95_stream_p95": serial_stats["p95_ms"] / stream_stats["p95_ms"],
+        "lag_frames": steps - 1,
+        "fill_ms": fill_ms,
+        "quality_mean_channel_abs_diff": statistics.mean(paired) if paired else 0.0,
+        "inside_500": stream_stats["p95_ms"] <= BAR_MS,
+        "notes": "1-step should be near 1x; do not advertise N=4 turbo",
+    }
+    print(json.dumps(result, indent=2))
+    if args.out:
+        pathlib.Path(args.out).write_text(json.dumps(result, indent=2) + "\n")
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="vega-rt")
+    parser.add_argument("--steps", type=int)
+    parser.add_argument("--size", type=int, default=512)
+    parser.add_argument("--frames", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=1000)
+    parser.add_argument("--out")
+    parser.add_argument("--tiny-vae", action=argparse.BooleanOptionalAction, default=True)
+    run(parser.parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prototype-stream-batch.py
+++ b/scripts/prototype-stream-batch.py
@@ -149,7 +149,8 @@ def stream_frame(
     adapter_buffer: list[list[Any]],
     latent_buffer: list[Any],
     timesteps: Any,
-    noise_sequence: list[Any],
+    latent: Any,
+    generator: Any,
     size: int,
     scale: float,
     is_lcm: bool,
@@ -163,17 +164,25 @@ def stream_frame(
             for _ in latent_buffer
         ]
     adapter_batch = [current_adapter, *adapter_buffer]
-    latent = noise_sequence[0]
-    noise_sequence.pop(0)
     latent_batch = assemble_batch(latent, latent_buffer)
+    batch_size = len(latent_batch)
+    step_timesteps = list(timesteps[:batch_size])
+    if not is_lcm:
+        pipeline.scheduler.set_timesteps(len(timesteps), device=timesteps.device)
     model_inputs = [
         pipeline.scheduler.scale_model_input(item, timestep)
-        for item, timestep in zip(latent_batch, timesteps, strict=True)
+        for item, timestep in zip(latent_batch, step_timesteps, strict=True)
     ]
     model_input = torch.cat(model_inputs, dim=0)
-    batch_size = len(latent_batch)
     prompt = embeds["prompt_embeds"].repeat(batch_size, 1, 1)
     pooled = embeds["pooled_prompt_embeds"].repeat(batch_size, 1)
+    timestep_cond = None
+    if pipeline.unet.config.time_cond_proj_dim is not None:
+        guidance_scale_tensor = torch.tensor(-1.0).repeat(batch_size)
+        timestep_cond = pipeline.get_guidance_scale_embedding(
+            guidance_scale_tensor,
+            embedding_dim=pipeline.unet.config.time_cond_proj_dim,
+        ).to(device=model_input.device, dtype=latent.dtype)
     time_ids = pipeline._get_add_time_ids(
         (size, size),
         (0, 0),
@@ -182,12 +191,13 @@ def stream_frame(
         text_encoder_projection_dim=pipeline.text_encoder_2.config.projection_dim,
     ).to(model_input.device).repeat(batch_size, 1)
     residuals = stack_adapter_states(
-        adapter_batch, lambda states: torch.cat(states, dim=0)
+        adapter_batch, lambda states: torch.cat([state.clone() for state in states], dim=0)
     )
     noise_pred = pipeline.unet(
         model_input,
-        torch.stack(list(timesteps)),
+        step_timesteps[0] if batch_size == 1 else torch.stack(step_timesteps),
         encoder_hidden_states=prompt,
+        timestep_cond=timestep_cond,
         added_cond_kwargs={"text_embeds": pooled, "time_ids": time_ids},
         down_intrablock_additional_residuals=residuals,
         return_dict=False,
@@ -196,7 +206,7 @@ def stream_frame(
         x0_batch = []
         alphas = []
         betas = []
-        for index, timestep in enumerate(timesteps):
+        for index, timestep in enumerate(step_timesteps):
             alpha_bar = pipeline.scheduler.alphas_cumprod[timestep.long()]
             alpha = alpha_bar**0.5
             beta = (1 - alpha_bar) ** 0.5
@@ -222,15 +232,15 @@ def stream_frame(
             do_add_noise=True,
         )
     else:
-        pipeline.scheduler.set_timesteps(len(timesteps), device=timesteps.device)
         stepped = [
             pipeline.scheduler.step(
                 noise_pred[index : index + 1],
                 timestep,
                 latent_batch[index],
+                **pipeline.prepare_extra_step_kwargs(generator, 0.0),
                 return_dict=False,
             )[0]
-            for index, timestep in enumerate(timesteps)
+            for index, timestep in enumerate(step_timesteps)
         ]
         finished, next_latents = stepped[-1], stepped[:-1]
     next_adapters = shift_condition_buffer(current_adapter, adapter_buffer)
@@ -260,17 +270,10 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     prompt = "mountains in the alps, a lake, photorealistic"
     embeds = prompt_embeds(pipeline, prompt, device)
     maps = [sketch_map(size, index * 7) for index in range(args.frames + steps - 1)]
-    generators = [
-        torch.Generator(device=device).manual_seed(args.seed + index)
-        for index in range(args.frames + steps)
-    ]
-    stream_generators = [
-        torch.Generator(device=device).manual_seed(args.seed + index)
-        for index in range(args.frames + steps)
-    ]
     serial_images: list[Any] = []
     serial_times: list[float] = []
     for index, image in enumerate(maps):
+        g_serial = torch.Generator(device=device).manual_seed(args.seed + index)
         torch.cuda.synchronize()
         started = time.perf_counter()
         with torch.inference_mode():
@@ -280,7 +283,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
                 num_inference_steps=steps,
                 guidance_scale=0.0,
                 adapter_conditioning_scale=scale,
-                generator=generators[index],
+                generator=g_serial,
                 height=size,
                 width=size,
                 output_type="latent",
@@ -292,25 +295,26 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
             serial_times.append(elapsed)
     pipeline.scheduler.set_timesteps(steps, device=device)
     timesteps = pipeline.scheduler.timesteps
-    shape = (
-        1,
-        pipeline.unet.config.in_channels,
-        size // pipeline.vae_scale_factor,
-        size // pipeline.vae_scale_factor,
-    )
-    noise = [
-        torch.randn(shape, generator=generator, device=device, dtype=dtype)
-        * pipeline.scheduler.init_noise_sigma
-        for generator in stream_generators
-    ]
-    latent_buffer: list[Any] = [
-        torch.zeros_like(noise[0]) for _ in range(max(0, steps - 1))
-    ]
+    latent_buffer: list[Any] = []
     adapter_buffer: list[list[Any]] = []
     stream_times: list[float] = []
     paired: list[float] = []
     fill_started = time.perf_counter()
     for index in range(args.frames + steps - 1):
+        g_stream = torch.Generator(device=device).manual_seed(args.seed + index)
+        latent = pipeline.prepare_latents(
+            1,
+            pipeline.unet.config.in_channels,
+            size,
+            size,
+            dtype,
+            device,
+            g_stream,
+        )
+        if not latent_buffer:
+            latent_buffer = [
+                torch.zeros_like(latent) for _ in range(max(0, steps - 1))
+            ]
         torch.cuda.synchronize()
         started = time.perf_counter()
         with torch.inference_mode():
@@ -322,7 +326,8 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
                 adapter_buffer,
                 latent_buffer,
                 timesteps,
-                noise[index:],
+                latent,
+                g_stream,
                 size,
                 scale,
                 manifest.get("scheduler") == "lcm",
@@ -352,6 +357,7 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
         "lag_frames": steps - 1,
         "fill_ms": fill_ms,
         "quality_mean_channel_abs_diff": statistics.mean(paired) if paired else 0.0,
+        "quality_max_channel_abs_diff": max(paired) if paired else 0.0,
         "inside_500": stream_stats["p95_ms"] <= BAR_MS,
         "notes": "1-step should be near 1x; do not advertise N=4 turbo",
     }

--- a/worker/tests/test_stream_batch.py
+++ b/worker/tests/test_stream_batch.py
@@ -1,0 +1,81 @@
+from worker.stream_batch import (
+    assemble_batch,
+    commit_latent_buffer,
+    predicted_x0,
+    renoised_slot,
+    shift_condition_buffer,
+    split_output,
+    stack_adapter_states,
+)
+
+
+def test_assemble_batch_prepends_new_item():
+    assert assemble_batch("new", ["old"]) == ["new", "old"]
+    assert assemble_batch("new", []) == ["new"]
+
+
+def test_split_output_returns_last_as_finished():
+    finished, prefix = split_output([1, 2, 3, 4])
+    assert finished == 4
+    assert prefix == [1, 2, 3]
+
+
+def test_shift_condition_buffer_drops_oldest_condition():
+    assert shift_condition_buffer("x", []) == []
+    assert shift_condition_buffer("x", ["a", "b", "c"]) == ["x", "a", "b"]
+
+
+def test_renoised_slot_respects_noise_flag():
+    assert renoised_slot(10, 0.5, 0.2, 3, True) == 5.6
+    assert renoised_slot(10, 0.5, 0.2, 3, False) == 5
+
+
+def test_commit_latent_buffer_for_one_step():
+    assert commit_latent_buffer(
+        [10],
+        [],
+        [],
+        [],
+        do_add_noise=True,
+    ) == (10, [])
+
+
+def test_commit_latent_buffer_commits_finished_and_renoises_prefix():
+    x0_batch = [10, 20, 30, 40]
+    alpha_tail = [0.1, 0.2, 0.3]
+    beta_tail = [0.4, 0.5, 0.6]
+    noise_tail = [1, 2, 3]
+    finished, buffer = commit_latent_buffer(
+        x0_batch,
+        alpha_tail,
+        beta_tail,
+        noise_tail,
+        do_add_noise=True,
+    )
+    expected = [
+        renoised_slot(x0, alpha, beta, noise, True)
+        for x0, alpha, beta, noise in zip(
+            x0_batch[:-1], alpha_tail, beta_tail, noise_tail
+        )
+    ]
+    assert finished == 40
+    assert len(buffer) == 3
+    assert buffer == expected
+
+
+def test_predicted_x0_matches_numeric_identity():
+    latent = 10
+    noise_pred = 3
+    alpha = 0.5
+    beta = 0.2
+    c_skip = 0.1
+    c_out = 0.9
+    expected = c_out * ((latent - beta * noise_pred) / alpha) + c_skip * latent
+    assert predicted_x0(
+        latent, noise_pred, alpha, beta, c_skip, c_out
+    ) == expected
+
+
+def test_stack_adapter_states_handles_empty_and_residuals():
+    assert stack_adapter_states([], tuple) == []
+    assert stack_adapter_states([[1, 2], [3, 4]], tuple) == [(1, 3), (2, 4)]

--- a/worker/worker/stream_batch.py
+++ b/worker/worker/stream_batch.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+
+def assemble_batch(new_item, buffer: list) -> list:
+    return [new_item, *buffer]
+
+
+def split_output(batch: list) -> tuple:
+    return batch[-1], batch[:-1]
+
+
+def shift_condition_buffer(new_item, buffer: list) -> list:
+    if not buffer:
+        return []
+    return [new_item, *buffer[:-1]]
+
+
+def renoised_slot(x0, alpha, beta, noise, do_add_noise: bool):
+    scaled = alpha * x0
+    if do_add_noise:
+        return scaled + beta * noise
+    return scaled
+
+
+def commit_latent_buffer(
+    x0_batch: list,
+    alpha_tail: list,
+    beta_tail: list,
+    noise_tail: list,
+    *,
+    do_add_noise: bool,
+) -> tuple:
+    finished, prefix = split_output(x0_batch)
+    buffer = [
+        renoised_slot(x0, a, b, n, do_add_noise)
+        for x0, a, b, n in zip(prefix, alpha_tail, beta_tail, noise_tail)
+    ]
+    return finished, buffer
+
+
+def predicted_x0(latent, noise_pred, alpha, beta, c_skip, c_out):
+    f_theta = (latent - beta * noise_pred) / alpha
+    return c_out * f_theta + c_skip * latent
+
+
+def stack_adapter_states(states: list, cat) -> list:
+    if not states:
+        return []
+    width = len(states[0])
+    return [cat([state[index] for state in states]) for index in range(width)]


### PR DESCRIPTION
# Description

Stream Batch is the next catalog experiment after the batch-admission curve. This PR adds the queue math, CPU tests, and a GPU prototype. It does not change `Engine._frame`.

# Motivation

A fourth turbo session and heavier models need a cheaper single-frame UNet. Stream Batch batches a stream's denoise steps. It can help 4-step `vega-rt`. It cannot help 1-step `sdxl-turbo`.

# Functionality

- `worker/worker/stream_batch.py` holds the staggered-queue math. No torch import.
- `scripts/prototype-stream-batch.py` times serial `pipeline()` against one batched UNet call per output.
- The 1-step loop now uses `prepare_latents`, Euler `generator`, and the same adapter residuals as `pipeline()`.
- The worker realtime path is unchanged.

Closes #379.

# Details

Measured on this desk (RX 7600 XT), TAESD decode, prompt embeds cached:

| Model | serial p95 | stream p95 | ratio | lag | mean channel abs / 255 |
| --- | --- | --- | --- | --- | --- |
| vega-rt (4 step, 20 frames) | 206 ms | 145 ms | 1.42x | 3 frames | 0.135 |
| sdxl-turbo (1 step, 8 frames) | 271 ms (cold p95) | 128 ms | ~1x at p50 | 0 | 0.000 |

1-step pixels now match `pipeline()` (max error 0). The 4-step speed win is real. Do not adopt: output lags three canvases, calibration still times serial `Engine.frame()`, and 4-step mean error 0.135 is above the distilled-encoder reject bar (22.4/255).

Do not advertise a fourth turbo slot from this.

# Test plan

- [x] `make verify`
- [x] GPU script on vega-rt
- [x] GPU script on sdxl-turbo (1-step MAE 0.0)
- [ ] Do not merge until a reviewer accepts that Engine stays on the serial path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU benchmarking for serial and streamed Stable Diffusion XL Adapter inference.
  * Added configurable model, resolution, steps, frame count, seed, VAE, and LoRA options.
  * Added latency, warm-up, frame-lag, image-difference, and p95 performance reporting.
  * Added optional JSON result export.
  * Added stream-batch processing utilities for assembling batches, managing buffers, and stacking adapter states.

* **Tests**
  * Added coverage for batching, buffer handling, re-noising, latent calculations, output splitting, and adapter-state processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->