### PR TITLE
Spend the proof where the outcome is decided, not where it is checked

### DIFF
--- a/backend/app/factors.py
+++ b/backend/app/factors.py
@@ -10,11 +10,13 @@ import hashlib
 import json
 import secrets
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import delete, func, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.exc import IntegrityError, OperationalError
 from starlette.responses import JSONResponse, RedirectResponse, Response
 
@@ -196,31 +198,33 @@ async def answer_challenge(body: CodeRequest, request: Request) -> Response:
         factor = await enrolled_factor(session, claimed.user_id)
     if user is None or factor is None or user.state in CANNOT_SIGN_IN:
         raise REFUSED
-    if not await _accepted(body.code, user, factor):
+    proof = await _verify(body.code, user, factor)
+    if proof is None:
         raise REFUSED
-    # Answering a challenge proves the authenticator is in the right hands,
-    # which is what the replacement budget is there to wait for. An attacker
-    # holding only a session cannot reach this line.
     async with db.session_factory() as session:
-        await session.execute(
-            update(AuthFactor).where(AuthFactor.id == factor.id,
-                                     AuthFactor.replace_attempts > 0)
-            .values(replace_attempts=0))
-        await session.commit()
-    async with db.session_factory() as session:
-        # The session is contingent on winning this. The attempt was counted
-        # and committed before the code was checked, so a second request
-        # carrying the same challenge reaches here too, and only the one that
-        # actually spends the token is let in (issue #421).
-        spent = (await session.execute(
-            update(AuthToken)
-            .where(AuthToken.id == claimed.id, AuthToken.consumed_at.is_(None))
-            .values(consumed_at=func.now())
-            .returning(AuthToken.id)
-        )).first()
-        await session.commit()
-    if spent is None:
-        raise REFUSED
+        async with session.begin():
+            # The session is contingent on winning this. The attempt was
+            # counted and committed before the code was checked, so a second
+            # request carrying the same challenge reaches here too, and only
+            # the one that actually spends the token is let in (issue #421).
+            won = (await session.execute(
+                update(AuthToken)
+                .where(AuthToken.id == claimed.id, AuthToken.consumed_at.is_(None))
+                .values(consumed_at=func.now())
+                .returning(AuthToken.id)
+            )).first()
+            # The proof is spent here rather than when it was checked, so the
+            # request that loses the race rolls back and gives the code or the
+            # step back with it (#424).
+            if won is None or not await _spend(session, factor, proof):
+                raise REFUSED
+            # Answering a challenge proves the authenticator is in the right
+            # hands, which is what the replacement budget waits for. An
+            # attacker holding only a session cannot reach this line.
+            await session.execute(
+                update(AuthFactor).where(AuthFactor.id == factor.id,
+                                         AuthFactor.replace_attempts > 0)
+                .values(replace_attempts=0))
     remembered = request.cookies.get(f"{_cookie_name(settings)}_remember") == "1"
     response = Response(status_code=204)
     from app.accounts import issue_session
@@ -239,55 +243,75 @@ def _clear_challenge(response: Response, settings: Settings) -> None:
                            httponly=True)
 
 
-async def _accepted(code: str, user: User, factor: AuthFactor) -> bool:
-    if await _spend_recovery_code(user.id, code):
-        return True
+@dataclass(frozen=True)
+class Proof:
+    """What a presented code turned out to be, and what spending it will cost.
+
+    Checking and spending are separate because the caller decides whether the
+    thing the proof authorises actually happens. Spent at the moment it is
+    checked, a code is gone whether or not the request that presented it
+    succeeded, and a one-use credential consumed for nothing is a way into the
+    account that its holder no longer has and cannot know about (#424, #430).
+    """
+
+    recovery_code_id: uuid.UUID | None = None
+    step: int | None = None
+
+
+async def _verify(code: str, user: User, factor: AuthFactor) -> Proof | None:
+    """What this code is, without consuming it. None if it is nothing."""
+    if db.session_factory is None:
+        return None
+    async with db.session_factory() as session:
+        found = (await session.execute(
+            select(RecoveryCode.id).where(
+                RecoveryCode.user_id == user.id,
+                RecoveryCode.code_hash == _hash(code.strip().lower()),
+                RecoveryCode.consumed_at.is_(None))
+        )).first()
+    if found is not None:
+        return Proof(recovery_code_id=found.id)
     try:
         secret = keyring.get_key_ring().decrypt(
             TOTP_PURPOSE, factor.secret_ciphertext, user.id.bytes).decode()
     except Exception:
         # A secret this installation can no longer read is a factor nobody can
         # pass, which is the fail-closed direction.
-        return False
+        return None
     step = totp.matched_step(secret, code)
     if step is None:
-        return False
-    return await _claim_step(factor.id, step)
+        return None
+    return Proof(step=step)
 
 
-async def _claim_step(factor_id: uuid.UUID, step: int) -> bool:
-    """A code is good once, which RFC 6238 requires and the drift window makes
-    necessary: without this one stays live for ninety seconds, long enough for
-    whoever phished it to spend it."""
-    if db.session_factory is None:
-        return False
-    async with db.session_factory() as session:
-        claimed = (await session.execute(
-            update(AuthFactor)
-            .where(AuthFactor.id == factor_id,
-                   (AuthFactor.last_step.is_(None)) | (AuthFactor.last_step < step))
-            .values(last_step=step)
-            .returning(AuthFactor.id)
-        )).first()
-        await session.commit()
-    return claimed is not None
+async def _spend(session: AsyncSession, factor: AuthFactor, proof: Proof) -> bool:
+    """Consume the proof inside the caller's transaction.
 
-
-async def _spend_recovery_code(user_id: uuid.UUID, code: str) -> bool:
-    """One use, and consumed by the same statement that finds it."""
-    if db.session_factory is None:
-        return False
-    async with db.session_factory() as session:
+    Conditional on it still being unspent, so of two requests holding the same
+    proof only one is told it spent it, and the caller that loses gives the
+    credential back by rolling the transaction it was part of.
+    """
+    if proof.recovery_code_id is not None:
         spent = (await session.execute(
             update(RecoveryCode)
-            .where(RecoveryCode.user_id == user_id,
-                   RecoveryCode.code_hash == _hash(code.strip().lower()),
+            .where(RecoveryCode.id == proof.recovery_code_id,
                    RecoveryCode.consumed_at.is_(None))
             .values(consumed_at=func.now())
             .returning(RecoveryCode.id)
         )).first()
-        await session.commit()
-    return spent is not None
+        return spent is not None
+    claimed = (await session.execute(
+        update(AuthFactor)
+        .where(AuthFactor.id == factor.id,
+               (AuthFactor.last_step.is_(None)) | (AuthFactor.last_step < proof.step))
+        .values(last_step=proof.step)
+        .returning(AuthFactor.id)
+    )).first()
+    return claimed is not None
+
+
+
+
 
 
 @router.post("/api/v1/account/totp")
@@ -394,6 +418,7 @@ async def confirm_enrolment(
     # this, two requests from a session with recent authentication replaced
     # somebody's second factor with one the caller held, and the account
     # found out when its own authenticator stopped working (issue #427).
+    proof: Proof | None = None
     async with db.session_factory() as session:
         replacing = await enrolled_factor(session, user_id)
     if replacing is not None:
@@ -403,16 +428,23 @@ async def confirm_enrolment(
             # The budget is gone. Signing in with the factor clears it, which
             # is the one thing an attacker holding only a session cannot do.
             raise REFUSED
-        if not await _accepted(body.current_code, principal.user, replacing):
+        proof = await _verify(body.current_code, principal.user, replacing)
+        if proof is None:
             raise REFUSED
 
     ring = keyring.get_key_ring()
     async with db.session_factory() as session:
         async with session.begin():
-            # Replacing an enrolment replaces its codes with it: a code minted
-            # for a secret nobody holds any more is a way in nobody expects.
-            await session.execute(delete(RecoveryCode).where(RecoveryCode.user_id == user_id))
             if replacing is not None:
+                # Inside the transaction, so a replacement that turns out to
+                # be impossible gives the code or the step back instead of
+                # keeping them for a change that did not happen (#430).
+                #
+                # Before the codes are cleared, not after: spending a recovery
+                # code means marking the row consumed, and the delete below
+                # would have taken the row out from under it.
+                if proof is None or not await _spend(session, replacing, proof):
+                    raise REFUSED
                 # Bound to the factor that was proved, and the request only
                 # continues if it is the one that removed it. An account-wide
                 # delete would let the last writer replace a factor it never
@@ -424,6 +456,9 @@ async def confirm_enrolment(
                 )).first()
                 if gone is None:
                     raise REFUSED
+            # Replacing an enrolment replaces its codes with it: a code minted
+            # for a secret nobody holds any more is a way in nobody expects.
+            await session.execute(delete(RecoveryCode).where(RecoveryCode.user_id == user_id))
             # A first enrolment deletes nothing at all. Deleting by account
             # here is what let two of them race: both read no factor, the
             # first installed one, and the second removed it and installed

--- a/backend/app/factors.py
+++ b/backend/app/factors.py
@@ -436,6 +436,16 @@ async def confirm_enrolment(
     async with db.session_factory() as session:
         async with session.begin():
             if replacing is not None:
+                # The factor row first, always, whichever kind of proof this
+                # is. Spending a recovery code touches recovery_codes and then
+                # auth_factors, and spending a step touches auth_factors and
+                # then the code sweep touches recovery_codes: two replacements
+                # of different kinds would take the two tables in opposite
+                # orders and deadlock, and PostgreSQL resolves that by killing
+                # one of them, which reaches the caller as a 500.
+                await session.execute(
+                    select(AuthFactor.id).where(AuthFactor.id == replacing.id)
+                    .with_for_update())
                 # Inside the transaction, so a replacement that turns out to
                 # be impossible gives the code or the step back instead of
                 # keeping them for a change that did not happen (#430).

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -739,47 +739,6 @@ def test_two_replacements_at_once_leave_one_factor(accounts, monkeypatch):
 
 
 @pytest.mark.db
-def test_a_refused_replacement_keeps_the_recovery_codes(accounts, monkeypatch):
-    """The transaction deletes the codes before it learns it lost the factor.
-
-    If that did not roll back, losing the race would strip the account's
-    recovery codes and leave it holding a factor with no way past it but the
-    authenticator, which is the position the codes exist to prevent. Forced
-    here rather than raced, because the interleaving that reaches it is not
-    one a barrier can arrange.
-    """
-    from app import factors
-
-    with TestClient(app, base_url=ORIGIN) as client:
-        client.portal.call(_make, "rolledback@example.com")
-        assert _login(client, "rolledback@example.com").status_code == 204
-        _enrol(client)
-        before = len(client.portal.call(_codes))
-        assert before == totp.RECOVERY_CODES
-
-        stale = client.portal.call(_factors)[0]
-        stale.id = uuid.uuid4()
-
-        async def vanished(session, user_id):
-            return stale
-
-        async def proved(code, user, factor):
-            return factors.Proof(step=1)
-
-        monkeypatch.setattr(factors, "enrolled_factor", vanished)
-        monkeypatch.setattr(factors, "_verify", proved)
-
-        started = client.post("/api/v1/account/totp", headers=_csrf(client))
-        refused = client.post("/api/v1/account/totp/confirm", headers=_csrf(client),
-                              json={"enrolment": started.json()["enrolment"],
-                                    "code": totp.code_at(started.json()["secret"],
-                                                         int(_now())),
-                                    "current_code": "whatever"})
-        assert refused.status_code == 403
-        assert len(client.portal.call(_codes)) == before
-
-
-@pytest.mark.db
 def test_the_old_factor_cannot_be_guessed_at_leisure(accounts):
     """The caller holds the new secret, so they answer that half every time.
     Without a budget the old half is a six-digit space and the sealed
@@ -874,6 +833,10 @@ def test_a_first_enrolment_that_races_a_factor_is_refused_not_a_crash(accounts, 
                                json={"enrolment": started["enrolment"],
                                      "code": totp.code_at(started["secret"], int(_now()))})
         assert answered.status_code == 409
+        # The sweep ran before the insert that failed, so the account's
+        # recovery codes were deleted inside the transaction that then rolled
+        # back. Losing this race must not cost them.
+        assert len(client.portal.call(_unspent_codes)) == totp.RECOVERY_CODES
         # The factor that was already there is the one still there.
         stored = client.portal.call(_factors)
         assert len(stored) == 1

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -75,6 +75,15 @@ async def _codes() -> list[RecoveryCode]:
         return list((await session.execute(select(RecoveryCode))).scalars().all())
 
 
+async def _unspent_codes() -> list[RecoveryCode]:
+    """Spending a code sets consumed_at rather than deleting the row, so a
+    count of rows says nothing about how many are still good."""
+    async with db.session_factory() as session:
+        return list((await session.execute(
+            select(RecoveryCode).where(RecoveryCode.consumed_at.is_(None))
+        )).scalars().all())
+
+
 async def _challenges() -> list[AuthToken]:
     async with db.session_factory() as session:
         return list((await session.execute(
@@ -754,11 +763,11 @@ def test_a_refused_replacement_keeps_the_recovery_codes(accounts, monkeypatch):
         async def vanished(session, user_id):
             return stale
 
-        async def accepted(code, user, factor):
-            return True
+        async def proved(code, user, factor):
+            return factors.Proof(step=1)
 
         monkeypatch.setattr(factors, "enrolled_factor", vanished)
-        monkeypatch.setattr(factors, "_accepted", accepted)
+        monkeypatch.setattr(factors, "_verify", proved)
 
         started = client.post("/api/v1/account/totp", headers=_csrf(client))
         refused = client.post("/api/v1/account/totp/confirm", headers=_csrf(client),
@@ -893,3 +902,95 @@ def test_only_the_one_factor_constraint_reads_as_a_lost_race(accounts, monkeypat
                               "code": totp.code_at(started["secret"], int(_now()))})
         assert "recovery_codes_unique" in str(raised.value)
         assert client.portal.call(_factors) == []
+
+
+@pytest.mark.db
+def test_losing_the_challenge_race_keeps_the_recovery_code(accounts, monkeypatch):
+    """The loser is refused and must be refused having spent nothing.
+
+    A code consumed for a session nobody got is a way in the account no longer
+    has, and the person holding it has no way to know (issue #424).
+    """
+    import asyncio
+
+    import httpx
+
+    from app import factors
+
+    with TestClient(app, base_url=ORIGIN) as client:
+        client.portal.call(_make, "keepcode@example.com")
+        assert _login(client, "keepcode@example.com").status_code == 204
+        _, codes = _enrol(client)
+    with TestClient(app, base_url=ORIGIN) as fresh:
+        assert _login(fresh, "keepcode@example.com").status_code == 200
+        held = {cookie.name: cookie.value for cookie in fresh.cookies.jar}
+
+        # Both requests verify before either consumes the challenge, which is
+        # the window the loser used to spend its code in.
+        ready = asyncio.Event()
+        verified = 0
+        real_verify = factors._verify
+
+        async def both_have_verified(code, user, factor):
+            nonlocal verified
+            proof = await real_verify(code, user, factor)
+            verified += 1
+            if verified == 2:
+                ready.set()
+            await asyncio.wait_for(ready.wait(), timeout=10)
+            return proof
+
+        monkeypatch.setattr(factors, "_verify", both_have_verified)
+
+        async def answer(code: str) -> int:
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app),
+                                         base_url=ORIGIN, cookies=held) as caller:
+                answered = await caller.post("/api/v1/auth/totp",
+                                             headers={"Origin": ORIGIN},
+                                             json={"code": code})
+                return answered.status_code
+
+        async def together() -> list[int]:
+            return list(await asyncio.gather(answer(codes[0]), answer(codes[1])))
+
+        answered = fresh.portal.call(together)
+        # One got in. The other's code is still good, so it is still unspent.
+        assert sorted(answered) == [204, 403], answered
+        # fresh, not client: the first one's lifespan is over and its portal
+        # with it.
+        assert len(fresh.portal.call(_unspent_codes)) == totp.RECOVERY_CODES - 1
+
+
+@pytest.mark.db
+def test_a_replacement_that_is_refused_keeps_the_code_it_was_given(accounts, monkeypatch):
+    """Same rule on the other route: proof presented to a replacement that
+    does not happen is proof that was never spent (issue #430)."""
+    from app import factors
+
+    with TestClient(app, base_url=ORIGIN) as client:
+        client.portal.call(_make, "keepcode2@example.com")
+        assert _login(client, "keepcode2@example.com").status_code == 204
+        _, codes = _enrol(client)
+        before = len(client.portal.call(_unspent_codes))
+
+        stale = client.portal.call(_factors)[0]
+        stale.id = uuid.uuid4()
+
+        async def vanished(session, user_id):
+            return stale
+
+        async def budget_is_fine(factor_id):
+            return True
+
+        monkeypatch.setattr(factors, "enrolled_factor", vanished)
+        # Past the budget on purpose: the window this test is about opens
+        # after the proof has been checked and closes when the replacement
+        # turns out to be impossible. Refusing earlier never reaches it.
+        monkeypatch.setattr(factors, "_spend_replacement_attempt", budget_is_fine)
+        started = client.post("/api/v1/account/totp", headers=_csrf(client)).json()
+        refused = client.post("/api/v1/account/totp/confirm", headers=_csrf(client),
+                              json={"enrolment": started["enrolment"],
+                                    "code": totp.code_at(started["secret"], int(_now())),
+                                    "current_code": codes[0]})
+        assert refused.status_code == 403
+        assert len(client.portal.call(_unspent_codes)) == before


### PR DESCRIPTION
# Description

`_accepted` is split into a check that writes nothing and a spend the caller runs inside its own transaction. Closes #424 and closes #430.

# Motivation

`_accepted` verified a code and consumed it in the same breath, in transactions of its own, before either caller knew whether the thing the code authorised would actually happen. Two routes paid for that:

- **The challenge (#424).** Two requests answering one challenge with two different recovery codes both spent their code, and only one got a session. The loser was refused having given up a one-use credential.
- **The replacement (#430).** A replacement that turned out to be impossible had already spent the code or claimed the TOTP step it was handed.

Neither tells anybody. A one-use credential consumed for nothing is a way into the account that its holder still believes they have, and they find out when they try to use it.

# Functionality

- `_verify(code, user, factor)` returns a `Proof` describing what the code is, or `None`. It writes nothing.
- `_spend(session, factor, proof)` consumes it inside the caller's transaction, conditionally on it still being unspent, and says whether it matched.
- `answer_challenge` spends the challenge token and the proof in one transaction, so winning the race and spending the code are the same event.
- `confirm_enrolment` spends the proof inside the replacement transaction, so a replacement that cannot proceed rolls the spend back with it.
- `_claim_step` and `_spend_recovery_code` are gone. `_spend` does both jobs, where a transaction can undo them.

# Details

**Order inside the replacement matters and cost a red test to find.** The transaction swept the account's recovery codes before spending the proof, so a legitimate recovery-code replacement was refused: spending a recovery code marks a row that the sweep had already removed. The spend now precedes the sweep.

**Both new tests passed before they bit, for different reasons, and both are worth recording.**

The first counted rows in `recovery_codes`. Spending sets `consumed_at` rather than deleting, so the row count does not move and the assertion proved nothing. It counts unspent codes now, through a helper that says why in its docstring.

The second refused at the attempt budget before it ever reached the window it was written for, because the stale factor id it used to force the failure also fails the budget lookup. It saw the 403 it expected and never touched the code path in question. It now gets past the budget deliberately, and says in a comment why it has to.

That is the same shape as the barrier problem in #428: a test that reaches *a* refusal, sees the status it expected, and never exercises the thing it is named for. The tell both times was a new test going green on the first run against unfixed code.

**Neuter-checked** by restoring the eager spend inside `_verify`: 8 tests fail, including both new ones. Restored, 37 pass.

**Verification.** `make verify` from the worktree with `PYTHONPATH` forced to it: 913 backend, 247 worker, frontend and CSP, `MAKE_EXIT=0`.

An earlier run of the same tree hit one unrelated failure in `test_realtime.py`, filed as #431: a realtime session answered `error` instead of `ready` under full-suite load. It does not reproduce, this branch touches `app/factors.py` only, and the interesting part is that the assertion discarded the error frame that would have explained it.

**Not addressed here.** `app/factors.py` still revokes no sessions on a factor change, though the specification says MFA events rotate them. That applies to enrolment, replacement and removal alike and wants its own change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TOTP and recovery-code verification to prevent credentials from being reused during concurrent requests.
  * Ensured challenges and recovery codes are consumed atomically, avoiding partial updates when operations fail or lose a race.
  * Strengthened factor replacement flows so existing verification credentials remain intact if replacement cannot be completed.
  * Reset replacement-attempt tracking consistently during successful operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Review round.** Two findings, both taken.

**A lock-order deadlock, and it was real.** Spending a recovery code touches `recovery_codes` then `auth_factors`; spending a step touches `auth_factors`, and the sweep afterwards touches `recovery_codes`. Two replacements of different proof kinds therefore took the two tables in opposite orders, and PostgreSQL breaks that cycle by killing one of them, which reaches the caller as a `500` for a request that did nothing wrong. The factor row is locked first now, in both paths.

**The rollback test had become unreachable, and my own reorder is what did it.** The reviewer noticed the stale factor id refuses before the transaction. The deeper reason is that moving the spend ahead of the sweep closed the window the test was written for: a refused replacement now fails before the recovery codes are touched, so there is nothing left there to roll back. Where a rollback is still observable is the first enrolment that loses its race, which sweeps, inserts, and has the unique constraint refuse the insert. That test now asserts the codes survive it, and neutering the transaction fails it in about a second.

That is the fourth test on this branch that did not reach its own path. The others counted rows that do not move when a code is spent, and refused at the attempt budget before the window under test. Every one of them went green on its first run against unfixed code, which is the tell.

**One guard here has no test, deliberately.** The lock ordering rests on the ordering argument written above it rather than on a test. Producing the deadlock on demand means holding one transaction inside `_spend` while another starts, and an attempt at that is how a suite ends up hanging instead of failing; it hung once already while these were being checked. A documented argument seemed better than a test that could turn a rare 500 into a routine hang.

**Confirmed clean by the review**, and worth recording because they are the two ways this refactor could have been catastrophic: nothing can be spent twice, and nothing can be accepted without being spent. Neither caller can return success between `_verify` and `_spend`, the conditional updates are sufficient without row locking, and `_spend` preserves the exact `last_step < step` monotonicity `_claim_step` carried, which I checked separately by neutering it.

One pre-existing case the review noted and this PR does not change: `answer_challenge` commits before `sessions.mint()`, so a response lost in flight can consume a proof without the client receiving a usable session.
