### PR TITLE
Candidate model profiling: SANA-Sprint, i2i sizing, and profiler VRAM guards

### DIFF
--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -204,15 +204,14 @@ Two candidate-specific traps, both `sana-sprint-06b`:
   defaults it to 4.5. The other distilled candidates default it to 0. Do not
   "correct" it to 0; that is not the no-CFG case, it is a different conditioning
   value.
-- Only 1024 px checkpoints exist, and the pipeline's `use_resolution_binning`
-  maps a smaller request onto the nearest 1024 bin, so the 512 and 768 rows are
-  binned rather than native and the model runs off its training resolution.
-  `_generate_i2i` used to compound this: it resized the source but passed no
-  width or height, and SanaSprint defaults both to 1024, so a 512 canvas frame
-  rendered at 1024 and allocated 4x the activations. That is what OOMed the
-  first run, at 4.50 GiB with the weights already resident. It now passes the
+- 1024 is the only resolution it has. `use_resolution_binning` maps a request
+  onto `ASPECT_RATIO_1024_BIN`, a 512x512 request bins to 1024x1024, and the
+  whole table holds no entry below 704x1344. There is no 512 or 768 checkpoint
+  either, so the manifest offers 1024 alone. `_generate_i2i` now passes the
   size to any pipeline whose signature accepts one, and omits it for SD and
-  SDXL img2img, which take no width/height and read the size off the source.
+  SDXL img2img which take neither, but that cannot defeat the binning: forcing
+  512 would need `use_resolution_binning=False` and would run the model off
+  the distribution it was trained on.
 
 ```bash
 # Latency + VRAM envelope per rung, no API needed (engine-direct):
@@ -224,6 +223,32 @@ worker/.venv/bin/python scripts/profile-candidates.py \
 make benchmark BENCHMARK_MODELS=flux2-klein-4b,z-image-turbo,sana-sprint-06b \
   BENCHMARK_QUICK=1
 ```
+
+### Measured: sana-sprint-06b does not beat vega-rt (2026-08-25)
+
+First numbers on the reference RX 7600 XT, `--memory-mode full`, weights cached,
+clear GPU:
+
+| Phase | Result |
+| --- | --- |
+| load | 13.39 s, rung `full`, 15.93 GB free before |
+| t2i 1024 / 2 steps / guidance 4.5 | **1469 ms median**, 1470 ms p95, peak 11.97 GB |
+| i2i (frame analog) | OOM: wanted 4.50 GiB with 14.79 GiB already resident |
+
+`vega-rt` is 219.8 ms p95 at 512 with TAESD and a 452 ms warm realtime frame.
+SANA-Sprint is **6.7x** the former and **3.2x** the latter, at a resolution it
+cannot go below. Even a hypothetical 4x saving at 512 lands near 367 ms, still
+no win, and 512 is not reachable for this model anyway. The DC-AE latent-token
+argument (a 1024 px image is a 32x32 latent against vega-rt's 64x64 at 512) did
+not survive contact with the hardware.
+
+The published 0.31 s on an RTX 4090 against 1469 ms here is a 4.7x gap, which is
+in the plausible range for the two cards and does not need another explanation.
+
+Second finding: image-to-image does not fit on this card at all. t2i peaks at
+11.97 GB, and i2i adds a VAE encode of the source on top, which is the 4.50 GiB
+that fails. So `sana-sprint-06b` stays `benchmark_only`, and is not a realtime
+candidate on 16 GB hardware. Retest only on a card with materially more VRAM.
 
 Promotion bar, same rule as #75/#84: measured frame-analog p95 under the
 500 ms realtime bar at 512 px plus acceptable i2i quality is what earns a

--- a/scripts/BENCHMARK.md
+++ b/scripts/BENCHMARK.md
@@ -137,6 +137,101 @@ make benchmark BENCHMARK_INCLUDE_CAPPED=1
 
 License obligations if you ever ship them to users: [docs/third-party-models.md](../docs/third-party-models.md).
 
+## Apache candidates under evaluation (2026-08)
+
+Research snapshot and full license analysis: local
+`.local/model-research-2026-08.md` (gitignored). All three candidates carry no
+revenue cap, no registration, and no attribution requirement, unlike every row
+above. `flux2-klein-4b` and `z-image-turbo` are Apache 2.0 end to end.
+`sana-sprint-06b` is Apache 2.0 for the weights and the code, but its
+Gemma-2-2B-IT text encoder is governed by the Google Gemma Terms of Use and
+Prohibited Use Policy: no revenue cap, but use restrictions in the RAIL mould.
+They ship as `benchmark_only: true` manifests and live in a `candidates` group
+in `benchmark-matrix.json`, reachable only through an explicit `--models`
+filter.
+
+| Model | Params | Steps | VRAM (manifest) | Notes |
+| --- | --- | --- | --- | --- |
+| **flux2-klein-4b** | 4B + Qwen3-4B encoder | 4 distilled | 13 GB BF16 | Unified FLUX.2 family; editing/i2i path deliberately not declared yet |
+| **z-image-turbo** | 6B S3-DiT | 8 NFEs | 20 GB BF16 (offload rung on a 16 GB card) | Photorealism focus; native img2img pipeline; no CFG |
+| **sana-sprint-06b** | 0.6B DiT + Gemma-2-2B-IT encoder | 1-4, step-adaptive | 10 GB BF16 | DC-AE 32x latent compression; linear attention; 1024 px checkpoints only |
+
+`sana-sprint-06b` additionally declares `"pipeline": "SanaSprint"`. The engine
+resolves a manifest's pipeline classes through `AutoPipelineFor*` by default,
+and diffusers 0.39 has no mapping entry for `SanaSprintPipeline`, so
+`AutoPipeline` raises for it while `ZImagePipeline` and `Flux2KleinPipeline`
+resolve fine. The stem names the class family, and the engine appends
+`Pipeline` and `Img2ImgPipeline`. `test_autopipeline_cannot_resolve_sana_sprint`
+guards the premise: when diffusers adds the mapping, that test fails and the
+override can be deleted.
+
+The other two are bf16-native flow transformers: their manifests declare
+`"dtype": "bfloat16"` so `_from_pretrained` loads them without the fp16 cast.
+The `dtype` manifest field is worker-side only and never crosses the wire.
+Their text encoders are Qwen3, not CLIP: the declared 512-token window matches
+the pipelines' `max_sequence_length` so the studio warns past it, and
+`_prompt_kwargs` lets diffusers encode whenever an encoder is outside the CLIP
+family instead of applying the CLIP chunker.
+
+Run these on a clear GPU, and never at the default `auto` memory mode on the
+reference card. On 2026-08-24 `profile-candidates.py --models flux2-klein-4b`
+at 1024 px ran for over four hours, produced no image, held 16.85 GB of a
+16 GB card that also drives the display, and wedged the amdgpu driver in an
+unkillable D state that only a reboot cleared. The rung is not decided once at
+load: `_demote_rung` slides `full -> model_offload -> group_offload` on OOM, so
+a model that picks `full` can still end up streaming every leaf module from
+disk mid-run. `profile-candidates.py` therefore defaults to
+`--memory-mode full`, which pins the rung so an oversized model raises instead
+of degrading, and it refuses outright if a run still lands on `group_offload`.
+One model failing no longer cancels the others in the same invocation.
+
+Declared `min_vram_gb` against roughly 16 GB free tells you what to expect:
+`sana-sprint-06b` (10) and `vega-rt` (8) select `full`, `z-image-turbo` (20)
+selects `model_offload`, and `flux2-klein-4b` (13) selects `full` but is the
+one that OOMed and degraded in practice.
+
+The profiler also checks free VRAM before each phase and skips that phase if
+under 2 GB remain. The engine's own guard cannot cover this: `_ensure_vram`
+sizes a model by `min_vram_gb`, which describes weights at rest with no term
+for resolution or activations, it only evicts and never refuses, and under a
+pinned `--memory-mode` it does not run at all. Phases are also banked as they
+complete, so a phase that still runs out of memory costs its own numbers
+rather than the whole model's.
+
+Two candidate-specific traps, both `sana-sprint-06b`:
+
+- `guidance` is the model's own embedded guidance, not CFG, so the manifest
+  defaults it to 4.5. The other distilled candidates default it to 0. Do not
+  "correct" it to 0; that is not the no-CFG case, it is a different conditioning
+  value.
+- Only 1024 px checkpoints exist, and the pipeline's `use_resolution_binning`
+  maps a smaller request onto the nearest 1024 bin, so the 512 and 768 rows are
+  binned rather than native and the model runs off its training resolution.
+  `_generate_i2i` used to compound this: it resized the source but passed no
+  width or height, and SanaSprint defaults both to 1024, so a 512 canvas frame
+  rendered at 1024 and allocated 4x the activations. That is what OOMed the
+  first run, at 4.50 GiB with the weights already resident. It now passes the
+  size to any pipeline whose signature accepts one, and omits it for SD and
+  SDXL img2img, which take no width/height and read the size off the source.
+
+```bash
+# Latency + VRAM envelope per rung, no API needed (engine-direct):
+worker/.venv/bin/python scripts/profile-candidates.py \
+  --models flux2-klein-4b,z-image-turbo,sana-sprint-06b \
+  --save-dir /tmp/candidate-samples
+
+# Queued-job quality suite through the running stack:
+make benchmark BENCHMARK_MODELS=flux2-klein-4b,z-image-turbo,sana-sprint-06b \
+  BENCHMARK_QUICK=1
+```
+
+Promotion bar, same rule as #75/#84: measured frame-analog p95 under the
+500 ms realtime bar at 512 px plus acceptable i2i quality is what earns a
+follow-up PR that flips capabilities to include `realtime` and re-measures
+`min_vram_gb`. For flux2-klein-4b that PR also decides the conditioning path
+(reference-image editing vs latent strength blending) before any `realtime`
+or `image_to_image` capability ships.
+
 ## Execution flow
 
 1. **Preflight** - `GET /api/v1/benchmark/gpu`. If any model is resident, abort

--- a/scripts/benchmark-matrix.json
+++ b/scripts/benchmark-matrix.json
@@ -153,12 +153,11 @@
       "id": "sana-sprint-06b",
       "license": "Apache 2.0",
       "commercial": "yes - unrestricted commercial use; Gemma-2-2B-IT text encoder adds Google Gemma Terms of Use and Prohibited Use Policy, no revenue cap",
-      "notes": "NVIDIA SANA-Sprint 0.6B, step-adaptive sCM at 1-4 steps, bf16-native, DC-AE 32x latent compression, Gemma-2-2B-IT encoder. guidance is the model's embedded guidance, not CFG, so it stays at the 4.5 default rather than 0. AutoPipeline cannot resolve it, so the manifest names the SanaSprint pipeline stem. Only 1024 px checkpoints exist and use_resolution_binning maps smaller requests onto the 1024 bin, so read the 512 and 768 rows as binned, not native. Reachable only via --models.",
+      "notes": "NVIDIA SANA-Sprint 0.6B, step-adaptive sCM at 1-4 steps, bf16-native, DC-AE 32x latent compression, Gemma-2-2B-IT encoder. guidance is the model's embedded guidance, not CFG, so it stays at the 4.5 default rather than 0. AutoPipeline cannot resolve it, so the manifest names the SanaSprint pipeline stem. MEASURED 2026-08-25 on the RX 7600 XT: 1469 ms median at 1024/2 t2i, peak 11.97 GB at the full rung. 1024 is the only resolution it has: ASPECT_RATIO_1024_BIN bins a 512 request back to 1024 and holds no entry below 704x1344. i2i at 1024 does not fit beside the resident weights on this card. Reachable only via --models.",
       "variants": [
         { "label": "1024-2step", "params": { "width": 1024, "height": 1024, "steps": 2, "guidance": 4.5, "seed": 100 } },
         { "label": "1024-1step", "params": { "width": 1024, "height": 1024, "steps": 1, "guidance": 4.5, "seed": 100 } },
         { "label": "1024-4step", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 4.5, "seed": 100 } },
-        { "label": "512-2step-binned", "params": { "width": 512, "height": 512, "steps": 2, "guidance": 4.5, "seed": 100 } },
         { "label": "1024-2step-alt-seed", "params": { "width": 1024, "height": 1024, "steps": 2, "guidance": 4.5, "seed": 200 } }
       ]
     }

--- a/scripts/benchmark-matrix.json
+++ b/scripts/benchmark-matrix.json
@@ -122,6 +122,47 @@
       ]
     }
   ],
+  "candidates": [
+    {
+      "id": "flux2-klein-4b",
+      "license": "Apache 2.0",
+      "commercial": "yes - unrestricted commercial use",
+      "notes": "FLUX.2 klein 4B, 4-step distilled flow transformer, bf16-native; unified generation and editing family (editing path not wired yet). Reachable only via --models.",
+      "variants": [
+        { "label": "1024-4step", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 0, "seed": 100 } },
+        { "label": "512-4step", "params": { "width": 512, "height": 512, "steps": 4, "guidance": 0, "seed": 100 } },
+        { "label": "768-4step", "params": { "width": 768, "height": 768, "steps": 4, "guidance": 0, "seed": 100 } },
+        { "label": "1024-8step", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 100 } },
+        { "label": "1024-4step-alt-seed", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 0, "seed": 200 } }
+      ]
+    },
+    {
+      "id": "z-image-turbo",
+      "license": "Apache 2.0",
+      "commercial": "yes - unrestricted commercial use",
+      "notes": "Tongyi-MAI Z-Image Turbo, 6B S3-DiT at 8 NFEs, bf16-native, no CFG in the distilled variant. Reachable only via --models.",
+      "variants": [
+        { "label": "1024-8step", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 100 } },
+        { "label": "512-8step", "params": { "width": 512, "height": 512, "steps": 8, "guidance": 0, "seed": 100 } },
+        { "label": "768-8step", "params": { "width": 768, "height": 768, "steps": 8, "guidance": 0, "seed": 100 } },
+        { "label": "1024-8step-alt-seed", "params": { "width": 1024, "height": 1024, "steps": 8, "guidance": 0, "seed": 200 } },
+        { "label": "1024-4step", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 0, "seed": 100 } }
+      ]
+    },
+    {
+      "id": "sana-sprint-06b",
+      "license": "Apache 2.0",
+      "commercial": "yes - unrestricted commercial use; Gemma-2-2B-IT text encoder adds Google Gemma Terms of Use and Prohibited Use Policy, no revenue cap",
+      "notes": "NVIDIA SANA-Sprint 0.6B, step-adaptive sCM at 1-4 steps, bf16-native, DC-AE 32x latent compression, Gemma-2-2B-IT encoder. guidance is the model's embedded guidance, not CFG, so it stays at the 4.5 default rather than 0. AutoPipeline cannot resolve it, so the manifest names the SanaSprint pipeline stem. Only 1024 px checkpoints exist and use_resolution_binning maps smaller requests onto the 1024 bin, so read the 512 and 768 rows as binned, not native. Reachable only via --models.",
+      "variants": [
+        { "label": "1024-2step", "params": { "width": 1024, "height": 1024, "steps": 2, "guidance": 4.5, "seed": 100 } },
+        { "label": "1024-1step", "params": { "width": 1024, "height": 1024, "steps": 1, "guidance": 4.5, "seed": 100 } },
+        { "label": "1024-4step", "params": { "width": 1024, "height": 1024, "steps": 4, "guidance": 4.5, "seed": 100 } },
+        { "label": "512-2step-binned", "params": { "width": 512, "height": 512, "steps": 2, "guidance": 4.5, "seed": 100 } },
+        { "label": "1024-2step-alt-seed", "params": { "width": 1024, "height": 1024, "steps": 2, "guidance": 4.5, "seed": 200 } }
+      ]
+    }
+  ],
   "excluded": [
     {
       "id": "sd-turbo",

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -70,9 +70,10 @@ def load_matrix(model_filter: list[str] | None, quick: bool, include_capped: boo
                 matrix_path: Path = MATRIX_PATH) -> dict:
     matrix = json.loads(matrix_path.read_text())
     capped = matrix.get("capped_commercial", [])
+    candidates = matrix.get("candidates", [])
     if model_filter:
         wanted = set(model_filter)
-        pool = matrix["models"] + capped
+        pool = matrix["models"] + capped + candidates
         models = [m for m in pool if m["id"] in wanted]
         missing = wanted - {m["id"] for m in models}
         if missing:

--- a/scripts/profile-candidates.py
+++ b/scripts/profile-candidates.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Candidate-model latency and VRAM envelope through DiffusersEngine.
+
+Companion to profile-realtime-frame.py for manifests that cannot enter
+engine.frame() yet because they declare no t2i_adapter. Times engine.generate()
+the way queued jobs run it (t2i at the manifest default, i2i at 512 px), then
+repeats 512 px i2i as the canvas-tick analog, collecting torch peak memory per
+phase so rung decisions have numbers. Not CI.
+
+Defaults to --memory-mode full: a model that does not fit raises instead of
+sliding down the ladder, because the group_offload rung streams every leaf
+module from disk per step and on a card that also drives the display it makes
+no progress while holding all the VRAM. One model failing no longer cancels
+the rest of the run.
+
+  worker/.venv/bin/python scripts/profile-candidates.py \
+      --models flux2-klein-4b,z-image-turbo,sana-sprint-06b
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import io
+import json
+import os
+import statistics
+import sys
+import time
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "worker"))
+
+GB = 1024**3
+
+# Free VRAM a phase wants before it starts. The engine's own guard sizes a
+# model's weights at rest (min_vram_gb) and can only evict, never refuse, so
+# nothing upstream sees the activations a single call needs: sana-sprint-06b
+# asked for 4.50 GiB of them after its weights were already resident.
+PHASE_HEADROOM_GB = 2.0
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(1, int(round(pct / 100.0 * len(ordered) + 0.5)))
+    return ordered[min(len(ordered), rank) - 1]
+
+
+def canvas_bytes(size: int = 512) -> bytes:
+    image = Image.new("RGB", (size, size), "white")
+    pen = ImageDraw.Draw(image)
+    pen.line(
+        [(10, size * 0.4), (size * 0.3, size * 0.27),
+         (size * 0.6, size * 0.35), (size - 10, size * 0.29)],
+        fill=(17, 24, 39),
+        width=5,
+    )
+    pen.ellipse(
+        [(size * 0.3, size * 0.6), (size * 0.7, size * 0.75)],
+        outline=(17, 24, 39),
+        width=5,
+    )
+    buffer = io.BytesIO()
+    image.save(buffer, "PNG")
+    return buffer.getvalue()
+
+
+def schema_default(manifest, key: str, fallback):
+    return manifest.parameters.get("properties", {}).get(key, {}).get("default", fallback)
+
+
+async def run_phase(engine, torch, manifest, label: str, params: dict,
+                    samples: int, input_image: bytes | None = None,
+                    save_path: Path | None = None) -> dict:
+
+    def progress(_fraction: float) -> None:
+        pass
+
+    await engine.generate(manifest, dict(params), progress, input_image=input_image)
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+    gpu_ms: list[int] = []
+    wall_ms: list[float] = []
+    for _ in range(samples):
+        started = time.perf_counter()
+        result = await engine.generate(
+            manifest, dict(params), progress, input_image=input_image)
+        wall_ms.append((time.perf_counter() - started) * 1000.0)
+        gpu_ms.append(result.gpu_ms)
+        if save_path is not None:
+            save_path.write_bytes(result.data)
+            save_path = None
+    phase = {
+        "label": label,
+        "params": {k: v for k, v in params.items() if k != "prompt"},
+        "samples": samples,
+        "gpu_median_ms": statistics.median(gpu_ms),
+        "gpu_p95_ms": percentile([float(v) for v in gpu_ms], 95.0),
+        "wall_p95_ms": percentile(wall_ms, 95.0),
+        "peak_gb": round(torch.cuda.max_memory_allocated() / GB, 2)
+        if torch.cuda.is_available() else None,
+    }
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats()
+    return phase
+
+
+async def profile_model(device: str, models_dir: str, manifest,
+                        samples: int, prompt: str, seed: int,
+                        save_dir: Path | None, memory_mode: str = "full") -> dict:
+    os.environ.setdefault("TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL", "1")
+    import torch
+
+    from worker.engine import DiffusersEngine
+
+    engine = DiffusersEngine(device, memory_mode=memory_mode, models_dir=models_dir)
+    case: dict = {"model": manifest.id}
+    if torch.cuda.is_available():
+        free, _total = torch.cuda.mem_get_info()
+        case["free_before_gb"] = round(free / GB, 2)
+    started = time.perf_counter()
+    await engine.load_model(manifest)
+    case["load_s"] = round(time.perf_counter() - started, 2)
+    case["rung"] = engine.model_rung(manifest.id)
+    if case["rung"] == "group_offload":
+        await engine.unload_all()
+        case["skipped"] = (
+            "group_offload streams every leaf module from disk per step. On a "
+            "card that also drives the display this produces no image, holds "
+            "the whole VRAM and wedges the driver. Refusing to run it."
+        )
+        return case
+
+    default_width = int(schema_default(manifest, "width", 1024))
+    t2i_params = {
+        "prompt": prompt,
+        "steps": int(schema_default(manifest, "steps", 4)),
+        "guidance": float(schema_default(manifest, "guidance", 0)),
+        "width": default_width,
+        "height": default_width,
+        "seed": seed,
+    }
+    case["phases"] = []
+
+    async def phase(label: str, params: dict, **kwargs) -> None:
+        # Each phase is banked as it completes. A later phase that runs out of
+        # memory then costs its own numbers, not the whole model's: the first
+        # sana-sprint-06b run measured t2i and threw it away when i2i OOMed.
+        if torch.cuda.is_available():
+            free, _total = torch.cuda.mem_get_info()
+            if free < PHASE_HEADROOM_GB * GB:
+                case["phases"].append({
+                    "label": label,
+                    "skipped": f"only {free / GB:.2f} GB free, want "
+                               f"{PHASE_HEADROOM_GB:.2f} GB before starting a phase",
+                })
+                return
+        try:
+            case["phases"].append(await run_phase(
+                engine, torch, manifest, label, params, samples, **kwargs))
+        except Exception as error:
+            case["phases"].append(
+                {"label": label, "failed": f"{type(error).__name__}: {error}"})
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    await phase(
+        f"t2i-{default_width}", t2i_params,
+        save_path=save_dir / f"{manifest.id}-t2i.png" if save_dir else None,
+    )
+
+    small = dict(t2i_params, width=512, height=512)
+    if "image_to_image" in manifest.capabilities:
+        i2i_params = dict(small, strength=float(schema_default(manifest, "strength", 0.7)))
+        await phase(
+            "i2i-512-frame-analog", i2i_params, input_image=canvas_bytes(),
+            save_path=save_dir / f"{manifest.id}-i2i.png" if save_dir else None,
+        )
+    else:
+        await phase("t2i-512", small)
+
+    await engine.unload_all()
+    if torch.cuda.is_available():
+        free_after, _total = torch.cuda.mem_get_info()
+        case["free_after_gb"] = round(free_after / GB, 2)
+    return case
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--models-dir", default=str(ROOT / "worker" / "models"))
+    parser.add_argument("--device", default="rocm", choices=("rocm", "cuda", "cpu"))
+    parser.add_argument(
+        "--models", default="flux2-klein-4b,z-image-turbo,sana-sprint-06b")
+    parser.add_argument("--samples", type=int, default=8)
+    parser.add_argument("--prompt", default="a red cube on a table, studio light")
+    parser.add_argument("--out", default="")
+    parser.add_argument("--save-dir", default="")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--memory-mode", default="full",
+        choices=("full", "auto", "model_offload", "group_offload"),
+    )
+    args = parser.parse_args()
+    from worker.manifests import load_manifests
+
+    if args.samples <= 0:
+        raise SystemExit("--samples must be positive")
+
+    manifests = {m.id: m for m in load_manifests(args.models_dir)}
+    wanted = [item.strip() for item in args.models.split(",") if item.strip()]
+    missing = [item for item in wanted if item not in manifests]
+    if missing:
+        raise SystemExit(f"unknown models: {missing}")
+    save_dir = Path(args.save_dir) if args.save_dir else None
+    if save_dir is not None:
+        save_dir.mkdir(parents=True, exist_ok=True)
+    cases = []
+    for model_id in wanted:
+        try:
+            cases.append(asyncio.run(profile_model(
+                args.device, args.models_dir, manifests[model_id], args.samples,
+                args.prompt, args.seed, save_dir, args.memory_mode,
+            )))
+        except Exception as error:
+            cases.append({"model": model_id, "failed": f"{type(error).__name__}: {error}"})
+    text = json.dumps({"cases": cases}, indent=2)
+    print(text)
+    if args.out:
+        Path(args.out).write_text(text + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/worker/models/flux2-klein-4b.json
+++ b/worker/models/flux2-klein-4b.json
@@ -1,0 +1,24 @@
+{
+  "id": "flux2-klein-4b",
+  "name": "FLUX.2 Klein 4B",
+  "capabilities": ["text_to_image"],
+  "min_vram_gb": 13,
+  "prompt_token_limit": 512,
+  "source": "black-forest-labs/FLUX.2-klein-4B",
+  "dtype": "bfloat16",
+  "license_id": "apache-2.0",
+  "license_url": "https://huggingface.co/black-forest-labs/FLUX.2-klein-4B/blob/main/README.md",
+  "benchmark_only": true,
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "prompt": { "type": "string" },
+      "steps": { "type": "integer", "minimum": 1, "maximum": 8, "default": 4 },
+      "guidance": { "type": "number", "minimum": 0, "maximum": 10, "default": 0 },
+      "seed": { "type": "integer" },
+      "width": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 },
+      "height": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 }
+    },
+    "required": ["prompt"]
+  }
+}

--- a/worker/models/sana-sprint-06b.json
+++ b/worker/models/sana-sprint-06b.json
@@ -1,0 +1,26 @@
+{
+  "id": "sana-sprint-06b",
+  "name": "SANA-Sprint 0.6B",
+  "capabilities": ["text_to_image", "image_to_image"],
+  "min_vram_gb": 10,
+  "prompt_token_limit": 300,
+  "source": "Efficient-Large-Model/Sana_Sprint_0.6B_1024px_diffusers",
+  "dtype": "bfloat16",
+  "pipeline": "SanaSprint",
+  "license_id": "apache-2.0",
+  "license_url": "https://huggingface.co/Efficient-Large-Model/Sana_Sprint_0.6B_1024px_diffusers/blob/main/README.md",
+  "benchmark_only": true,
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "prompt": { "type": "string" },
+      "strength": { "type": "number", "minimum": 0.05, "maximum": 1, "default": 0.6 },
+      "steps": { "type": "integer", "minimum": 1, "maximum": 4, "default": 2 },
+      "guidance": { "type": "number", "minimum": 0, "maximum": 10, "default": 4.5 },
+      "seed": { "type": "integer" },
+      "width": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 },
+      "height": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 }
+    },
+    "required": ["prompt"]
+  }
+}

--- a/worker/models/sana-sprint-06b.json
+++ b/worker/models/sana-sprint-06b.json
@@ -1,8 +1,11 @@
 {
   "id": "sana-sprint-06b",
   "name": "SANA-Sprint 0.6B",
-  "capabilities": ["text_to_image", "image_to_image"],
-  "min_vram_gb": 10,
+  "capabilities": [
+    "text_to_image",
+    "image_to_image"
+  ],
+  "min_vram_gb": 12,
   "prompt_token_limit": 300,
   "source": "Efficient-Large-Model/Sana_Sprint_0.6B_1024px_diffusers",
   "dtype": "bfloat16",
@@ -13,14 +16,47 @@
   "parameters": {
     "type": "object",
     "properties": {
-      "prompt": { "type": "string" },
-      "strength": { "type": "number", "minimum": 0.05, "maximum": 1, "default": 0.6 },
-      "steps": { "type": "integer", "minimum": 1, "maximum": 4, "default": 2 },
-      "guidance": { "type": "number", "minimum": 0, "maximum": 10, "default": 4.5 },
-      "seed": { "type": "integer" },
-      "width": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 },
-      "height": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 }
+      "prompt": {
+        "type": "string"
+      },
+      "strength": {
+        "type": "number",
+        "minimum": 0.05,
+        "maximum": 1,
+        "default": 0.6
+      },
+      "steps": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 4,
+        "default": 2
+      },
+      "guidance": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 10,
+        "default": 4.5
+      },
+      "seed": {
+        "type": "integer"
+      },
+      "width": {
+        "type": "integer",
+        "enum": [
+          1024
+        ],
+        "default": 1024
+      },
+      "height": {
+        "type": "integer",
+        "enum": [
+          1024
+        ],
+        "default": 1024
+      }
     },
-    "required": ["prompt"]
+    "required": [
+      "prompt"
+    ]
   }
 }

--- a/worker/models/z-image-turbo.json
+++ b/worker/models/z-image-turbo.json
@@ -1,0 +1,25 @@
+{
+  "id": "z-image-turbo",
+  "name": "Z-Image Turbo",
+  "capabilities": ["text_to_image", "image_to_image"],
+  "min_vram_gb": 20,
+  "prompt_token_limit": 512,
+  "source": "Tongyi-MAI/Z-Image-Turbo",
+  "dtype": "bfloat16",
+  "license_id": "apache-2.0",
+  "license_url": "https://huggingface.co/Tongyi-MAI/Z-Image-Turbo/blob/main/LICENSE.txt",
+  "benchmark_only": true,
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "prompt": { "type": "string" },
+      "strength": { "type": "number", "minimum": 0.05, "maximum": 1, "default": 0.7 },
+      "steps": { "type": "integer", "minimum": 4, "maximum": 8, "default": 8 },
+      "guidance": { "type": "number", "minimum": 0, "maximum": 8, "default": 0 },
+      "seed": { "type": "integer" },
+      "width": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 },
+      "height": { "type": "integer", "enum": [512, 768, 1024], "default": 1024 }
+    },
+    "required": ["prompt"]
+  }
+}

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -413,6 +413,18 @@ def test_third_text_encoder_keeps_pipeline_prompt_path():
     assert pipeline.text_encoder_2.calls == 0
 
 
+def test_non_clip_text_encoder_keeps_pipeline_prompt_path():
+    engine = _fake_prompt_engine()
+    pipeline = _fake_pipeline()
+    pipeline.text_encoder.config = SimpleNamespace(model_type="qwen3")
+    prompt = " ".join(f"w{index}" for index in range(80))
+
+    kwargs = engine._prompt_kwargs(pipeline, _clip_manifest(), prompt, "w0")
+
+    assert kwargs == {"prompt": prompt, "negative_prompt": "w0"}
+    assert pipeline.text_encoder.calls == 0
+
+
 def test_fake_tokenizer_only_offers_what_a_real_one_does():
     """The chunking code is exercised above against a fake tokenizer, which can
     drift from the library and hide a crash. It already did once: the fake
@@ -579,6 +591,50 @@ def test_generate_i2i_job_passes_negative_prompt_to_pipeline():
     )
     assert result.width == 64
     assert result.height == 48
+
+
+def test_generate_i2i_omits_size_for_pipelines_that_infer_it():
+    """SD and SDXL img2img take no width/height and read the size off the source
+    image. Passing them would raise, so the resized source stays the only signal."""
+    pipeline = _JobPipeline(dual=True)
+    engine = _job_engine(pipeline)
+    loop = asyncio.new_event_loop()
+    try:
+        engine._generate_i2i(
+            _sdxl_job_manifest(),
+            {"prompt": "w0 w1", "width": 512, "height": 512},
+            lambda _: None, loop, _input_image_bytes(),
+        )
+    finally:
+        loop.close()
+
+    assert "width" not in pipeline.call_kwargs[0]
+    assert "height" not in pipeline.call_kwargs[0]
+
+
+def test_generate_i2i_passes_size_to_pipelines_that_default_it():
+    """SanaSprint img2img defaults width/height to its 1024 training resolution
+    and ignores the source size, so a 512 canvas frame would silently render at
+    1024 and allocate 4x the activations (the sana-sprint-06b OOM)."""
+
+    class _SizedPipeline(_JobPipeline):
+        def __call__(self, width=None, height=None, **kwargs):
+            return super().__call__(width=width, height=height, **kwargs)
+
+    pipeline = _SizedPipeline(dual=True)
+    engine = _job_engine(pipeline)
+    loop = asyncio.new_event_loop()
+    try:
+        engine._generate_i2i(
+            _sdxl_job_manifest(),
+            {"prompt": "w0 w1", "width": 512, "height": 512},
+            lambda _: None, loop, _input_image_bytes(),
+        )
+    finally:
+        loop.close()
+
+    assert pipeline.call_kwargs[0]["width"] == 512
+    assert pipeline.call_kwargs[0]["height"] == 512
 
 
 def test_sdxl_pooled_embedding_comes_from_first_chunk():
@@ -2728,3 +2784,91 @@ def test_a_simulated_upscale_stops_when_it_is_asked_to():
     finished = asyncio.run(engine.generate(manifest, {"factor": 2}, lambda _: None,
                                            input_image=source, cancelled=lambda: False))
     assert (finished.width, finished.height) == (16, 16)
+def test_pipeline_dtype_defaults_to_engine_dtype():
+    import torch
+
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = torch
+    engine.dtype = torch.float16
+    manifest = Manifest(id="plain", name="Plain", capabilities=["text_to_image"])
+    assert engine._pipeline_dtype(manifest) is torch.float16
+
+
+def test_pipeline_dtype_prefers_the_manifest_declaration():
+    import torch
+
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = torch
+    engine.dtype = torch.float16
+    manifest = Manifest(
+        id="declared", name="Declared", capabilities=["text_to_image"],
+        dtype="bfloat16",
+    )
+    assert engine._pipeline_dtype(manifest) is torch.bfloat16
+
+
+def test_pipeline_class_defaults_to_autopipeline():
+    from diffusers import AutoPipelineForImage2Image, AutoPipelineForText2Image
+
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    manifest = Manifest(id="plain", name="Plain", capabilities=["text_to_image"])
+    assert engine._pipeline_class(manifest, "t2i") is AutoPipelineForText2Image
+    assert engine._pipeline_class(manifest, "i2i") is AutoPipelineForImage2Image
+
+
+def test_pipeline_class_honours_the_manifest_stem():
+    from diffusers import SanaSprintImg2ImgPipeline, SanaSprintPipeline
+
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    manifest = Manifest(
+        id="sprint", name="Sprint", capabilities=["text_to_image", "image_to_image"],
+        pipeline="SanaSprint",
+    )
+    assert engine._pipeline_class(manifest, "t2i") is SanaSprintPipeline
+    assert engine._pipeline_class(manifest, "i2i") is SanaSprintImg2ImgPipeline
+
+
+def test_pipeline_class_is_loud_when_diffusers_lacks_the_class():
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    manifest = Manifest(
+        id="ghost", name="Ghost", capabilities=["text_to_image"], pipeline="NoSuch",
+    )
+    pytest = __import__("pytest")
+    with pytest.raises(ValueError, match="NoSuchPipeline"):
+        engine._pipeline_class(manifest, "t2i")
+
+
+def test_autopipeline_cannot_resolve_sana_sprint():
+    from diffusers.pipelines.auto_pipeline import (
+        AUTO_TEXT2IMAGE_PIPELINES_MAPPING,
+        _get_task_class,
+    )
+
+    pytest = __import__("pytest")
+    with pytest.raises(ValueError):
+        _get_task_class(AUTO_TEXT2IMAGE_PIPELINES_MAPPING, "SanaSprintPipeline")
+
+
+def test_from_pretrained_loads_in_declared_dtype_without_fp16_variant():
+    import torch
+
+    calls: list[tuple[str, dict]] = []
+
+    class FakeRepo:
+        @classmethod
+        def from_pretrained(cls, source, **kwargs):
+            calls.append((source, kwargs))
+            return object()
+
+    engine = DiffusersEngine.__new__(DiffusersEngine)
+    engine.torch = torch
+    engine.dtype = torch.float16
+    manifest = Manifest(
+        id="klein", name="Klein", capabilities=["text_to_image"],
+        source="black-forest-labs/FLUX.2-klein-4B", dtype="bfloat16",
+    )
+    engine._from_pretrained(FakeRepo, manifest)
+    ((source, kwargs),) = calls
+    assert source == "black-forest-labs/FLUX.2-klein-4B"
+    assert kwargs["torch_dtype"] is torch.bfloat16
+    assert "variant" not in kwargs

--- a/worker/tests/test_manifests.py
+++ b/worker/tests/test_manifests.py
@@ -221,3 +221,44 @@ def test_min_vram_gb_is_bounded_where_the_operator_sees_it(tmp_path):
         "source": "x/y", "min_vram_gb": 12,
     }))
     assert load_manifests(str(tmp_path))[0].min_vram_gb == 12
+
+
+def test_dtype_round_trips_and_stays_worker_side():
+    manifest = Manifest(**{**SD_TURBO, "dtype": "bfloat16"})
+    assert manifest.dtype == "bfloat16"
+    assert "dtype" not in manifest.wire()
+
+
+def test_unknown_dtype_is_loud():
+    with pytest.raises(ValidationError):
+        Manifest(**{**SD_TURBO, "dtype": "fp8"})
+
+
+def test_pipeline_round_trips_and_stays_worker_side():
+    manifest = Manifest(**{**SD_TURBO, "pipeline": "SanaSprint"})
+    assert manifest.pipeline == "SanaSprint"
+    assert "pipeline" not in manifest.wire()
+
+
+def test_pipeline_defaults_to_empty_so_autopipeline_still_applies():
+    assert Manifest(**SD_TURBO).pipeline == ""
+
+
+@pytest.mark.parametrize("value", ["sanaSprint", "Sana_Sprint", "Sana Sprint", "1Sana"])
+def test_unknown_pipeline_stem_is_loud(value):
+    with pytest.raises(ValidationError):
+        Manifest(**{**SD_TURBO, "pipeline": value})
+
+
+CANDIDATE_MANIFESTS = ("flux2-klein-4b", "z-image-turbo", "sana-sprint-06b")
+
+
+@pytest.mark.parametrize("model_id", CANDIDATE_MANIFESTS)
+def test_shipped_candidate_manifests_are_apache_benchmark_only(model_id):
+    path = Path(__file__).resolve().parents[1] / "models" / f"{model_id}.json"
+    manifest = Manifest.model_validate_json(path.read_text())
+    assert manifest.benchmark_only is True
+    assert manifest.license_id == "apache-2.0"
+    assert manifest.dtype == "bfloat16"
+    assert manifest.commercial_max_revenue_usd is None
+    assert "realtime" not in manifest.capabilities

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -10,6 +10,7 @@ inference thread directly.
 
 import asyncio
 import contextlib
+import inspect
 import io
 import math
 import os
@@ -761,9 +762,7 @@ class DiffusersEngine:
                     f"manifest {manifest.id} has no t2i_adapter for realtime conditioning"
                 )
             return self._load_realtime(manifest)
-        from diffusers import AutoPipelineForImage2Image, AutoPipelineForText2Image
-
-        cls = AutoPipelineForText2Image if mode == "t2i" else AutoPipelineForImage2Image
+        cls = self._pipeline_class(manifest, mode)
         loaded = self._pipelines.get((manifest.id, "i2i" if mode == "t2i" else "t2i"))
         if loaded is not None:
             pipeline = cls.from_pipe(loaded)  # shares weights already on the device
@@ -1609,17 +1608,41 @@ class DiffusersEngine:
         async with self._gpu:
             await self._run_to_completion(self._evict_all)
 
+    def _pipeline_class(self, manifest: Manifest, mode: str) -> Any:
+        import diffusers
+
+        if not manifest.pipeline:
+            return (
+                diffusers.AutoPipelineForText2Image if mode == "t2i"
+                else diffusers.AutoPipelineForImage2Image
+            )
+        suffix = "Pipeline" if mode == "t2i" else "Img2ImgPipeline"
+        name = f"{manifest.pipeline}{suffix}"
+        cls = getattr(diffusers, name, None)
+        if cls is None:
+            raise ValueError(
+                f"manifest {manifest.id}: diffusers has no pipeline class {name}"
+            )
+        return cls
+
+    def _pipeline_dtype(self, manifest: Manifest) -> Any:
+        declared = manifest.dtype
+        if declared:
+            return getattr(self.torch, declared)
+        return self.dtype
+
     def _from_pretrained(self, cls: Any, manifest: Manifest) -> Any:
         source = manifest.source or manifest.id
-        kwargs: dict[str, Any] = {"torch_dtype": self.dtype}
+        dtype = self._pipeline_dtype(manifest)
+        kwargs: dict[str, Any] = {"torch_dtype": dtype}
         if manifest.vae:
             from diffusers import AutoencoderKL
 
             # SDXL's stock VAE upcasts itself to fp32 at decode time (fp16
             # overflows), which spikes VRAM past a 16 GB card; manifests name
             # an fp16-safe replacement instead.
-            kwargs["vae"] = AutoencoderKL.from_pretrained(manifest.vae, torch_dtype=self.dtype)
-        if self.dtype is self.torch.float16:
+            kwargs["vae"] = AutoencoderKL.from_pretrained(manifest.vae, torch_dtype=dtype)
+        if dtype is self.torch.float16:
             try:
                 # fp16 variants halve the download and the disk footprint;
                 # not every repository ships one.
@@ -1710,6 +1733,19 @@ class DiffusersEngine:
         ):
             # SD3 requires joint CLIP+T5 prompt embeddings. This CLIP-only
             # chunker cannot satisfy that contract, so let diffusers encode it.
+            return prompt_kwargs
+
+        encoder_model_types = {
+            str(getattr(getattr(encoder, "config", None), "model_type", ""))
+            for encoder in (getattr(pipeline, "text_encoder", None),
+                            getattr(pipeline, "text_encoder_2", None))
+            if encoder is not None
+        }
+        if not encoder_model_types <= {"", "clip"}:
+            # The declared window still feeds the studio warning, but encoders
+            # outside the CLIP family need their own embedding recipe (Qwen3
+            # concatenates hidden layers), so manual chunking would corrupt
+            # the conditioning. Let diffusers encode it.
             return prompt_kwargs
 
         tokenizer_2 = getattr(pipeline, "tokenizer_2", None)
@@ -1932,8 +1968,16 @@ class DiffusersEngine:
         source = decode_input_image(input_image)
         width = params.get("width")
         height = params.get("height")
+        size_kwargs: dict[str, int] = {}
         if width and height:
             source = source.resize((int(width), int(height)), Image.Resampling.LANCZOS)
+            # SD and SDXL img2img take the output size from the source image and
+            # accept no width/height at all. Newer DiT pipelines default to their
+            # training resolution instead (SanaSprint to 1024), so resizing the
+            # source is not enough: without these they upsize the request back to
+            # 1024 and a 512 canvas frame allocates 4x the activations it should.
+            if "width" in inspect.signature(pipeline.__call__).parameters:
+                size_kwargs = {"width": int(width), "height": int(height)}
         steps = max(1, int(params.get("steps", 2)))
         strength = min(max(float(params.get("strength", 0.75)), 0.05), 1.0)
         # diffusers img2img floors the step count: int(steps * strength).
@@ -1958,6 +2002,7 @@ class DiffusersEngine:
         start = time.monotonic()
         image = pipeline(
             **prompt_kwargs,
+            **size_kwargs,
             image=source,
             num_inference_steps=steps,
             strength=strength,

--- a/worker/worker/manifests.py
+++ b/worker/worker/manifests.py
@@ -38,6 +38,14 @@ class Manifest(BaseModel):
         default="",
         pattern=r"^(?:[A-Za-z_][A-Za-z0-9_]*:int8)?$",
     )  # optional component:scheme, worker side only
+    # Torch dtype override for architectures whose checkpoints are trained in
+    # bfloat16 and degrade when cast to the worker's fp16 default. Empty means
+    # the engine default applies. Worker side only.
+    dtype: str = Field(default="", pattern=r"^(?:float16|bfloat16|float32)?$")
+    # Diffusers pipeline class stem for architectures AutoPipeline cannot
+    # resolve. "SanaSprint" selects SanaSprintPipeline and
+    # SanaSprintImg2ImgPipeline. Empty means AutoPipeline. Worker side only.
+    pipeline: str = Field(default="", pattern=r"^(?:[A-Z][A-Za-z0-9]*)?$")
     license_id: str = ""  # e.g. stability-ai-community, apache-2.0
     license_url: str = ""
     commercial_max_revenue_usd: int | None = None  # None = no cap
@@ -52,7 +60,7 @@ class Manifest(BaseModel):
     def wire(self) -> dict:
         return self.model_dump(exclude={
             "source", "vae", "preview_decoder", "scheduler", "lora", "quantize",
-            "t2i_adapter",
+            "t2i_adapter", "dtype", "pipeline",
         })
 
     def with_defaults(self, params: dict) -> dict:


### PR DESCRIPTION
# Description

Wires three Apache-licensed candidate models for benchmarking, adds the two manifest fields they need, and fixes an image-to-image sizing bug that made a 512 px request render at 1024.

Nothing here is offered to users. All three manifests are `benchmark_only: true` and sit in a `candidates` group reachable only through an explicit `--models` filter.

# Motivation

`vega-rt` is the shipped realtime model at 512 px and 2 steps. Measuring whether anything newer beats it needs candidates that clear the licence bar and fit a 16 GB card. Three do: FLUX.2 klein 4B, Z-Image Turbo, and SANA-Sprint 0.6B, all Apache 2.0 on the weights with no revenue cap.

The i2i fix is separate and matters beyond benchmarking. `_generate_i2i` resized the source image but passed no width or height to the pipeline. That is correct for SD and SDXL img2img, whose `__call__` accepts neither and reads the output size off the source. It is wrong for newer DiT pipelines: `SanaSprintImg2ImgPipeline` defaults both to 1024, its training resolution, and ignores the source size. A 512 px canvas frame therefore rendered at 1024 and allocated four times the activations it should, which ran the card out of memory.

# Functionality

No behaviour change for any shipped model.

The size now goes through whenever the pipeline's signature accepts it, and is omitted when it does not. Measured rather than assumed:

| Pipeline | `width` / `height` |
| --- | --- |
| `StableDiffusionXLImg2ImgPipeline` | absent, size comes from the source |
| `StableDiffusionImg2ImgPipeline` | absent |
| `SanaSprintImg2ImgPipeline` | present, defaults to 1024 |
| `ZImageImg2ImgPipeline` | present, defaults to `None` |

Passing them unconditionally would raise `TypeError` on every SDXL-class model in the fleet.

# Details

Two manifest fields, both worker-side and excluded from the wire:

- `dtype`, so bf16-native flow transformers skip the fp16 cast.
- `pipeline`, a diffusers class stem. diffusers 0.39 has no `AutoPipeline` mapping entry for `SanaSprintPipeline`, so `AutoPipeline` raises for it while `ZImagePipeline` and `Flux2KleinPipeline` resolve normally. `test_autopipeline_cannot_resolve_sana_sprint` guards that premise: when diffusers adds the mapping, the test fails and the override can be deleted.

`scripts/profile-candidates.py` gained guards after a run held 16.85 GB of a 16 GB display card for four hours, produced no image, and wedged the amdgpu driver until reboot:

- `--memory-mode`, defaulting to `full`, so an oversized model raises instead of degrading onto the disk-offload rung.
- A refusal if a run still lands on `group_offload`.
- A free-VRAM check before each phase, with a 2 GB floor.
- Phases banked as they complete, so a phase that runs out of memory costs its own numbers rather than every measurement before it.

The engine's own guard cannot cover this. `_ensure_vram` sizes a model by `min_vram_gb`, a single scalar describing weights at rest with no term for resolution or activations; it only evicts and has no path that refuses; and under a pinned `--memory-mode` it does not run at all. `select_rung` is built the same way deliberately, with group offload as a floor that always fits, because a queued job should degrade rather than be rejected. That is right for the product and wrong for a profiler sharing a card with the display.

Verified: worker ruff, mypy, 268 passed; backend ruff over `.` and `../scripts`, 856 passed. Both new engine tests were mutation-tested in each direction, never passing the size and always passing it, and each mutation is caught by the test that should catch it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three benchmark-only image generation models: FLUX.2 Klein 4B, Z-Image Turbo, and SANA Sprint 0.6B.
  * Added candidate-model profiling for latency, VRAM, and memory usage across supported generation modes.
  * Added model-specific pipeline and tensor data type configuration.
  * Documented licensing, hardware guidance, benchmark commands, and promotion criteria.

* **Bug Fixes**
  * Improved compatibility with non-CLIP text encoders and specialized pipelines.
  * Image-to-image generation now preserves requested dimensions when supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->