### PR TITLE
Measure RGB change-mask compositing after a full frame

### DIFF
--- a/scripts/prototype-region-composite.py
+++ b/scripts/prototype-region-composite.py
@@ -28,6 +28,7 @@ sys.path.insert(0, str(ROOT / "worker"))
 region_composite = importlib.import_module("worker.region_composite")
 composite_rgb = region_composite.composite_rgb
 feather_change_mask = region_composite.feather_change_mask
+max_channel_difference = region_composite.max_channel_difference
 sketch_change_mask = region_composite.sketch_change_mask
 
 MODELS_DIR = ROOT / "worker" / "models"
@@ -46,20 +47,20 @@ def percentile(values: list[float], pct: float) -> float:
     return ordered[min(rank, len(ordered)) - 1]
 
 
+def threshold_map(image: Image.Image) -> Image.Image:
+    mapped = ImageOps.invert(image.convert("L"))
+    return mapped.point(lambda value: 255 if value >= 128 else 0).convert("RGB")
+
+
 def canvas_map(kind: str) -> Image.Image:
     canvas = Image.new("RGB", (SIZE, SIZE), "white")
     draw = ImageDraw.Draw(canvas)
     draw.line([(40, 390), (150, 250), (275, 320), (440, 190)], fill=(17, 24, 39), width=6)
-    if kind == "small_stroke":
+    if kind in ("small_stroke", "erasure"):
         draw.line([(315, 400), (350, 370)], fill=(17, 24, 39), width=6)
-    elif kind == "erasure":
-        draw.line([(315, 400), (350, 370)], fill=(17, 24, 39), width=6)
-    elif kind == "shape_close":
-        draw.arc([(130, 130), (380, 400)], 35, 320, fill=(17, 24, 39), width=6)
     elif kind != "base":
         raise ValueError(f"unknown case: {kind}")
-    mapped = ImageOps.invert(canvas.convert("L"))
-    return mapped.point(lambda value: 255 if value >= 128 else 0).convert("RGB")
+    return threshold_map(canvas)
 
 
 def case_maps(name: str) -> tuple[Image.Image, Image.Image]:
@@ -78,12 +79,8 @@ def case_maps(name: str) -> tuple[Image.Image, Image.Image]:
             width=6,
         )
         return (
-            ImageOps.invert(open_map.convert("L")).point(
-                lambda value: 255 if value >= 128 else 0
-            ).convert("RGB"),
-            ImageOps.invert(closed_map.convert("L")).point(
-                lambda value: 255 if value >= 128 else 0
-            ).convert("RGB"),
+            threshold_map(open_map),
+            threshold_map(closed_map),
         )
     raise ValueError(f"unknown case: {name}")
 
@@ -137,7 +134,11 @@ def encode_prompt(pipeline: Any) -> dict[str, Any]:
         "pooled_prompt_embeds",
         "negative_pooled_prompt_embeds",
     )
-    return {name: value for name, value in zip(names, encoded) if value is not None}
+    return {
+        name: value
+        for name, value in zip(names, encoded, strict=True)
+        if value is not None
+    }
 
 
 def render(
@@ -177,21 +178,15 @@ def decode_preview(pipeline: Any, decoder: Any, latent: Any) -> Image.Image:
 
 
 def changed_fraction(previous: Image.Image, current: Image.Image) -> float:
-    difference = ImageChops.difference(previous.convert("RGB"), current.convert("RGB"))
-    channels = difference.split()
-    changed = ImageChops.lighter(
-        ImageChops.lighter(channels[0], channels[1]), channels[2]
-    ).point(lambda value: 1 if value else 0)
+    changed = max_channel_difference(previous, current).point(
+        lambda value: 1 if value else 0
+    )
     return sum(changed.getdata()) / (previous.width * previous.height)
 
 
 def exact_where(alpha: Image.Image, left: Image.Image, right: Image.Image, value: int) -> bool:
     selected = alpha.point(lambda pixel: 255 if pixel == value else 0)
-    difference = ImageChops.difference(left.convert("RGB"), right.convert("RGB"))
-    channels = difference.split()
-    any_difference = ImageChops.lighter(
-        ImageChops.lighter(channels[0], channels[1]), channels[2]
-    )
+    any_difference = max_channel_difference(left, right)
     return ImageChops.multiply(selected, any_difference).getbbox() is None
 
 
@@ -201,12 +196,8 @@ def webp_round_trip(image: Image.Image) -> float:
     buffer.seek(0)
     with Image.open(buffer) as opened:
         decoded = opened.convert("RGB")
-    difference = ImageChops.difference(image.convert("RGB"), decoded)
-    channels = difference.split()
-    any_difference = ImageChops.lighter(
-        ImageChops.lighter(channels[0], channels[1]), channels[2]
-    )
-    return sum(any_difference.getdata()) / (SIZE * SIZE * 255)
+    any_difference = max_channel_difference(image, decoded)
+    return sum(any_difference.getdata()) / (image.width * image.height * 255)
 
 
 def save_image(image: Image.Image, path: Path | None) -> None:
@@ -240,64 +231,72 @@ def main() -> int:
         properties = manifest["parameters"]["properties"]
         steps = int(properties["steps"]["default"])
         scale = float(properties["structure_strength"]["default"])
-        pipeline = build_pipeline(manifest, torch.float16)
-        prompt_kwargs = encode_prompt(pipeline)
-        decoder = AutoencoderTiny.from_pretrained(
-            manifest["preview_decoder"], torch_dtype=torch.float16
-        ).to("cuda")
-        decoder.eval()
-        render(pipeline, prompt_kwargs, canvas_map("base"), steps, scale, SEED, "latent")
-        model_report: dict[str, Any] = {
-            "model": model_id,
-            "steps": steps,
-            "adapter_scale": scale,
-            "cases": [],
-        }
-        for case_name in ("small_stroke", "erasure", "shape_close"):
-            previous_map, current_map = case_maps(case_name)
-            previous_latent = render(
-                pipeline, prompt_kwargs, previous_map, steps, scale, SEED, "latent"
+        pipeline = None
+        decoder = None
+        try:
+            pipeline = build_pipeline(manifest, torch.float16)
+            prompt_kwargs = encode_prompt(pipeline)
+            decoder = AutoencoderTiny.from_pretrained(
+                manifest["preview_decoder"], torch_dtype=torch.float16
+            ).to("cuda")
+            decoder.eval()
+            render(
+                pipeline, prompt_kwargs, canvas_map("base"), steps, scale, SEED, "latent"
             )
-            current_latent = render(
-                pipeline, prompt_kwargs, current_map, steps, scale, SEED, "latent"
-            )
-            previous = decode_preview(pipeline, decoder, previous_latent)
-            current = decode_preview(pipeline, decoder, current_latent)
-            frame_times: list[float] = []
-            for _ in range(args.frames):
-                started = time.perf_counter()
-                frame_latent = render(
+            model_report: dict[str, Any] = {
+                "model": model_id,
+                "steps": steps,
+                "adapter_scale": scale,
+                "cases": [],
+            }
+            for case_name in ("small_stroke", "erasure", "shape_close"):
+                previous_map, current_map = case_maps(case_name)
+                previous_latent = render(
+                    pipeline, prompt_kwargs, previous_map, steps, scale, SEED, "latent"
+                )
+                current_latent = render(
                     pipeline, prompt_kwargs, current_map, steps, scale, SEED, "latent"
                 )
-                decode_preview(pipeline, decoder, frame_latent)
-                torch.cuda.synchronize()
-                frame_times.append((time.perf_counter() - started) * 1000)
-            raw_mask = sketch_change_mask(previous_map, current_map)
-            sweeps: list[dict[str, Any]] = []
-            for dilation_px, feather_px in SWEEP:
-                alpha = feather_change_mask(raw_mask, dilation_px, feather_px)
-                composited = composite_rgb(previous, current, alpha)
-                save_image(
-                    composited,
-                    save_dir / f"{model_id}-{case_name}-d{dilation_px}-f{feather_px}.png"
-                    if save_dir
-                    else None,
-                )
-                sweeps.append({
-                    "dilation_px": dilation_px,
-                    "feather_px": feather_px,
-                    "composited_changed_frac": changed_fraction(previous, composited),
-                    "outside_mask_prev_exact": exact_where(alpha, composited, previous, 0),
-                    "inside_mask_new_exact": exact_where(alpha, composited, current, 255),
+                previous = decode_preview(pipeline, decoder, previous_latent)
+                current = decode_preview(pipeline, decoder, current_latent)
+                frame_times: list[float] = []
+                for _ in range(args.frames):
+                    started = time.perf_counter()
+                    frame_latent = render(
+                        pipeline, prompt_kwargs, current_map, steps, scale, SEED, "latent"
+                    )
+                    decode_preview(pipeline, decoder, frame_latent)
+                    torch.cuda.synchronize()
+                    frame_times.append((time.perf_counter() - started) * 1000)
+                raw_mask = sketch_change_mask(previous_map, current_map)
+                sweeps: list[dict[str, Any]] = []
+                for dilation_px, feather_px in SWEEP:
+                    alpha = feather_change_mask(raw_mask, dilation_px, feather_px)
+                    composited = composite_rgb(previous, current, alpha)
+                    save_image(
+                        composited,
+                        save_dir / f"{model_id}-{case_name}-d{dilation_px}-f{feather_px}.png"
+                        if save_dir
+                        else None,
+                    )
+                    sweeps.append({
+                        "dilation_px": dilation_px,
+                        "feather_px": feather_px,
+                        "composited_changed_frac": changed_fraction(previous, composited),
+                        "outside_mask_prev_exact": exact_where(alpha, composited, previous, 0),
+                        "inside_mask_new_exact": exact_where(alpha, composited, current, 255),
+                    })
+                model_report["cases"].append({
+                    "name": case_name,
+                    "uncomposited_changed_frac": changed_fraction(previous, current),
+                    "p95_ms": percentile(frame_times, 95),
+                    "webp_round_trip_mean_max_channel_over_255": webp_round_trip(current),
+                    "sweeps": sweeps,
                 })
-            model_report["cases"].append({
-                "name": case_name,
-                "uncomposited_changed_frac": changed_fraction(previous, current),
-                "p95_ms": percentile(frame_times, 95),
-                "webp_round_trip_mean_abs_over_255": webp_round_trip(current),
-                "sweeps": sweeps,
-            })
-        report["models"].append(model_report)
+            report["models"].append(model_report)
+        finally:
+            del pipeline, decoder
+            torch.cuda.empty_cache()
     print(json.dumps(report, indent=2))
     if args.out:
         Path(args.out).write_text(json.dumps(report, indent=2) + "\n")

--- a/scripts/prototype-region-composite.py
+++ b/scripts/prototype-region-composite.py
@@ -1,0 +1,308 @@
+"""Measure RGB change-mask compositing after full adapter-conditioned frames.
+
+The realtime UNet still renders the whole canvas, but unchanged pixels can
+keep the previous bitmap. This prototype measures the resulting pixel churn
+and the serial full-frame cost without changing the shipped worker path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import io
+import json
+import math
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+from PIL import Image, ImageChops, ImageDraw, ImageOps
+
+os.environ.setdefault("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "1")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "worker"))
+
+region_composite = importlib.import_module("worker.region_composite")
+composite_rgb = region_composite.composite_rgb
+feather_change_mask = region_composite.feather_change_mask
+sketch_change_mask = region_composite.sketch_change_mask
+
+MODELS_DIR = ROOT / "worker" / "models"
+BAR_MS = 500.0
+SIZE = 512
+SEED = 1337
+PROMPT = "a cosy stone cottage in a green valley at sunset, oil painting"
+SWEEP = ((0, 0), (8, 8), (16, 16))
+
+
+def percentile(values: list[float], pct: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    rank = max(1, math.ceil(len(ordered) * pct / 100.0))
+    return ordered[min(rank, len(ordered)) - 1]
+
+
+def canvas_map(kind: str) -> Image.Image:
+    canvas = Image.new("RGB", (SIZE, SIZE), "white")
+    draw = ImageDraw.Draw(canvas)
+    draw.line([(40, 390), (150, 250), (275, 320), (440, 190)], fill=(17, 24, 39), width=6)
+    if kind == "small_stroke":
+        draw.line([(315, 400), (350, 370)], fill=(17, 24, 39), width=6)
+    elif kind == "erasure":
+        draw.line([(315, 400), (350, 370)], fill=(17, 24, 39), width=6)
+    elif kind == "shape_close":
+        draw.arc([(130, 130), (380, 400)], 35, 320, fill=(17, 24, 39), width=6)
+    elif kind != "base":
+        raise ValueError(f"unknown case: {kind}")
+    mapped = ImageOps.invert(canvas.convert("L"))
+    return mapped.point(lambda value: 255 if value >= 128 else 0).convert("RGB")
+
+
+def case_maps(name: str) -> tuple[Image.Image, Image.Image]:
+    if name == "small_stroke":
+        return canvas_map("base"), canvas_map("small_stroke")
+    if name == "erasure":
+        return canvas_map("erasure"), canvas_map("base")
+    if name == "shape_close":
+        open_map = Image.new("RGB", (SIZE, SIZE), "white")
+        draw = ImageDraw.Draw(open_map)
+        draw.line([(90, 280), (170, 140), (330, 140), (420, 280)], fill=(17, 24, 39), width=6)
+        closed_map = open_map.copy()
+        ImageDraw.Draw(closed_map).line(
+            [(420, 280), (330, 400), (170, 400), (90, 280)],
+            fill=(17, 24, 39),
+            width=6,
+        )
+        return (
+            ImageOps.invert(open_map.convert("L")).point(
+                lambda value: 255 if value >= 128 else 0
+            ).convert("RGB"),
+            ImageOps.invert(closed_map.convert("L")).point(
+                lambda value: 255 if value >= 128 else 0
+            ).convert("RGB"),
+        )
+    raise ValueError(f"unknown case: {name}")
+
+
+def build_pipeline(manifest: dict[str, Any], dtype: Any) -> Any:
+    import torch
+    from diffusers import (
+        AutoencoderKL,
+        LCMScheduler,
+        StableDiffusionXLAdapterPipeline,
+        StableDiffusionXLPipeline,
+        T2IAdapter,
+    )
+
+    kwargs: dict[str, Any] = {"torch_dtype": dtype}
+    if manifest.get("vae"):
+        kwargs["vae"] = AutoencoderKL.from_pretrained(manifest["vae"], **kwargs)
+    try:
+        base = StableDiffusionXLPipeline.from_pretrained(
+            manifest["source"], variant="fp16", **kwargs
+        )
+    except Exception:
+        base = StableDiffusionXLPipeline.from_pretrained(manifest["source"], **kwargs)
+    if manifest.get("lora"):
+        repo, _, weight = manifest["lora"].rpartition("/")
+        base.load_lora_weights(repo, weight_name=weight)
+        base.fuse_lora()
+    if manifest.get("scheduler") == "lcm":
+        base.scheduler = LCMScheduler.from_config(base.scheduler.config)
+    base.to("cuda")
+    for module in (base.unet, base.vae):
+        module.to(memory_format=torch.channels_last)
+    base.set_progress_bar_config(disable=True)
+    adapter = T2IAdapter.from_pretrained(manifest["t2i_adapter"], torch_dtype=dtype)
+    pipeline = StableDiffusionXLAdapterPipeline.from_pipe(
+        base, adapter=adapter, torch_dtype=dtype
+    )
+    pipeline.to("cuda")
+    pipeline.set_progress_bar_config(disable=True)
+    return pipeline
+
+
+def encode_prompt(pipeline: Any) -> dict[str, Any]:
+    encoded = pipeline.encode_prompt(
+        PROMPT, device="cuda", num_images_per_prompt=1,
+        do_classifier_free_guidance=False,
+    )
+    names = (
+        "prompt_embeds",
+        "negative_prompt_embeds",
+        "pooled_prompt_embeds",
+        "negative_pooled_prompt_embeds",
+    )
+    return {name: value for name, value in zip(names, encoded) if value is not None}
+
+
+def render(
+    pipeline: Any,
+    prompt_kwargs: dict[str, Any],
+    sketch: Image.Image,
+    steps: int,
+    scale: float,
+    seed: int,
+    output_type: str = "pil",
+) -> Image.Image | Any:
+    import torch
+
+    with torch.inference_mode():
+        result = pipeline(
+            **prompt_kwargs,
+            image=sketch,
+            num_inference_steps=steps,
+            guidance_scale=0.0,
+            adapter_conditioning_scale=scale,
+            generator=torch.Generator(device="cuda").manual_seed(seed),
+            height=SIZE,
+            width=SIZE,
+            output_type=output_type,
+        )
+    return result.images if output_type == "latent" else result.images[0]
+
+
+def decode_preview(pipeline: Any, decoder: Any, latent: Any) -> Image.Image:
+    import torch
+
+    with torch.inference_mode():
+        decoded = decoder.decode(latent, return_dict=False)[0].detach()
+        if decoded.dim() == 3:
+            decoded = decoded.unsqueeze(0)
+    return pipeline.image_processor.postprocess(decoded, output_type="pil")[0]
+
+
+def changed_fraction(previous: Image.Image, current: Image.Image) -> float:
+    difference = ImageChops.difference(previous.convert("RGB"), current.convert("RGB"))
+    channels = difference.split()
+    changed = ImageChops.lighter(
+        ImageChops.lighter(channels[0], channels[1]), channels[2]
+    ).point(lambda value: 1 if value else 0)
+    return sum(changed.getdata()) / (previous.width * previous.height)
+
+
+def exact_where(alpha: Image.Image, left: Image.Image, right: Image.Image, value: int) -> bool:
+    selected = alpha.point(lambda pixel: 255 if pixel == value else 0)
+    difference = ImageChops.difference(left.convert("RGB"), right.convert("RGB"))
+    channels = difference.split()
+    any_difference = ImageChops.lighter(
+        ImageChops.lighter(channels[0], channels[1]), channels[2]
+    )
+    return ImageChops.multiply(selected, any_difference).getbbox() is None
+
+
+def webp_round_trip(image: Image.Image) -> float:
+    buffer = io.BytesIO()
+    image.save(buffer, format="WEBP", quality=90, method=0)
+    buffer.seek(0)
+    with Image.open(buffer) as opened:
+        decoded = opened.convert("RGB")
+    difference = ImageChops.difference(image.convert("RGB"), decoded)
+    channels = difference.split()
+    any_difference = ImageChops.lighter(
+        ImageChops.lighter(channels[0], channels[1]), channels[2]
+    )
+    return sum(any_difference.getdata()) / (SIZE * SIZE * 255)
+
+
+def save_image(image: Image.Image, path: Path | None) -> None:
+    if path is not None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        image.save(path, format="PNG")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models", default="sdxl-turbo,vega-rt")
+    parser.add_argument("--frames", type=int, default=8)
+    parser.add_argument("--out", default="")
+    parser.add_argument("--save-dir", default="")
+    args = parser.parse_args()
+    if args.frames < 1:
+        parser.error("--frames must be >= 1")
+    save_dir = Path(args.save_dir).resolve() if args.save_dir else None
+    if save_dir is not None:
+        try:
+            save_dir.relative_to((ROOT / ".local").resolve())
+        except ValueError:
+            parser.error("--save-dir must be under .local")
+
+    import torch
+    from diffusers import AutoencoderTiny
+
+    report: dict[str, Any] = {"bar_ms": BAR_MS, "seed": SEED, "models": []}
+    for model_id in [item.strip() for item in args.models.split(",") if item.strip()]:
+        manifest = json.loads((MODELS_DIR / f"{model_id}.json").read_text())
+        properties = manifest["parameters"]["properties"]
+        steps = int(properties["steps"]["default"])
+        scale = float(properties["structure_strength"]["default"])
+        pipeline = build_pipeline(manifest, torch.float16)
+        prompt_kwargs = encode_prompt(pipeline)
+        decoder = AutoencoderTiny.from_pretrained(
+            manifest["preview_decoder"], torch_dtype=torch.float16
+        ).to("cuda")
+        decoder.eval()
+        render(pipeline, prompt_kwargs, canvas_map("base"), steps, scale, SEED, "latent")
+        model_report: dict[str, Any] = {
+            "model": model_id,
+            "steps": steps,
+            "adapter_scale": scale,
+            "cases": [],
+        }
+        for case_name in ("small_stroke", "erasure", "shape_close"):
+            previous_map, current_map = case_maps(case_name)
+            previous_latent = render(
+                pipeline, prompt_kwargs, previous_map, steps, scale, SEED, "latent"
+            )
+            current_latent = render(
+                pipeline, prompt_kwargs, current_map, steps, scale, SEED, "latent"
+            )
+            previous = decode_preview(pipeline, decoder, previous_latent)
+            current = decode_preview(pipeline, decoder, current_latent)
+            frame_times: list[float] = []
+            for _ in range(args.frames):
+                started = time.perf_counter()
+                frame_latent = render(
+                    pipeline, prompt_kwargs, current_map, steps, scale, SEED, "latent"
+                )
+                decode_preview(pipeline, decoder, frame_latent)
+                torch.cuda.synchronize()
+                frame_times.append((time.perf_counter() - started) * 1000)
+            raw_mask = sketch_change_mask(previous_map, current_map)
+            sweeps: list[dict[str, Any]] = []
+            for dilation_px, feather_px in SWEEP:
+                alpha = feather_change_mask(raw_mask, dilation_px, feather_px)
+                composited = composite_rgb(previous, current, alpha)
+                save_image(
+                    composited,
+                    save_dir / f"{model_id}-{case_name}-d{dilation_px}-f{feather_px}.png"
+                    if save_dir
+                    else None,
+                )
+                sweeps.append({
+                    "dilation_px": dilation_px,
+                    "feather_px": feather_px,
+                    "composited_changed_frac": changed_fraction(previous, composited),
+                    "outside_mask_prev_exact": exact_where(alpha, composited, previous, 0),
+                    "inside_mask_new_exact": exact_where(alpha, composited, current, 255),
+                })
+            model_report["cases"].append({
+                "name": case_name,
+                "uncomposited_changed_frac": changed_fraction(previous, current),
+                "p95_ms": percentile(frame_times, 95),
+                "webp_round_trip_mean_abs_over_255": webp_round_trip(current),
+                "sweeps": sweeps,
+            })
+        report["models"].append(model_report)
+    print(json.dumps(report, indent=2))
+    if args.out:
+        Path(args.out).write_text(json.dumps(report, indent=2) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worker/tests/test_region_composite.py
+++ b/worker/tests/test_region_composite.py
@@ -1,0 +1,101 @@
+import pytest
+from PIL import Image
+
+from worker.region_composite import (
+    composite_rgb,
+    feather_change_mask,
+    sketch_change_mask,
+)
+
+
+def test_sketch_change_mask_returns_all_zero_for_identical_images():
+    image = Image.new("RGB", (3, 2), (12, 34, 56))
+
+    result = sketch_change_mask(image, image.copy())
+
+    assert result.mode == "L"
+    assert result.size == image.size
+    assert set(result.getdata()) == {0}
+
+
+def test_sketch_change_mask_marks_one_changed_pixel():
+    previous = Image.new("RGB", (3, 3), (0, 0, 0))
+    current = previous.copy()
+    current.putpixel((1, 2), (255, 255, 255))
+
+    result = sketch_change_mask(previous, current)
+
+    assert result.getpixel((1, 2)) == 255
+    assert sum(pixel != 0 for pixel in result.getdata()) == 1
+
+
+def test_sketch_change_mask_rejects_size_mismatch():
+    with pytest.raises(ValueError):
+        sketch_change_mask(Image.new("RGB", (2, 2)), Image.new("RGB", (3, 2)))
+
+
+def test_feather_change_mask_dilation_expands_one_pixel_mark():
+    mask = Image.new("L", (5, 5), 0)
+    mask.putpixel((2, 2), 255)
+
+    result = feather_change_mask(mask, dilation_px=1, feather_px=0)
+
+    assert all(result.getpixel((x, y)) == 255 for x in range(1, 4) for y in range(1, 4))
+    assert result.getpixel((0, 0)) == 0
+    assert sum(pixel == 255 for pixel in result.getdata()) == 9
+
+
+def test_feather_change_mask_feathering_creates_intermediate_edge_values():
+    mask = Image.new("L", (5, 5), 0)
+    mask.putpixel((2, 2), 255)
+
+    result = feather_change_mask(mask, dilation_px=0, feather_px=1)
+
+    assert any(0 < pixel < 255 for pixel in result.getdata())
+
+
+def test_composite_rgb_uses_previous_and_current_at_alpha_extremes():
+    previous = Image.new("RGB", (2, 1), (10, 20, 30))
+    current = Image.new("RGB", (2, 1), (200, 210, 220))
+
+    result = composite_rgb(
+        previous,
+        current,
+        Image.new("L", (2, 1), 0),
+    )
+    current_result = composite_rgb(
+        previous,
+        current,
+        Image.new("L", (2, 1), 255),
+    )
+
+    assert result.getpixel((0, 0)) == (10, 20, 30)
+    assert current_result.getpixel((0, 0)) == (200, 210, 220)
+
+
+def test_composite_rgb_blends_intermediate_alpha():
+    previous = Image.new("RGB", (1, 1), (0, 100, 200))
+    current = Image.new("RGB", (1, 1), (200, 200, 0))
+
+    result = composite_rgb(previous, current, Image.new("L", (1, 1), 128))
+
+    pixel = result.getpixel((0, 0))
+    assert result.mode == "RGB"
+    assert all(0 < channel < 200 for channel in pixel)
+    assert pixel == (100, 150, 100)
+
+
+def test_composite_rgb_rejects_size_mismatch():
+    previous = Image.new("RGB", (2, 2))
+    current = Image.new("RGB", (2, 2))
+
+    with pytest.raises(ValueError):
+        composite_rgb(previous, Image.new("RGB", (3, 2)), Image.new("L", (2, 2)))
+    with pytest.raises(ValueError):
+        composite_rgb(previous, current, Image.new("L", (3, 2)))
+
+
+@pytest.mark.parametrize("dilation_px, feather_px", [(-1, 0), (0, -1), (-1, -1)])
+def test_feather_change_mask_rejects_negative_parameters(dilation_px, feather_px):
+    with pytest.raises(ValueError):
+        feather_change_mask(Image.new("L", (2, 2)), dilation_px, feather_px)

--- a/worker/tests/test_region_composite.py
+++ b/worker/tests/test_region_composite.py
@@ -4,8 +4,35 @@ from PIL import Image
 from worker.region_composite import (
     composite_rgb,
     feather_change_mask,
+    max_channel_difference,
     sketch_change_mask,
 )
+
+
+def test_max_channel_difference_returns_all_zero_for_identical_images():
+    image = Image.new("RGB", (3, 2), (12, 34, 56))
+
+    result = max_channel_difference(image, image.copy())
+
+    assert result.mode == "L"
+    assert result.size == image.size
+    assert set(result.getdata()) == {0}
+
+
+def test_max_channel_difference_returns_single_channel_delta():
+    previous = Image.new("RGB", (3, 2), (10, 20, 30))
+    current = previous.copy()
+    current.putpixel((1, 1), (10, 77, 30))
+
+    result = max_channel_difference(previous, current)
+
+    assert result.getpixel((1, 1)) == 57
+    assert sum(pixel != 0 for pixel in result.getdata()) == 1
+
+
+def test_max_channel_difference_rejects_size_mismatch():
+    with pytest.raises(ValueError):
+        max_channel_difference(Image.new("RGB", (2, 2)), Image.new("RGB", (3, 2)))
 
 
 def test_sketch_change_mask_returns_all_zero_for_identical_images():

--- a/worker/worker/region_composite.py
+++ b/worker/worker/region_composite.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from PIL import Image, ImageChops, ImageFilter
+
+
+def sketch_change_mask(previous: Image.Image, current: Image.Image) -> Image.Image:
+    if previous.size != current.size:
+        raise ValueError("images must have the same size")
+    previous_rgb = previous.convert("RGB")
+    current_rgb = current.convert("RGB")
+    difference = ImageChops.difference(previous_rgb, current_rgb)
+    channels = difference.split()
+    changed = ImageChops.lighter(
+        ImageChops.lighter(channels[0], channels[1]), channels[2]
+    )
+    return changed.point(lambda value: 255 if value else 0, mode="L")
+
+
+def feather_change_mask(
+    mask: Image.Image, dilation_px: int, feather_px: int
+) -> Image.Image:
+    if dilation_px < 0 or feather_px < 0:
+        raise ValueError("dilation_px and feather_px must be non-negative")
+    binary = mask.convert("L").point(lambda value: 255 if value else 0, mode="L")
+    if dilation_px:
+        binary = binary.filter(ImageFilter.MaxFilter(dilation_px * 2 + 1))
+    if feather_px:
+        return binary.filter(ImageFilter.GaussianBlur(feather_px))
+    return binary
+
+
+def composite_rgb(
+    previous: Image.Image, current: Image.Image, alpha: Image.Image
+) -> Image.Image:
+    if previous.size != current.size or previous.size != alpha.size:
+        raise ValueError("images and alpha must have the same size")
+    previous_rgb = previous.convert("RGB")
+    current_rgb = current.convert("RGB")
+    alpha_l = alpha.convert("L")
+    return Image.composite(current_rgb, previous_rgb, alpha_l)

--- a/worker/worker/region_composite.py
+++ b/worker/worker/region_composite.py
@@ -3,16 +3,20 @@ from __future__ import annotations
 from PIL import Image, ImageChops, ImageFilter
 
 
-def sketch_change_mask(previous: Image.Image, current: Image.Image) -> Image.Image:
+def max_channel_difference(
+    previous: Image.Image, current: Image.Image
+) -> Image.Image:
     if previous.size != current.size:
         raise ValueError("images must have the same size")
-    previous_rgb = previous.convert("RGB")
-    current_rgb = current.convert("RGB")
-    difference = ImageChops.difference(previous_rgb, current_rgb)
+    difference = ImageChops.difference(previous.convert("RGB"), current.convert("RGB"))
     channels = difference.split()
-    changed = ImageChops.lighter(
+    return ImageChops.lighter(
         ImageChops.lighter(channels[0], channels[1]), channels[2]
     )
+
+
+def sketch_change_mask(previous: Image.Image, current: Image.Image) -> Image.Image:
+    changed = max_channel_difference(previous, current)
     return changed.point(lambda value: 255 if value else 0, mode="L")
 
 


### PR DESCRIPTION
# Description

A small stroke still re-denoises the whole latent. This PR adds CPU mask and composite helpers plus a GPU prototype. It does not change `Engine._frame`.

# Motivation

Session seed already makes an unchanged canvas bit-identical. One small stroke still changes the whole picture. That is not a wire problem. Vector deltas were rejected. The recorded next step is compositing.

# Functionality

- `sketch_change_mask`, `feather_change_mask`, `composite_rgb` in `worker/worker/region_composite.py`
- `scripts/prototype-region-composite.py` times full regen vs RGB composite on `sdxl-turbo` and `vega-rt`
- Exact-hash GPU skip is not in this PR

Closes #380.

Related: #55, #376.

# Details

Measured on this desk (RX 7600 XT), TAESD, fixed seed, 8 frames. "Changed" here means any channel differs by at least 1, so uncomposited fractions are ~97 percent, not the recorded 10.4 percent (that used a stricter rule). Composite still keeps pixels outside the mask equal to the previous bitmap.

| Model | case | uncomposited | composite 8/8 | p95 |
| --- | --- | --- | --- | --- |
| sdxl-turbo | small_stroke | 0.973 | 0.019 | 137 ms |
| sdxl-turbo | shape_close | 0.999 | 0.106 | 142 ms |
| vega-rt | small_stroke | 0.993 | 0.019 | 200 ms |
| vega-rt | shape_close | 0.995 | 0.109 | 208 ms |

Outside the feathered mask, previous pixels match exactly. Inside 255, new pixels match exactly. The UNet still runs on the whole frame. Do not adopt until a person accepts seams and frozen lighting on the saved PNGs under `.local/region-composite/`.

# Test plan

- [x] `make verify`
- [x] GPU script on sdxl-turbo and vega-rt
- [ ] Human look at `.local/region-composite/*.png`
- [ ] Do not merge as a worker behavior change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added image-difference masking to identify changed regions between frames.
  * Added configurable mask dilation and feathering for smoother transitions.
  * Added RGB compositing to blend new and previous image content using transparency masks.
  * Added a prototype for evaluating rendering performance, compositing quality, and WebP fidelity.
  * Added optional PNG output and JSON reporting for prototype results.

* **Tests**
  * Added coverage for masking, blending, image-size validation, and invalid processing parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->