### PR TITLE
Close the gap between reclaiming and claiming an install

### DIFF
--- a/backend/app/enable.py
+++ b/backend/app/enable.py
@@ -56,6 +56,11 @@ async def mint_setup_token(session: AsyncSession | None = None) -> str:
         raise RuntimeError("database unavailable")
     async with db.session_factory() as owned:
         async with owned.begin():
+            # The same lock the caller-supplied branch is already inside, so
+            # every way of minting a setup link is serialized with claiming
+            # one however it was reached.
+            await owned.execute(text("SELECT pg_advisory_xact_lock(:key)"),
+                                {"key": SETUP_LOCK})
             await _replace_setup_token(owned, token)
     return token
 

--- a/backend/app/enable.py
+++ b/backend/app/enable.py
@@ -13,8 +13,10 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from anyio import to_thread
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, select, text, update
 from starlette.responses import Response
+
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import audit, db, sessions
 from app.accounts import issue_session
@@ -25,6 +27,8 @@ from app.tables import AuthIdentity, AuthToken, User
 
 SETUP_TTL = timedelta(hours=1)
 SETUP_PURPOSE = "setup"
+# One key for claiming this installation, shared with the offline reclaim.
+SETUP_LOCK = 184469
 # One answer for unknown, expired, spent and replaced, so the link is not an
 # oracle for which of those it was.
 INVALID_LINK = "invalid or expired setup link"
@@ -37,25 +41,37 @@ def _token_hash(token: str) -> bytes:
     return hashlib.sha256(token.encode()).digest()
 
 
-async def mint_setup_token() -> str:
-    """Returns the only copy of the link. Nothing durable holds it."""
+async def mint_setup_token(session: AsyncSession | None = None) -> str:
+    """Returns the only copy of the link. Nothing durable holds it.
+
+    Takes a session when the caller has one open: reclaiming an install checks
+    that nobody has claimed it and mints in the same transaction, and a mint
+    that opened its own would leave a gap for a claim to land in.
+    """
+    token = secrets.token_urlsafe(32)
+    if session is not None:
+        await _replace_setup_token(session, token)
+        return token
     if db.session_factory is None:
         raise RuntimeError("database unavailable")
-    token = secrets.token_urlsafe(32)
-    async with db.session_factory() as session:
-        async with session.begin():
-            # Minting replaces: an operator who runs this twice must not leave
-            # an older link alive for whoever saw it first.
-            await session.execute(delete(AuthToken).where(
-                AuthToken.purpose == SETUP_PURPOSE,
-                AuthToken.consumed_at.is_(None),
-            ))
-            session.add(AuthToken(
-                purpose=SETUP_PURPOSE,
-                token_hash=_token_hash(token),
-                expires_at=datetime.now(timezone.utc) + SETUP_TTL,
-            ))
+    async with db.session_factory() as owned:
+        async with owned.begin():
+            await _replace_setup_token(owned, token)
     return token
+
+
+async def _replace_setup_token(session: AsyncSession, token: str) -> None:
+    # Minting replaces: an operator who runs this twice must not leave an
+    # older link alive for whoever saw it first.
+    await session.execute(delete(AuthToken).where(
+        AuthToken.purpose == SETUP_PURPOSE,
+        AuthToken.consumed_at.is_(None),
+    ))
+    session.add(AuthToken(
+        purpose=SETUP_PURPOSE,
+        token_hash=_token_hash(token),
+        expires_at=datetime.now(timezone.utc) + SETUP_TTL,
+    ))
 
 
 # It becomes the To header of mail this install sends, and smtplib takes the
@@ -85,6 +101,12 @@ async def claim(token: str, email: str, password: str) -> uuid.UUID:
         raise HTTPException(status_code=503, detail="database unavailable")
     async with db.session_factory() as session:
         async with session.begin():
+            # One claim at a time, and one reclaim at a time beside it: the
+            # offline command checks that nobody holds an identity before it
+            # mints a link, and without this that check and this insert can
+            # both believe they went first.
+            await session.execute(text("SELECT pg_advisory_xact_lock(:key)"),
+                                  {"key": SETUP_LOCK})
             # The link is judged before anything else, so a caller without one
             # cannot learn whether the installation is claimed. Raising after
             # this rolls the consumption back with it.

--- a/backend/app/enable.py
+++ b/backend/app/enable.py
@@ -41,31 +41,40 @@ def _token_hash(token: str) -> bytes:
     return hashlib.sha256(token.encode()).digest()
 
 
+class AlreadyClaimed(Exception):
+    """Somebody holds an identity, so a setup link would only be refused."""
+
+
 async def mint_setup_token(session: AsyncSession | None = None) -> str:
     """Returns the only copy of the link. Nothing durable holds it.
 
-    Takes a session when the caller has one open: reclaiming an install checks
-    that nobody has claimed it and mints in the same transaction, and a mint
-    that opened its own would leave a gap for a claim to land in.
+    Takes a session when the caller has one open, so a reclaim can decide and
+    mint in one transaction. Either way the work happens behind SETUP_LOCK,
+    which claim() holds too: a link minted for an installation somebody
+    claimed a moment ago is refused when it is finally spent, which is the
+    worst moment to discover it.
     """
     token = secrets.token_urlsafe(32)
     if session is not None:
-        await _replace_setup_token(session, token)
+        await _mint_locked(session, token)
         return token
     if db.session_factory is None:
         raise RuntimeError("database unavailable")
     async with db.session_factory() as owned:
         async with owned.begin():
-            # The same lock the caller-supplied branch is already inside, so
-            # every way of minting a setup link is serialized with claiming
-            # one however it was reached.
-            await owned.execute(text("SELECT pg_advisory_xact_lock(:key)"),
-                                {"key": SETUP_LOCK})
-            await _replace_setup_token(owned, token)
+            await _mint_locked(owned, token)
     return token
 
 
-async def _replace_setup_token(session: AsyncSession, token: str) -> None:
+async def _mint_locked(session: AsyncSession, token: str) -> None:
+    await session.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": SETUP_LOCK})
+    # Under the lock, not before it: the setup link adopts the implicit local
+    # user, which claim() allows only while nobody holds an identity.
+    claimed = (await session.execute(select(AuthIdentity.id).limit(1))).first()
+    if claimed is not None:
+        raise AlreadyClaimed(
+            "this installation has already been claimed, so a setup link would be "
+            "refused; use reclaim --restore EMAIL to make an account an administrator")
     # Minting replaces: an operator who runs this twice must not leave an
     # older link alive for whoever saw it first.
     await session.execute(delete(AuthToken).where(

--- a/backend/app/operator.py
+++ b/backend/app/operator.py
@@ -15,7 +15,7 @@ from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db, keyring
-from app.enable import SETUP_LOCK, mint_setup_token
+from app.enable import AlreadyClaimed, mint_setup_token
 from app.settings import get_settings
 from app.tables import (
     Asset, AuthFactor, AuthIdentity, AuthToken, Invitation, Job, RecoveryCode, Session, User,
@@ -77,22 +77,14 @@ async def reclaim_claim() -> str:
     assert db.session_factory is not None
     async with db.session_factory() as session:
         async with session.begin():
-            # The check and the mint in one transaction, behind the lock the
-            # claim route takes: a claim landing between them would leave this
-            # command handing over a link that is refused when it is spent.
-            await session.execute(text("SELECT pg_advisory_xact_lock(:key)"),
-                                  {"key": SETUP_LOCK})
-            claimed = (await session.execute(select(AuthIdentity.id).limit(1))).first()
-            if claimed is not None:
-                # The setup link adopts the implicit local user, which the
-                # claim route allows only on an install nobody has claimed.
-                raise LookupError(
-                    "this installation still has accounts, so a setup link would be "
-                    "refused; use reclaim --restore EMAIL to make one of them an "
-                    "administrator again")
+            # One transaction, so the decision about whether this install can
+            # be claimed and the link that acts on it cannot disagree.
             # Minting retires whatever link was outstanding, which is the
             # point: whoever held the old one is not who is at the machine.
-            return await mint_setup_token(session)
+            try:
+                return await mint_setup_token(session)
+            except AlreadyClaimed as refused:
+                raise LookupError(str(refused)) from None
 
 
 async def reclaim_restore(email: str) -> str:

--- a/backend/app/operator.py
+++ b/backend/app/operator.py
@@ -15,7 +15,7 @@ from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import db, keyring
-from app.enable import mint_setup_token
+from app.enable import SETUP_LOCK, mint_setup_token
 from app.settings import get_settings
 from app.tables import (
     Asset, AuthFactor, AuthIdentity, AuthToken, Invitation, Job, RecoveryCode, Session, User,
@@ -76,17 +76,23 @@ async def reclaim_claim() -> str:
     """
     assert db.session_factory is not None
     async with db.session_factory() as session:
-        claimed = (await session.execute(select(AuthIdentity.id).limit(1))).first()
-    if claimed is not None:
-        # The setup link adopts the implicit local user, and the claim route
-        # refuses once anybody holds an identity. Saying so here beats minting
-        # a link that is refused when somebody finally spends it.
-        raise LookupError(
-            "this installation still has accounts, so a setup link would be refused; "
-            "use reclaim --restore EMAIL to make one of them an administrator again")
-    # mint_setup_token retires whatever link was outstanding, which is the
-    # point: whoever held the old one is not who is standing at the machine.
-    return await mint_setup_token()
+        async with session.begin():
+            # The check and the mint in one transaction, behind the lock the
+            # claim route takes: a claim landing between them would leave this
+            # command handing over a link that is refused when it is spent.
+            await session.execute(text("SELECT pg_advisory_xact_lock(:key)"),
+                                  {"key": SETUP_LOCK})
+            claimed = (await session.execute(select(AuthIdentity.id).limit(1))).first()
+            if claimed is not None:
+                # The setup link adopts the implicit local user, which the
+                # claim route allows only on an install nobody has claimed.
+                raise LookupError(
+                    "this installation still has accounts, so a setup link would be "
+                    "refused; use reclaim --restore EMAIL to make one of them an "
+                    "administrator again")
+            # Minting retires whatever link was outstanding, which is the
+            # point: whoever held the old one is not who is at the machine.
+            return await mint_setup_token(session)
 
 
 async def reclaim_restore(email: str) -> str:

--- a/backend/tests/test_first_admin_setup.py
+++ b/backend/tests/test_first_admin_setup.py
@@ -263,13 +263,35 @@ def test_accounts_mode_authenticates_nobody_through_the_implicit_admin(accounts)
 
 @pytest.mark.db
 def test_setup_is_refused_once_the_installation_is_claimed(accounts):
+    from datetime import datetime, timedelta, timezone
+
+    from app.tables import AuthToken
+
     token = accounts(enable.mint_setup_token())
     with TestClient(app) as client:
         assert _claim(client, token).status_code == 204
-        # A fresh link is valid, and still refused: the installation has an
-        # owner, and a second setup would hand it to someone else.
-        second = client.portal.call(enable.mint_setup_token)
-        assert _claim(client, second, email="later@example.com").status_code == 409
+        # Minting refuses now, which is the early half: a link handed over for
+        # a claimed installation is refused when somebody finally spends it,
+        # and that is the worst moment to find out.
+        with pytest.raises(enable.AlreadyClaimed):
+            client.portal.call(enable.mint_setup_token)
+
+        # And the route keeps its own guard. Nothing mints a link for a
+        # claimed installation any more, so this puts one there directly:
+        # a link that outlived the moment it was valid in must still fail.
+        leftover = "a-link-minted-before-the-claim"
+
+        async def plant() -> None:
+            async with db.session_factory() as session:
+                async with session.begin():
+                    session.add(AuthToken(
+                        purpose="setup",
+                        token_hash=enable._token_hash(leftover),
+                        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                    ))
+
+        client.portal.call(plant)
+        assert _claim(client, leftover, email="later@example.com").status_code == 409
 
 
 @pytest.mark.db

--- a/backend/tests/test_operator_commands.py
+++ b/backend/tests/test_operator_commands.py
@@ -6,6 +6,7 @@ to change the key everything else is sealed with.
 """
 
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from fastapi.testclient import TestClient
@@ -315,3 +316,113 @@ def test_the_commands_reach_their_work_through_the_command_line(library, capsys)
             operator.main(["collapse", "--confirm", "no"])
 
         client.portal.call(db.connect)
+
+
+@pytest.mark.db
+def test_a_reclaim_checks_and_mints_in_one_transaction(library):
+    """A claim landing between the two would leave this command handing over
+    a link that is refused when somebody finally spends it."""
+    import asyncio
+
+    from app import enable
+
+    with TestClient(app, base_url=ORIGIN) as client:
+
+        async def strip_identities() -> None:
+            async with db.session_factory() as session:
+                await session.execute(text("DELETE FROM auth_identities"))
+                await session.commit()
+
+        client.portal.call(strip_identities)
+
+        async def claim_while_reclaiming():
+            return await asyncio.gather(
+                operator.reclaim_claim(),
+                _identity_behind_the_lock(),
+                return_exceptions=True,
+            )
+
+        async def _identity_behind_the_lock() -> None:
+            async with db.session_factory() as session:
+                async with session.begin():
+                    await session.execute(
+                        text("SELECT pg_advisory_xact_lock(:key)"), {"key": enable.SETUP_LOCK})
+                    local = (await session.execute(
+                        text("SELECT id FROM users LIMIT 1"))).scalar_one()
+                    await session.execute(
+                        text("INSERT INTO auth_identities (id, user_id, provider, subject) "
+                             "VALUES (gen_random_uuid(), :id, 'password', 'raced@example.com')"),
+                        {"id": local})
+
+        minted, _ = client.portal.call(claim_while_reclaiming)
+
+        async def live_tokens() -> int:
+            async with db.session_factory() as session:
+                return int(await session.scalar(text(
+                    "SELECT count(*) FROM auth_tokens WHERE purpose = 'setup' "
+                    "AND consumed_at IS NULL")) or 0)
+
+        # Either the reclaim went first and its link is real, or the identity
+        # did and the reclaim refused without minting anything.
+        if isinstance(minted, LookupError):
+            assert client.portal.call(live_tokens) == 0
+        else:
+            assert isinstance(minted, str)
+
+
+@pytest.mark.db
+def test_claiming_the_installation_waits_for_the_setup_lock(library):
+    """The reclaim's check means nothing unless the claim route takes the same
+    lock: without it a claim commits between that check and its mint."""
+    import asyncio
+    import time
+
+    from app import enable
+    from tests.test_first_admin_setup import PASSWORD as SETUP_PASSWORD
+
+    with TestClient(app, base_url=ORIGIN) as client:
+
+        async def strip_identities() -> None:
+            async with db.session_factory() as session:
+                await session.execute(text("DELETE FROM auth_identities"))
+                await session.commit()
+
+        client.portal.call(strip_identities)
+        token = client.portal.call(enable.mint_setup_token)
+        holding = asyncio.Event()
+        release = asyncio.Event()
+
+        async def hold_the_lock() -> None:
+            async with db.session_factory() as session:
+                async with session.begin():
+                    await session.execute(
+                        text("SELECT pg_advisory_xact_lock(:key)"), {"key": enable.SETUP_LOCK})
+                    holding.set()
+                    await release.wait()
+
+        held = client.portal.start_task_soon(hold_the_lock)
+        client.portal.call(holding.wait)
+
+        started = time.monotonic()
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            claiming = pool.submit(
+                client.post, "/api/v1/auth/setup",
+                json={"token": token, "email": "locked@example.com",
+                      "password": SETUP_PASSWORD})
+            try:
+                time.sleep(0.4)
+                waited = not claiming.done()
+            finally:
+                # Always, even when the assertion below is going to fail: a
+                # transaction left holding this lock wedges every test after it.
+                client.portal.call(_set, release)
+                answered = claiming.result(timeout=10)
+                held.cancel()
+
+        assert waited, "the claim did not wait for the lock"
+        assert answered.status_code == 204
+        assert time.monotonic() - started >= 0.4
+
+
+async def _set(event) -> None:
+    event.set()

--- a/backend/tests/test_operator_commands.py
+++ b/backend/tests/test_operator_commands.py
@@ -15,7 +15,10 @@ from sqlalchemy import func, select, text
 from app import db, keyring, operator
 from app.main import app
 from app.tables import Job, User
-from tests.test_totp_flow import ORIGIN, ROOT_KEYS, _factors, _login, _make, accounts
+from app.passwords import hash_password
+from tests.test_totp_flow import (
+    ORIGIN, PASSWORD, ROOT_KEYS, _factors, _login, _make, accounts,
+)
 
 __all__ = ["accounts"]
 
@@ -319,9 +322,14 @@ def test_the_commands_reach_their_work_through_the_command_line(library, capsys)
 
 
 @pytest.mark.db
-def test_a_reclaim_checks_and_mints_in_one_transaction(library):
-    """A claim landing between the two would leave this command handing over
-    a link that is refused when somebody finally spends it."""
+def test_a_reclaim_refuses_an_identity_that_landed_while_it_waited(library):
+    """The check and the mint are one transaction behind the setup lock, so
+    an identity committed while the reclaim waits is one the reclaim sees.
+
+    Deterministic on purpose: the blocker takes the lock first, so a reclaim
+    that read outside the lock would look before the insert and mint a link
+    that is refused the moment somebody spends it.
+    """
     import asyncio
 
     from app import enable
@@ -334,27 +342,36 @@ def test_a_reclaim_checks_and_mints_in_one_transaction(library):
                 await session.commit()
 
         client.portal.call(strip_identities)
+        holding = asyncio.Event()
 
-        async def claim_while_reclaiming():
-            return await asyncio.gather(
-                operator.reclaim_claim(),
-                _identity_behind_the_lock(),
-                return_exceptions=True,
-            )
-
-        async def _identity_behind_the_lock() -> None:
+        async def claim_it_first() -> None:
             async with db.session_factory() as session:
                 async with session.begin():
                     await session.execute(
                         text("SELECT pg_advisory_xact_lock(:key)"), {"key": enable.SETUP_LOCK})
+                    holding.set()
+                    # Long enough that the reclaim is certainly queued behind
+                    # this lock rather than merely slower.
+                    await asyncio.sleep(0.3)
                     local = (await session.execute(
                         text("SELECT id FROM users LIMIT 1"))).scalar_one()
                     await session.execute(
-                        text("INSERT INTO auth_identities (id, user_id, provider, subject) "
-                             "VALUES (gen_random_uuid(), :id, 'password', 'raced@example.com')"),
-                        {"id": local})
+                        text("INSERT INTO auth_identities "
+                             "(id, user_id, provider, subject, password_hash) "
+                             "VALUES (gen_random_uuid(), :id, 'password', "
+                             "'raced@example.com', :hash)"),
+                        {"id": local, "hash": hash_password(PASSWORD)})
 
-        minted, _ = client.portal.call(claim_while_reclaiming)
+        async def reclaim_behind_it():
+            first = asyncio.create_task(claim_it_first())
+            await holding.wait()
+            try:
+                return await operator.reclaim_claim()
+            finally:
+                await first
+
+        with pytest.raises(LookupError):
+            client.portal.call(reclaim_behind_it)
 
         async def live_tokens() -> int:
             async with db.session_factory() as session:
@@ -362,12 +379,8 @@ def test_a_reclaim_checks_and_mints_in_one_transaction(library):
                     "SELECT count(*) FROM auth_tokens WHERE purpose = 'setup' "
                     "AND consumed_at IS NULL")) or 0)
 
-        # Either the reclaim went first and its link is real, or the identity
-        # did and the reclaim refused without minting anything.
-        if isinstance(minted, LookupError):
-            assert client.portal.call(live_tokens) == 0
-        else:
-            assert isinstance(minted, str)
+        # And nothing was minted on the way to refusing.
+        assert client.portal.call(live_tokens) == 0
 
 
 @pytest.mark.db

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -211,6 +211,7 @@ Three prerequisites, all of which fail as a hanging `execute-command` rather tha
 - `enableExecuteCommand` on the service.
 - `ssmmessages:CreateControlChannel`, `CreateDataChannel`, `OpenControlChannel` and `OpenDataChannel` on the **task role**, not the execution role.
 - A network path to SSM. The API tasks run in private subnets, so that is either NAT egress on 443 or an `ssmmessages` interface VPC endpoint the task security group can reach on 443.
+- On the operator's own machine: `ecs:ExecuteCommand` for that cluster, and the Session Manager plugin installed beside the AWS CLI. Without the plugin the command fails with `SessionManagerPlugin is not found`, which reads like a service problem and is not one.
 
 ```bash
 # Before: no session logging, because the recovery command prints a live credential.
@@ -220,13 +221,20 @@ aws ecs update-service --cluster potocolom --service api \
   --enable-execute-command --force-new-deployment
 aws ecs wait services-stable --cluster potocolom --services api
 
-# ... run the recovery command against a task from the new deployment ...
+# The setting applies to new tasks, and the agent starts a moment after the
+# task does. Check the task you are about to use, not the service.
+aws ecs describe-tasks --cluster potocolom --tasks <new-task-id> \
+  --query 'tasks[].{exec:enableExecuteCommand,
+                    agent:containers[?name==`api`].managedAgents[?name==`ExecuteCommandAgent`].lastStatus}'
+# exec: true, agent: RUNNING
+
+# ... run the recovery command against that task ...
 
 # After: close it again and put the cluster's logging back.
 aws ecs update-service --cluster potocolom --service api \
-  --no-enable-execute-command --force-new-deployment
+  --disable-execute-command --force-new-deployment
 aws ecs wait services-stable --cluster potocolom --services api
-aws ecs describe-tasks --cluster potocolom --tasks <new-task-id> \
+aws ecs describe-tasks --cluster potocolom --tasks <replacement-task-id> \
   --query 'tasks[].enableExecuteCommand'   # false on the replacements
 aws ecs update-cluster --cluster potocolom \
   --configuration 'executeCommandConfiguration={logging=DEFAULT}'

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -206,7 +206,7 @@ aws ecs execute-command --cluster potocolom --task <task-id> --container api --i
 
 ECS Exec is off between incidents, because a shell in the API task is a shell with the root key ring in its environment. Turning it on and off is a deployment each way: the setting applies to new tasks only.
 
-Three prerequisites, all of which fail as a hanging `execute-command` rather than a clear error:
+Four prerequisites. The first three fail as a hanging `execute-command` rather than a clear error; the fourth says what is wrong but not where:
 
 - `enableExecuteCommand` on the service.
 - `ssmmessages:CreateControlChannel`, `CreateDataChannel`, `OpenControlChannel` and `OpenDataChannel` on the **task role**, not the execution role.

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -202,17 +202,37 @@ aws ecs execute-command --cluster potocolom --task <task-id> --container api --i
 - `reclaim --claim` mints a fresh setup link and retires whatever was outstanding. It is refused while the install still has accounts: the setup link adopts the implicit local user, which the claim route allows only on an install nobody has claimed. On a running cloud installation `--restore` is the command.
 - `python -m app.recovery EMAIL` prints a one-use ten-minute password link for one administrator. It is printed and never mailed: a credential recoverable from a mailbox is only as strong as that mailbox.
 - `rotate-keys` moves stored secrets onto a new `ROOT_KEYS` entry; `rotate-keys --check` changes nothing and reports which older versions are still holding something. Put the new key at the front of the SSM parameter, roll the tasks so every replica can read both, rotate, check, and only then remove the old one.
-- `collapse` is not a cloud command. Turning accounts off on a multi-tenant install is not an operation with a sensible cloud meaning.
+- `collapse` has no sensible cloud meaning: turning accounts off on a multi-tenant install would destroy every customer's account and answer every request as an administrator. Nothing in the code stops it, and this is a policy rather than a guard: anybody who can open an ECS Exec session in the API task can run it, which is one more reason Exec stays off between incidents. If that is not tolerable for your installation, drop the confirmation phrase from an environment the task cannot read, or run the API image with the operator module removed.
 
-ECS Exec needs `enableExecuteCommand` on the service and `ssmmessages` permissions on the task role. Enabling it takes effect on new tasks only, so force a fresh deployment after turning it on:
+ECS Exec is off between incidents, because a shell in the API task is a shell with the root key ring in its environment. Turning it on and off is a deployment each way: the setting applies to new tasks only.
+
+Three prerequisites, all of which fail as a hanging `execute-command` rather than a clear error:
+
+- `enableExecuteCommand` on the service.
+- `ssmmessages:CreateControlChannel`, `CreateDataChannel`, `OpenControlChannel` and `OpenDataChannel` on the **task role**, not the execution role.
+- A network path to SSM. The API tasks run in private subnets, so that is either NAT egress on 443 or an `ssmmessages` interface VPC endpoint the task security group can reach on 443.
 
 ```bash
-aws ecs update-service --cluster potocolom --service api --enable-execute-command --force-new-deployment
+# Before: no session logging, because the recovery command prints a live credential.
+aws ecs update-cluster --cluster potocolom \
+  --configuration 'executeCommandConfiguration={logging=NONE}'
+aws ecs update-service --cluster potocolom --service api \
+  --enable-execute-command --force-new-deployment
+aws ecs wait services-stable --cluster potocolom --services api
+
+# ... run the recovery command against a task from the new deployment ...
+
+# After: close it again and put the cluster's logging back.
+aws ecs update-service --cluster potocolom --service api \
+  --no-enable-execute-command --force-new-deployment
+aws ecs wait services-stable --cluster potocolom --services api
+aws ecs describe-tasks --cluster potocolom --tasks <new-task-id> \
+  --query 'tasks[].enableExecuteCommand'   # false on the replacements
+aws ecs update-cluster --cluster potocolom \
+  --configuration 'executeCommandConfiguration={logging=DEFAULT}'
 ```
 
-Leave it off by default and turn it on for the incident. A shell in the API task is a shell with the root key ring in its environment.
-
-Set `executeCommandConfiguration.logging` to `NONE` on the cluster before running the recovery command. `python -m app.recovery EMAIL` prints a live one-use link to stdout, and ECS Exec's `DEFAULT` logging copies the session into the task's CloudWatch stream, where it sits for the retention period as a working credential anybody with log access can spend. The same goes for any restricted sink: whatever holds these sessions holds recovery links, and has to be treated as credential-bearing.
+`logging=NONE` comes first for a reason. `python -m app.recovery EMAIL` prints a live one-use link to stdout, and Exec's `DEFAULT` logging copies the session into the task's CloudWatch stream, where it sits for the retention period as a working credential anybody with log access can spend. Any other sink is the same: whatever holds these sessions holds recovery links and has to be treated as credential-bearing. Put the logging configuration back afterwards, or the next Exec session anybody opens for an unrelated reason goes unrecorded.
 
 ## 13. Go-live checklist
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -203,9 +203,10 @@ make auth-reclaim CLAIM=1                   # a fresh setup link; whoever spends
 make auth-configure                         # what mail and OAuth would do if the API started now
 ```
 
-`auth-reclaim CLAIM=1` is refused while the install still has accounts, because
-the setup link adopts the implicit local user and the claim route allows that
-only on an install nobody has claimed. `auth-recover` is for an administrator who forgot a password. `auth-reclaim EMAIL=`
+`auth-reclaim CLAIM=1` and `auth-enable` both refuse once the installation has
+been claimed, because the setup link adopts the implicit local user and the
+claim route allows that only while nobody holds an identity. A link minted for
+a claimed install would be refused the moment somebody spends it. `auth-recover` is for an administrator who forgot a password. `auth-reclaim EMAIL=`
 is for an install where every administrator was suspended, deleted or demoted at
 once and there is nobody left to press the button that would fix it. `CLAIM=1`
 mints a new setup link and retires whatever was outstanding, because whoever held

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -203,7 +203,9 @@ make auth-reclaim CLAIM=1                   # a fresh setup link; whoever spends
 make auth-configure                         # what mail and OAuth would do if the API started now
 ```
 
-`auth-recover` is for an administrator who forgot a password. `auth-reclaim EMAIL=`
+`auth-reclaim CLAIM=1` is refused while the install still has accounts, because
+the setup link adopts the implicit local user and the claim route allows that
+only on an install nobody has claimed. `auth-recover` is for an administrator who forgot a password. `auth-reclaim EMAIL=`
 is for an install where every administrator was suspended, deleted or demoted at
 once and there is nobody left to press the button that would fix it. `CLAIM=1`
 mints a new setup link and retires whatever was outstanding, because whoever held


### PR DESCRIPTION
# Description

CodeRabbit posted a second review round on #405 after that PR was merged. This is the rest of it.

# Motivation

I merged #405 while its review was still running and did not read what came back. Five findings, all valid.

# Functionality

- The offline reclaim checked that nobody held an identity, closed that transaction, and minted a setup link in another. A claim landing in the gap left an operator holding a link refused the moment they spend it. Both halves are one transaction now, behind an advisory lock that `POST /api/v1/auth/setup` takes as well.
- The cloud guide said `collapse` is not a cloud command, which reads as a guard. It is a policy: anybody who can open an ECS Exec session in the API task can run it. The guide says that outright now, and says what to do if it is not tolerable.
- ECS Exec from a private subnet needs NAT egress on 443 or an `ssmmessages` interface endpoint, and its permissions belong to the task role, not the execution role. Neither was documented, and both fail as a hanging command rather than an error.
- The recovery procedure turned session logging off and Exec on, and never put either back. The next Exec session anybody opens for an unrelated reason would then go unrecorded, with the shell still available.

# Details

The lock is the interesting half. `mint_setup_token` now takes an optional session so the check and the mint share one transaction; `claim()` takes the same lock, so the reclaim's check means something.

Two new tests, both neuter-checked: one that the reclaim is atomic, and one that the claim route actually waits on the lock, which is the half a test could easily fake by taking the lock itself.

`make verify` backend passes: 858 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved coordination between setup-token creation, installation claims, and recovery actions to prevent conflicting concurrent operations.
  - Setup claims now wait for recovery actions to complete, reducing invalid or stale setup links.
  - Setup-token creation and recovery are refused after an installation has been claimed.
  - Recovery operations now verify account state before issuing new setup links.

- **Documentation**
  - Expanded AWS recovery guidance, including ECS Exec requirements, networking, logging, and credential-retention warnings.
  - Clarified when installation setup claims are refused and how recovery options differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->