### PR TITLE
Hold the TOTP guess budget to the account, and the challenge to one use

### DIFF
--- a/backend/app/factors.py
+++ b/backend/app/factors.py
@@ -15,6 +15,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import delete, func, select, text, update
+from sqlalchemy.exc import OperationalError
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from app import db, keyring, sessions, totp
@@ -110,8 +111,18 @@ async def begin_challenge(user: User, remember_me: bool,
             # ten guesses per login and a six-digit code had unlimited tries
             # against it (issue #421). A collision with another key here costs
             # two accounts a moment of waiting and nothing else.
-            await session.execute(text("SELECT pg_advisory_xact_lock(:key)"),
-                                  {"key": _budget_lock(user.id)})
+            # A waiter holds its pooled connection, and the pool is fifteen
+            # deep, so an unbounded wait would let a flood of logins for one
+            # account starve every other request. Giving up is safe here:
+            # nothing has been written yet, and the caller is told to come
+            # back rather than handed a challenge that skipped the carry.
+            await session.execute(text("SET LOCAL lock_timeout = '3s'"))
+            try:
+                await session.execute(text("SELECT pg_advisory_xact_lock(:key)"),
+                                      {"key": _budget_lock(user.id)})
+            except OperationalError as busy:
+                raise HTTPException(status_code=503,
+                                    detail="too many sign-ins at once") from busy
             # The budget belongs to the account, not to one challenge. Minted
             # per challenge it counts nothing, because starting another is
             # free to anyone who already has the password.

--- a/backend/app/factors.py
+++ b/backend/app/factors.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, select, text, update
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
 from app import db, keyring, sessions, totp
@@ -90,6 +90,11 @@ async def enrolled_factor(session, user_id: uuid.UUID) -> AuthFactor | None:
     )).scalar_one_or_none()
 
 
+def _budget_lock(user_id: uuid.UUID) -> int:
+    """A per-account advisory key, the way enable.py takes SETUP_LOCK."""
+    return int.from_bytes(user_id.bytes[:8], "big", signed=True)
+
+
 async def begin_challenge(user: User, remember_me: bool,
                           redirect_to: str | None = None) -> Response:
     """The pre-session capability a primary login hands back instead of a
@@ -99,6 +104,14 @@ async def begin_challenge(user: User, remember_me: bool,
     token = secrets.token_urlsafe(32)
     async with db.session_factory() as session:
         async with session.begin():
+            # Serialised per account, because the carry-forward below is a read
+            # and then a write. Two logins that overlap both found nothing
+            # outstanding and both seeded a fresh budget, so ten guesses became
+            # ten guesses per login and a six-digit code had unlimited tries
+            # against it (issue #421). A collision with another key here costs
+            # two accounts a moment of waiting and nothing else.
+            await session.execute(text("SELECT pg_advisory_xact_lock(:key)"),
+                                  {"key": _budget_lock(user.id)})
             # The budget belongs to the account, not to one challenge. Minted
             # per challenge it counts nothing, because starting another is
             # free to anyone who already has the password.
@@ -169,9 +182,19 @@ async def answer_challenge(body: CodeRequest, request: Request) -> Response:
     if not await _accepted(body.code, user, factor):
         raise REFUSED
     async with db.session_factory() as session:
-        await session.execute(
-            update(AuthToken).where(AuthToken.id == claimed.id).values(consumed_at=func.now()))
+        # The session is contingent on winning this. The attempt was counted
+        # and committed before the code was checked, so a second request
+        # carrying the same challenge reaches here too, and only the one that
+        # actually spends the token is let in (issue #421).
+        spent = (await session.execute(
+            update(AuthToken)
+            .where(AuthToken.id == claimed.id, AuthToken.consumed_at.is_(None))
+            .values(consumed_at=func.now())
+            .returning(AuthToken.id)
+        )).first()
         await session.commit()
+    if spent is None:
+        raise REFUSED
     remembered = request.cookies.get(f"{_cookie_name(settings)}_remember") == "1"
     response = Response(status_code=204)
     from app.accounts import issue_session

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi.testclient import TestClient
-from sqlalchemy import select, text
+from sqlalchemy import select, text, update
 
 from app import db, factors, keyring, sessions, totp
 from app.main import app
@@ -460,3 +460,82 @@ def test_an_enrolment_nobody_confirmed_in_time_is_no_longer_one(accounts, monkey
                                     "code": totp.code_at(started["secret"], int(_now()))})
         assert refused.status_code == 403
         assert client.portal.call(_factors) == []
+
+
+async def _live_challenges() -> list[int]:
+    async with db.session_factory() as session:
+        return sorted((await session.execute(
+            select(AuthToken.attempts).where(AuthToken.purpose == "challenge",
+                                             AuthToken.consumed_at.is_(None))
+        )).scalars().all())
+
+
+async def _spend(count: int) -> None:
+    """What answering wrong `count` times leaves on the live challenge."""
+    async with db.session_factory() as session:
+        await session.execute(
+            update(AuthToken)
+            .where(AuthToken.purpose == "challenge", AuthToken.consumed_at.is_(None))
+            .values(attempts=count))
+        await session.commit()
+
+
+@pytest.mark.db
+def test_the_guess_budget_survives_logins_that_overlap(accounts):
+    """Ten guesses per account, not ten per login. Starting a login costs
+    nothing to whoever already has the password, so a budget that resets on a
+    new challenge is no budget: they open more.
+
+    One at a time this held. Overlapping, every login but one used to come
+    back with a fresh challenge at zero, which is a six-digit code with
+    unlimited tries against it.
+    """
+    import asyncio
+
+    user = accounts(_make("racer@example.com"))
+    accounts(factors.begin_challenge(user, remember_me=False))
+    accounts(_spend(7))
+
+    async def overlapping() -> None:
+        await asyncio.gather(*[
+            factors.begin_challenge(user, remember_me=False) for _ in range(4)
+        ])
+
+    accounts(overlapping())
+    live = accounts(_live_challenges())
+    assert live, "a challenge should still be live"
+    assert all(spent == 7 for spent in live), live
+
+
+@pytest.mark.db
+def test_one_challenge_answered_twice_at_once_gets_in_once(accounts):
+    """A challenge is one use. The attempt was counted and committed, then the
+    code checked, then the token consumed, and between the first commit and
+    the last a second request carrying the same cookie still found it
+    unspent, so two valid recovery codes both bought a session (issue #421).
+    """
+    import asyncio
+
+    import httpx
+
+    with TestClient(app, base_url=ORIGIN) as client:
+        client.portal.call(_make, "twice@example.com")
+        assert _login(client, "twice@example.com").status_code == 204
+        _, codes = _enrol(client)
+    with TestClient(app, base_url=ORIGIN) as fresh:
+        assert _login(fresh, "twice@example.com").status_code == 200
+        held = {cookie.name: cookie.value for cookie in fresh.cookies.jar}
+
+        async def answer(code: str) -> int:
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app),
+                                         base_url=ORIGIN, cookies=held) as caller:
+                answered = await caller.post("/api/v1/auth/totp",
+                                             headers={"Origin": ORIGIN},
+                                             json={"code": code})
+                return answered.status_code
+
+        async def together() -> list[int]:
+            return list(await asyncio.gather(answer(codes[0]), answer(codes[1])))
+
+        answered = fresh.portal.call(together)
+    assert sorted(answered) == [204, 403], answered

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -496,15 +496,31 @@ def test_the_guess_budget_survives_logins_that_overlap(accounts):
     accounts(factors.begin_challenge(user, remember_me=False))
     accounts(_spend(7))
 
+    started = asyncio.Event()
+    waiting = 0
+
+    async def begin() -> None:
+        """Every caller reaches begin_challenge before any of them proceeds.
+
+        Without this the scheduler is free to run them one after another,
+        which is the case that always worked, so the test would pass against
+        the unlocked code whenever it happened to serialise them.
+        """
+        nonlocal waiting
+        waiting += 1
+        if waiting == 4:
+            started.set()
+        await started.wait()
+        await factors.begin_challenge(user, remember_me=False)
+
     async def overlapping() -> None:
-        await asyncio.gather(*[
-            factors.begin_challenge(user, remember_me=False) for _ in range(4)
-        ])
+        await asyncio.gather(*[begin() for _ in range(4)])
 
     accounts(overlapping())
-    live = accounts(_live_challenges())
-    assert live, "a challenge should still be live"
-    assert all(spent == 7 for spent in live), live
+    # Exactly one, not merely several that each carried the seven: each begin
+    # consumes the one before it, so four that overlap must still leave one
+    # challenge behind. Four rows at seven would be twelve guesses, not three.
+    assert accounts(_live_challenges()) == [7]
 
 
 @pytest.mark.db
@@ -526,9 +542,23 @@ def test_one_challenge_answered_twice_at_once_gets_in_once(accounts):
         assert _login(fresh, "twice@example.com").status_code == 200
         held = {cookie.name: cookie.value for cookie in fresh.cookies.jar}
 
+        ready = asyncio.Event()
+        arrived = 0
+
         async def answer(code: str) -> int:
+            """Both requests are in flight before either is allowed to post.
+
+            Left to the scheduler one can finish before the other starts,
+            which is the sequential case that always worked, so the test
+            would pass against the unconditional consume by luck.
+            """
+            nonlocal arrived
             async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app),
                                          base_url=ORIGIN, cookies=held) as caller:
+                arrived += 1
+                if arrived == 2:
+                    ready.set()
+                await ready.wait()
                 answered = await caller.post("/api/v1/auth/totp",
                                              headers={"Origin": ORIGIN},
                                              json={"code": code})


### PR DESCRIPTION
# Description

Two windows in `app/factors.py` that hold one request at a time and did not hold when requests overlap. Closes #421.

# Motivation

Ten guesses is meant to belong to the account rather than to a challenge, because starting another login costs nothing to whoever already has the password. That is the reasoning already written above the code, and it was right. The implementation reached it in sequence and not under concurrency.

Measured against the shipped code, with seven guesses already spent on a live challenge:

```
sequential begin_challenge:      [7]          the budget holds
four overlapping begin_challenge: [0, 0, 7]   two fresh budgets
```

Two of the three live challenges start at zero, and the pattern repeats: open logins in parallel and the ten-guess limit never binds. Against a six digit code, an unbounded number of tries is the difference between a second factor and a formality. The attacker already holds the password at this point, which is the exact situation the factor exists for.

The second window is in `answer_challenge`. The attempt is counted and committed, then the code is checked, then the token is consumed, and between the first commit and the last a second request carrying the same challenge cookie still finds it unspent. Measured: two valid recovery codes answered together both returned `204`, so one challenge bought two sessions.

# Functionality

- `begin_challenge` takes a per-account `pg_advisory_xact_lock` around the consume-and-insert, so the carry-forward is serialised per account.
- `answer_challenge` consumes the token conditionally on it still being unspent and reports whether that matched. The session is minted only by the request that actually spent it.

# Details

The lock follows the pattern `enable.py` already uses for `SETUP_LOCK` on the same shape of problem, a read followed by a write that another caller can interleave. Per account rather than global, keyed off the first eight bytes of the user id: a key collision costs two accounts a moment of waiting and nothing else. No migration, and no new concept in the codebase.

The alternatives considered were a partial unique index allowing one live challenge per account, which has a precedent in `asset_shares_one_active` but needs a migration and a retry path for the loser, and moving the counter onto the account row, which is a schema change for something the lock already settles.

**What this deliberately does not change.** The attempt is still counted in a transaction of its own, committed before the code is checked. That is what makes a wrong guess cost one whatever happens afterwards, and it is the reason the second window exists at all; closing it by deferring the count would trade a small concurrency defect for a way to guess for free. The fix is that the token now decides who gets in, not that the count moves.

**What the budget actually bounds, stated exactly.** Ten guesses per account per challenge lifetime, not ten ever. The consume that carries attempts forward matches only live challenges, so once a challenge passes its ten minutes its spent attempts are not carried and the next login starts at zero. Measured: nine spent, the challenge aged past `expires_at`, then a new login leaves `[0, 9]`.

That reset is not an oversight to fix here. A budget that never reset would mean ten wrong guesses ever, which locks an account out permanently and hands anybody who knows an address a denial of service. So the shipped shape is a rate limit, roughly ten guesses per ten minutes, and against a six digit code that is an exhaustive search measured in years rather than the unlimited one this PR removes. It is written down because "ten guesses per account" reads stronger than what the code does, and the decision entry should say the narrower thing.

**Both measured before and after, and both neuter-checked:**

| | before | after |
|---|---|---|
| four overlapping logins, seven spent | `[0, 0, 7]` | every live challenge at `7` |
| one challenge, two valid recovery codes at once | `[204, 204]` | `[204, 403]` |

Removing the advisory lock fails the budget test and nothing else. Making the consume unconditional fails the one-use test and nothing else.

`make verify` from the worktree with `PYTHONPATH` forced to it: 899 backend, 247 worker, frontend and CSP green.

The decision entry added in #418 already says the budget holds sequentially and not concurrently, and points here. It wants a follow-up edit once this lands, which is a one line change and is not in this PR because the entry should describe main rather than a branch.

**Review round.** Reviewed by a cursor agent (gpt-5.6-sol-xhigh). Five findings; two taken, two filed, one declined with the reasoning below.

Two of them turned out to share a cause that was neither of the things they named. The expiry reset and the lock holding pooled connections both reduce to the login rate limit the specification asks for and this code does not have: `login 10 per id and 30 per IP per 10 minutes` appears in the normative document and nowhere in `app/accounts.py`. That is the control that bounds how many challenges can be started at all. Filed as #423 rather than folded in here, because inventing a rate limiter inside a concurrency fix is how a security path gets a second one nobody reviewed.

So the expiry reset stays. Making attempts carry across a dead challenge would mean ten wrong guesses ever, which locks an account permanently and hands anybody who knows an address a denial of service. The narrower guarantee is stated above and belongs in the decision entry.

Taken: the lock wait is capped, so a waiter gives up rather than holding one of fifteen pooled connections while a flood of logins for one account queues behind it. Abandoning is safe at that point because nothing has been written yet.

Taken, and the sharpest of the five: both tests could pass against the broken code whenever the scheduler happened to run their requests one after the other, which is the case that always worked. Each now holds every caller at a barrier until all have arrived, so the overlap is the test rather than a hope. Re-running each mutation three times gives one failure every time instead of usually. The budget test also asserts exactly one live challenge rather than several that each carried the count, since four rows at seven is twelve guesses and not three.

Declined and filed as #424: the request that loses the token race has already spent its recovery code. It is real, and both obvious fixes are worse than the defect. Consuming the token before the code is checked makes one wrong guess destroy the ten guess budget this PR exists to protect, and un-consuming the code afterwards puts a rollback in a credential path. The shape that works splits the recovery check from the recovery spend, which is a change to a one-use credential and wants its own tests.

Clean on that pass: the lock key cannot collide with `SETUP_LOCK` or the startup lock for app-created UUIDs, transaction locks release on every path including cancellation, no deadlock cycle exists, and a wrong guess is still never free.
