### PR TITLE
Let the simulation take a free port

### DIFF
--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -12,6 +12,7 @@ Run from the repository root, after the setup in docs/local-development.md:
 import asyncio
 import json
 import os
+import socket
 import struct
 import subprocess
 import sys
@@ -28,7 +29,17 @@ import websockets
 from app.realtime import CANVAS_FRAME, FRAME_HEADER_BYTES
 
 ROOT = Path(__file__).resolve().parent.parent
-PORT = 8901
+
+
+def _free_port() -> int:
+    """Several self-hosted runners share one machine, so a fixed port meant
+    two simulations at once fought over it and the loser bound nothing."""
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+PORT = int(os.environ.get("SIMULATE_PORT") or _free_port())
 START = time.monotonic()
 # Pytest uses the same default. This script is not production; an unset key
 # now refuses to import the API (issues #245 and #260).


### PR DESCRIPTION
# Description

The simulation script bound a fixed port 8901. Four self-hosted runners share one machine, so two simulation jobs at once meant one API never bound and the browser it was waiting for closed with no frames.

# Motivation

Third instance of the same class of failure after the compose smoke port and the CI postgres port (#366). CI on #374 failed on exactly this.

# Functionality

The port is asked for from the OS. `SIMULATE_PORT` still pins it for anyone who wants to watch a run on a known port.

# Details

Verified with `make simulate` locally: 50 frames sent, 43 rendered, worker kill and resume as before.

Recorded as #390 (shipped).\n\n<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simulation now automatically selects an available local port, reducing startup conflicts.
  * Added an optional `SIMULATE_PORT` setting for specifying a preferred port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->