### PR TITLE
Put a deadline on the websocket reads

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -38,8 +38,51 @@ import shutil
 import tempfile
 from urllib.parse import urlsplit
 
+import anyio
 import pytest
 from sqlalchemy import text
+from starlette.testclient import WebSocketTestSession
+
+# Generous on purpose. The slowest whole test that drives a socket is under
+# two seconds and a single read is milliseconds, so this fires only on a read
+# that is never coming. Tight enough to be flaky on a loaded machine would be
+# worse than the hang it replaces.
+WS_RECEIVE_TIMEOUT_S = 15
+
+
+async def _receive_within(stream, seconds):
+    with anyio.fail_after(seconds):
+        return await stream.receive()
+
+
+def _bounded_receive(self):
+    try:
+        return self.portal.call(_receive_within, self._send_rx, WS_RECEIVE_TIMEOUT_S)
+    except TimeoutError:
+        raise AssertionError(f"no websocket message within {WS_RECEIVE_TIMEOUT_S}s") from None
+
+
+# Every TestClient socket read goes through one starlette method, so this is
+# the only place a deadline can go: receive_json, receive_bytes, receive_text
+# and the handshake in __enter__ all call WebSocketTestSession.receive, which
+# is `self.portal.call(self._send_rx.receive)` and takes no timeout. Without a
+# bound, a message that never arrives stops the whole suite rather than failing
+# one test, and CI reports a job timeout with no test name (issue #414).
+#
+# It lives in conftest because seven test files open sockets and any of them
+# can be run on its own. Patching from a test module would leave the other six
+# unbounded whenever that module was not imported.
+#
+# The deadline is raised inside the app's event loop, so anyio cancels the
+# pending read and drops the receiver rather than leaving it parked on the
+# memory stream to consume a later message.
+#
+# Replacing a library method is worth the coupling only because the
+# alternative is the same change at two hundred call sites, and reads added
+# later would arrive unbounded. It tracks two starlette internals, `portal`
+# and `_send_rx`; if either is renamed this fails loudly on the first read
+# rather than quietly going back to waiting forever.
+WebSocketTestSession.receive = _bounded_receive
 
 _CHECKOUT = pathlib.Path(__file__).resolve().parents[2]
 _VERSIONS = _CHECKOUT / "backend" / "migrations" / "versions"


### PR DESCRIPTION
# Description

Every TestClient websocket read now has a bound, so a message that never arrives fails one test with a name instead of stopping the suite. Closes #414.

One file, `backend/tests/conftest.py`, 43 added lines.

# Motivation

`receive_json()` and `receive_bytes()` take no timeout. When the expected message never comes the test does not fail; the run stops there and stays stopped.

Observed during a real `make verify`: the suite sat at 62 percent for over five minutes, process alive at 20 percent CPU, main thread parked in `futex_wait_queue`, inside `test_update_params_follows_the_workers_advertised_version[3]`. It is intermittent, and the same tree passed twice immediately afterwards.

A hang is worse than a failure here. Locally it reads as a slow test and costs several minutes before anyone thinks to check. In CI it burns the whole job timeout and reports a timeout rather than a test name, so the run says nothing about what went wrong and there is no traceback.

The suite already knew this failure mode existed: `conftest._no_inherited_jobs` documents a job left running being requeued so the next test to open a fleet socket receives a dispatch meant for someone else and waits for a message that already went elsewhere. That fixture removes one cause. It does not stop the waiting.

# Functionality

One replacement at the single choke point rather than at two hundred call sites. `receive_json`, `receive_bytes`, `receive_text` and the handshake inside `__enter__` all route through `WebSocketTestSession.receive`, which in starlette 1.3.1 is exactly `self.portal.call(self._send_rx.receive)`. The replacement does the same read inside `anyio.fail_after` and raises `AssertionError` on expiry, so pytest reports an ordinary failure. Reads added later are bounded without anyone remembering to do it.

It lives in `conftest.py` because seven test files open sockets and any of them can run on its own. An earlier draft patched from a test module, which left the other six unbounded whenever that module was not imported: a bound that holds only for the files somebody remembered is not a bound.

No new dependency: `anyio` is already a starlette requirement, and `pytest-timeout` is deliberately not added.

# Details

**The timeout is 15 seconds, and generous is the point.** The slowest whole test that drives a socket is under two seconds and a single read is milliseconds, so this fires only on a read that is never coming. A bound tight enough to be flaky on a loaded machine would be worse than the hang it replaces.

**The deadline is raised inside the app event loop**, so a timed-out read is cancelled and its receiver dropped rather than left parked on the memory stream, where it would go on to consume a later message.

**Proved twice, not asserted.** A probe test waiting for a message type nothing sends:

```
> raise AssertionError(f"no websocket message within {WS_RECEIVE_TIMEOUT_S}s") from None
E AssertionError: no websocket message within 15s
tests/conftest.py:62: AssertionError
1 failed in 15.54s
```

Against the same probe with the bound removed, `timeout -s KILL 60 pytest` exits 137 after the full minute with no output at all. The second proof is what moved the patch into `conftest`: the probe was planted in `test_realtime_auth.py`, which never imported any helper, and it now fails from `conftest.py` in 15 seconds.

**No measurable cost.** The full backend suite is 867 passed in 155 seconds with the bound; the four socket-driving files together are 261 passed in 35 seconds. Collection is unchanged.

**Left unbounded deliberately:** `WebSocketTestSession.send` and its siblings write to an unbounded memory stream and cannot block, and plain HTTP `TestClient` calls carry httpx timeouts and are not the reported failure mode.

The block carries its reasoning, including which two starlette internals it couples to and the fact that a rename fails loudly on the first read rather than quietly reverting to waiting forever, so the next reader has what they need to decide whether it still earns its place.
