### PR TITLE
Record the realtime density and region-composite PRs on the roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -129,12 +129,16 @@ tracker-verified detail (open issues and in-flight PRs).
   replay log, #55 vector masks and selections, #45 SPA/API version skew, #46
   status banner.
 
+Shipped this pass:
+
+- PR #368 closed #377, the Engine.frame baseline.
+- PR #370 closed #378, the two-session E2E.
+- PR #372 closed #294. Curve admission is on. Do not advertise four turbo
+  sessions (N=4 homogeneous turbo is about 501 ms on this desk).
+- PR #373 closed #379. Stream Batch stays out of Engine.
+
 In flight:
 
-- PR #368 closes #377, the Engine.frame baseline issue. Ship the measurement.
-- PR #370 closes #378, the two-session E2E issue. Ship the measurement.
-- PR #372 closes #294. Ship curve admission. Do not advertise four turbo
-  sessions (N=4 homogeneous turbo is about 501 ms on this desk).
 - PR #375 closes #380, the region-composite measurement. Do not wire Engine
   until a person accepts the images. Product follow-up is #376.
 - #376 stays open: select and edit a region. It is blocked on looking at the
@@ -193,8 +197,7 @@ In flight:
 
 ### Next steps after the realtime pass
 
-- Merge PRs #368, #370 and #372 as the #294 close-out.
-- Merge PRs #373 and #375 as measure records, not worker behavior changes.
+- Merge PR #375 as a measure record, not a worker behavior change.
 - Have a human look at the region PNGs, then decide #376 step 2 (Engine
   composite) or stop.
 - Drawing UI remains #3 and related issues.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -142,7 +142,9 @@ In flight:
 
 ### M4 Accounts
 
-- #5 / #9 auth modes (none, local, oauth behind one dependency seam), #10 account UI.
+- Still-open epics: #5 sessions and principal policy, #9 first-admin and adoption leftovers, and #10 account UI.
+- Shipped slices: invitations and roles (PR #364), realtime socket authentication (PR #365, recorded in an issue; #19 still owns admission queue, idle release, and other protocol work), mail outbox (PR #367), Google and GitHub OAuth sign-in and linking (PR #369; linking only, never enrolment by email), and TOTP and recovery (PR #371).
+- In flight: PR #374 closes the credential-change issue for passwords, primary addresses, and linked providers.
 
 ### M5 Cloud readiness (largest)
 
@@ -159,6 +161,9 @@ In flight:
   four-step vega with three-frame lag. Do not adopt it. Do not vendor
   StreamDiffusion. SSF remains unstarted; CUDA compile, Sage and TensorRT stay
   last, fleet card only.
+- In flight: PR #339 adds four self-hosted runners and concurrency groups.
+  Shipped: PR #366 gives jobs isolated ports and compose projects; PR #382 lets
+  simulation choose a free port.
 
 ### M6 Launch and beta
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,13 +136,13 @@ Shipped this pass:
 - PR #372 closed #294. Curve admission is on. Do not advertise four turbo
   sessions (N=4 homogeneous turbo is about 501 ms on this desk).
 - PR #373 closed #379. Stream Batch stays out of Engine.
+- PR #375 closed #380, the region-composite measurement. Engine is unchanged.
+  Product follow-up is #376.
 
-In flight:
+Still open:
 
-- PR #375 closes #380, the region-composite measurement. Do not wire Engine
-  until a person accepts the images. Product follow-up is #376.
-- #376 stays open: select and edit a region. It is blocked on looking at the
-  PR #375 images.
+- #376: select and edit a region. It is blocked on looking at the region
+  comparison images.
 
 ### M4 Accounts
 
@@ -197,7 +197,6 @@ In flight:
 
 ### Next steps after the realtime pass
 
-- Merge PR #375 as a measure record, not a worker behavior change.
 - Have a human look at the region PNGs, then decide #376 step 2 (Engine
   composite) or stop.
 - Drawing UI remains #3 and related issues.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,9 @@ milestones remain the planning source of truth; this file is the readable
 summary. Decisions and their rejected alternatives live in
 [docs/decisions.md](docs/decisions.md).
 
-Refreshed 2026-07-23 to cover the upscale, metrics and relicense work merged
-after the M2 snapshot. The GitHub issues and milestones remain the authoritative,
-grouped (M2-M8) view of what is open.
+Refreshed 2026-08-23 to cover the realtime density and region-composite pass.
+The GitHub issues and milestones remain the authoritative, grouped (M2-M8)
+view of what is open.
 
 > Correction: an earlier version of this file listed worker thumbnails (#56),
 > lineage columns (#57), self-hosted packaging (#18) under "To close M2" and the
@@ -129,6 +129,17 @@ tracker-verified detail (open issues and in-flight PRs).
   replay log, #55 vector masks and selections, #45 SPA/API version skew, #46
   status banner.
 
+In flight:
+
+- PR #368 closes #377, the Engine.frame baseline issue. Ship the measurement.
+- PR #370 closes #378, the two-session E2E issue. Ship the measurement.
+- PR #372 closes #294. Ship curve admission. Do not advertise four turbo
+  sessions (N=4 homogeneous turbo is about 501 ms on this desk).
+- PR #375 closes #380, the region-composite measurement. Do not wire Engine
+  until a person accepts the images. Product follow-up is #376.
+- #376 stays open: select and edit a region. It is blocked on looking at the
+  PR #375 images.
+
 ### M4 Accounts
 
 - #5 / #9 auth modes (none, local, oauth behind one dependency seam), #10 account UI.
@@ -144,6 +155,10 @@ tracker-verified detail (open issues and in-flight PRs).
 - Inference backlog note (#60): torch.compile warmup and measured realtime slots
   are in-flight in PR #141. That PR recommends against enabling torch.compile by
   default (measured ROCm speedup only 0.8-7.4% against a large cold-load cost).
+- PR #373 and #379 measured worker-internal Stream Batch on vega-rt: 1.42x on
+  four-step vega with three-frame lag. Do not adopt it. Do not vendor
+  StreamDiffusion. SSF remains unstarted; CUDA compile, Sage and TensorRT stay
+  last, fleet card only.
 
 ### M6 Launch and beta
 
@@ -166,6 +181,18 @@ tracker-verified detail (open issues and in-flight PRs).
 
 ### Deferred by recorded decision
 
-- Worker-internal batching (StreamDiffusion-class step batching, CFG drop) and
-  TAESD preview decode: the trigger is fleet spend, not local speed.
+- Worker-internal Stream Batch (StreamDiffusion-class step batching) was
+  measured and rejected because of lag and quality. TAESD preview decode is
+  shipped. The trigger for future batching work is fleet spend, not local
+  speed.
 - Dedicated realtime and batch pools: a configuration change at scaling stage 2.
+
+### Next steps after the realtime pass
+
+- Merge PRs #368, #370 and #372 as the #294 close-out.
+- Merge PRs #373 and #375 as measure records, not worker behavior changes.
+- Have a human look at the region PNGs, then decide #376 step 2 (Engine
+  composite) or stop.
+- Drawing UI remains #3 and related issues.
+- Do not shrink BATCH_WINDOW_MS. Do not start SSF, Sage, TRT, Flux or img2img
+  realtime.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,8 +143,7 @@ In flight:
 ### M4 Accounts
 
 - Still-open epics: #5 sessions and principal policy, #9 first-admin and adoption leftovers, and #10 account UI.
-- Shipped slices: invitations and roles (PR #364), realtime socket authentication (PR #365, recorded in an issue; #19 still owns admission queue, idle release, and other protocol work), mail outbox (PR #367), Google and GitHub OAuth sign-in and linking (PR #369; linking only, never enrolment by email), and TOTP and recovery (PR #371).
-- In flight: PR #374 closes the credential-change issue for passwords, primary addresses, and linked providers.
+- Shipped slices: invitations and roles (PR #364), realtime socket authentication (PR #365 / #383; #19 still owns admission queue, idle release, and other protocol work), mail outbox (PR #367 / #385), Google and GitHub OAuth sign-in and linking (PR #369 / #386; linking only, never enrolment by email), TOTP and recovery (PR #371 / #387), and credential changes (PR #374 / #388).
 
 ### M5 Cloud readiness (largest)
 


### PR DESCRIPTION
# Description

Record the realtime density and region-composite work on ROADMAP.md.

# Motivation

Keep the roadmap aligned with the open measurement PRs and the decisions from the density and region pass.

# Functionality

Record the Engine.frame baseline, live two-session measurement, measured curve admission, region-composite measurement, and rejected Stream Batch evaluation. State the human image review gate and the next steps.

# Details

This PR only updates ROADMAP.md. It does not merge the measure PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the roadmap snapshot date and reaffirmed GitHub issues and milestones as authoritative project-status sources.
  - Added realtime drawing measurement results, current progress, and follow-up actions.
  - Expanded M4 account completion details.
  - Documented Stream Batch rejection and infrastructure updates.
  - Recorded TAESD shipment, post-realtime next steps, and technologies deferred from development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->