### PR TITLE
A confirmed second factor ends the account's other sessions

### DIFF
--- a/backend/app/credentials.py
+++ b/backend/app/credentials.py
@@ -5,21 +5,19 @@ account's other sessions, because the usual reason to change a credential is
 that somebody else holds the old one.
 """
 
-import uuid
 
 from anyio import to_thread
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import delete, func, select, update
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import Response
 
 from app import db, sessions
 from app.auth import current_principal, require_accounts_mode
 from app.enable import _checked_email
 from app.passwords import PasswordRejected, hash_password, verify_password
-from app.tables import AuthIdentity, AuthToken, Session, User
+from app.tables import AuthIdentity, User
 
 router = APIRouter(dependencies=[Depends(require_accounts_mode)])
 
@@ -37,41 +35,10 @@ async def recent_principal(
     return principal
 
 
-async def _revoke_others(session: AsyncSession, principal: sessions.Resolved) -> None:
-    """Everything but the browser making the change, which would otherwise sign
-    somebody out of the session they are changing the credential from.
-
-    Reset and recovery links go too. Changing an address after a mailbox is
-    compromised is meant to end what that mailbox can still do, and a link
-    already sent to it is exactly that.
-    """
-    await session.execute(
-        update(Session)
-        .where(Session.user_id == principal.user.id, Session.id != principal.session.id,
-               Session.revoked_at.is_(None))
-        .values(revoked_at=func.now())
-    )
-    await _spend_capabilities(session, principal.user.id)
 
 
-async def _close_other_sockets(principal: sessions.Resolved) -> None:
-    """After the change is durable, and never inside its transaction.
-
-    A revoked row stops the next request; it does not reach a socket that
-    bound its principal at the handshake. Somebody changing a password to
-    evict a stranger would otherwise leave the stranger drawing.
-    """
-    await sessions.close_sockets(principal.user.id, keep=principal.session.id)
 
 
-async def _spend_capabilities(session: AsyncSession, user_id: uuid.UUID) -> None:
-    await session.execute(
-        update(AuthToken)
-        .where(AuthToken.user_id == user_id,
-               AuthToken.purpose.in_(("reset", "recovery")),
-               AuthToken.consumed_at.is_(None))
-        .values(consumed_at=func.now())
-    )
 
 
 class PasswordChange(BaseModel):
@@ -133,8 +100,8 @@ async def change_password(
                 await session.execute(
                     update(AuthIdentity).where(AuthIdentity.id == existing.id)
                     .values(password_hash=password_hash))
-            await _revoke_others(session, principal)
-    await _close_other_sockets(principal)
+            await sessions.revoke_others(session, principal)
+    await sessions.close_other_sockets(principal)
     return Response(status_code=204)
 
 
@@ -171,10 +138,10 @@ async def change_email(
                     .where(AuthIdentity.user_id == principal.user.id,
                            AuthIdentity.provider == "password")
                     .values(subject=normalized))
-                await _revoke_others(session, principal)
+                await sessions.revoke_others(session, principal)
     except IntegrityError as clash:
         raise HTTPException(status_code=409, detail=ADDRESS_TAKEN) from clash
-    await _close_other_sockets(principal)
+    await sessions.close_other_sockets(principal)
     return Response(status_code=204)
 
 
@@ -205,6 +172,6 @@ async def unlink_identity(
             if len(held) == 1:
                 raise HTTPException(status_code=409, detail="that is the only way in")
             await session.execute(delete(AuthIdentity).where(AuthIdentity.id == linked.id))
-            await _revoke_others(session, principal)
-    await _close_other_sockets(principal)
+            await sessions.revoke_others(session, principal)
+    await sessions.close_other_sockets(principal)
     return Response(status_code=204)

--- a/backend/app/factors.py
+++ b/backend/app/factors.py
@@ -502,4 +502,20 @@ async def confirm_enrolment(
                 raise HTTPException(
                     status_code=409,
                     detail="a second factor was enrolled already") from raced
+            # After the guarded flush, not before it. Any statement issued
+            # while the new factor is still pending autoflushes it, and that
+            # flush happens outside the try, so the constraint violation this
+            # route expects would escape as a 500 instead of a 409.
+            # Turning a second factor on, or moving it to a new authenticator,
+            # is what somebody does when they think their account is at risk.
+            # A factor gates the next sign-in and says nothing about a session
+            # already open, so the eviction has to be explicit (issue #433).
+            #
+            # Reset and recovery links are left alone: they prove control of a
+            # mailbox, which is not what changed here, and spending them would
+            # strip a way back in from somebody who just secured their account.
+            await sessions.revoke_others(session, principal, spend_capabilities=False)
+    # After the transaction, never inside it: a revoked row stops the next
+    # request and does not reach a socket that already bound its principal.
+    await sessions.close_other_sockets(principal)
     return Response(status_code=204)

--- a/backend/app/sessions.py
+++ b/backend/app/sessions.py
@@ -10,10 +10,12 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 
 from app import db
-from app.tables import Session, User
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.tables import AuthToken, Session, User
 
 ABSOLUTE = timedelta(hours=12)
 REMEMBER_ABSOLUTE = timedelta(days=30)
@@ -119,6 +121,45 @@ async def resolve(token: str) -> Resolved | None:
             row.last_seen_at = now
             await session.commit()
         return Resolved(session=row, user=user)
+
+
+async def revoke_others(db_session: AsyncSession, resolved: "Resolved",
+                        spend_capabilities: bool = True) -> None:
+    """Every session but the one making the change.
+
+    Signing somebody out of the browser they are changing their own security
+    settings in reads as a failure and invites them to try again, so that one
+    stays. Lives here rather than beside any one caller because more than one
+    kind of change owes this: a credential, an address, a linked identity, a
+    second factor.
+    """
+    await db_session.execute(
+        update(Session)
+        .where(Session.user_id == resolved.user.id, Session.id != resolved.session.id,
+               Session.revoked_at.is_(None))
+        .values(revoked_at=func.now())
+    )
+    if spend_capabilities:
+        # Reset and recovery links go with them. Changing a credential after a
+        # mailbox is compromised is meant to end what that mailbox can still
+        # do, and a link already sent to it is exactly that.
+        await db_session.execute(
+            update(AuthToken)
+            .where(AuthToken.user_id == resolved.user.id,
+                   AuthToken.purpose.in_(("reset", "recovery")),
+                   AuthToken.consumed_at.is_(None))
+            .values(consumed_at=func.now())
+        )
+
+
+async def close_other_sockets(resolved: "Resolved") -> None:
+    """After the change is durable, and never inside its transaction.
+
+    A revoked row stops the next request; it does not reach a socket that
+    bound its principal at the handshake, so somebody evicting a stranger
+    would otherwise leave the stranger drawing.
+    """
+    await close_sockets(resolved.user.id, keep=resolved.session.id)
 
 
 async def close_sockets(user_id: uuid.UUID, session_id: uuid.UUID | None = None,

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -9,7 +9,7 @@ from app import db, factors, keyring, sessions, totp
 from app.main import app
 from app.passwords import hash_password
 from app.settings import get_settings
-from app.tables import AuthFactor, AuthIdentity, AuthToken, RecoveryCode, User
+from app.tables import AuthFactor, AuthIdentity, AuthToken, RecoveryCode, Session, User
 
 PASSWORD = "a-long-enough-account-password"
 ORIGIN = "https://studio.example.com"
@@ -957,3 +957,105 @@ def test_a_replacement_that_is_refused_keeps_the_code_it_was_given(accounts, mon
                                     "current_code": codes[0]})
         assert refused.status_code == 403
         assert len(client.portal.call(_unspent_codes)) == before
+
+
+async def _live_sessions_for(user_id: uuid.UUID) -> list[Session]:
+    async with db.session_factory() as db_session:
+        return list((await db_session.execute(
+            select(Session).where(Session.user_id == user_id,
+                                  Session.revoked_at.is_(None))
+        )).scalars().all())
+
+
+def _session_cookie(client) -> str:
+    return next(c.value for c in client.cookies.jar
+                if c.name.endswith("potocolom_session"))
+
+
+def _signed_out(client) -> None:
+    """Drop the session cookie without putting one back, so the next login is
+    a clean start rather than a rotation of the one being held."""
+    for name in ("__Host-potocolom_session", "potocolom_session"):
+        client.cookies.delete(name, path="/")
+
+
+def _wearing(client, token: str) -> None:
+    """One client, two people. Nesting TestClients works until the inner
+    lifespan disposes the engine the outer one is still using."""
+    for name in ("__Host-potocolom_session", "potocolom_session"):
+        client.cookies.delete(name, path="/")
+    client.cookies.set("__Host-potocolom_session", token)
+
+
+@pytest.mark.db
+def test_enrolling_a_factor_signs_the_other_sessions_out(accounts):
+    """Turning on a second factor is what somebody does when they think their
+    account is at risk, and it is the moment where signing everything else out
+    is most obviously what they meant. A stolen session is untouched by a
+    factor that only gates the next sign-in (issue #433)."""
+    with TestClient(app, base_url=ORIGIN) as client:
+        user = client.portal.call(_make, "twoplaces@example.com")
+        assert _login(client, "twoplaces@example.com").status_code == 204
+        elsewhere = _session_cookie(client)
+        # Signing in again while holding the first cookie would retire it:
+        # login refuses to let a token planted before authentication be the
+        # one that comes out of it. Two live sessions needs two clean starts.
+        _signed_out(client)
+        assert _login(client, "twoplaces@example.com").status_code == 204
+        here = _session_cookie(client)
+        assert len(client.portal.call(_live_sessions_for, user.id)) == 2
+
+        _enrol(client)
+        # The one that enrolled keeps working; the other does not.
+        assert client.get("/api/v1/account").status_code == 200
+        assert len(client.portal.call(_live_sessions_for, user.id)) == 1
+        _wearing(client, elsewhere)
+        assert client.get("/api/v1/account").status_code == 401
+        _wearing(client, here)
+        assert client.get("/api/v1/account").status_code == 200
+
+
+@pytest.mark.db
+def test_replacing_a_factor_signs_the_other_sessions_out(accounts):
+    """Somebody replacing a factor has usually lost the old authenticator,
+    which is the same worry wearing a different hat."""
+    with TestClient(app, base_url=ORIGIN) as client:
+        user = client.portal.call(_make, "moved@example.com")
+        assert _login(client, "moved@example.com").status_code == 204
+        old_secret, codes = _enrol(client)
+        here = _session_cookie(client)
+
+        # A second session has to be earned now: once a factor is enrolled a
+        # login answers with a challenge rather than a session, so this one
+        # comes through the front door like anybody else's would.
+        _signed_out(client)
+        assert _login(client, "moved@example.com").status_code == 200
+        assert client.post("/api/v1/auth/totp", headers={"Origin": ORIGIN},
+                           json={"code": codes[0]}).status_code == 204
+        _wearing(client, here)
+        assert len(client.portal.call(_live_sessions_for, user.id)) == 2
+
+        _, replaced = _replace(client, None, current=_next_code(old_secret))
+        assert replaced.status_code == 204
+        assert len(client.portal.call(_live_sessions_for, user.id)) == 1
+
+
+@pytest.mark.db
+def test_the_other_realtime_sockets_are_closed_too(accounts, monkeypatch):
+    """A revoked row stops the next request and does not reach a socket that
+    bound its principal at the handshake, so the eviction has to be told to
+    the relay as well."""
+    from app import factors
+
+    closed: list[tuple] = []
+
+    async def close(user_id, session_id=None, keep=None):
+        closed.append((user_id, session_id, keep))
+
+    monkeypatch.setattr(factors.sessions, "close_sockets", close)
+    with TestClient(app, base_url=ORIGIN) as client:
+        user = client.portal.call(_make, "sockets@example.com")
+        assert _login(client, "sockets@example.com").status_code == 204
+        _enrol(client)
+    assert [call[0] for call in closed] == [user.id], closed
+    assert closed[0][2] is not None, "the enrolling session is kept"

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -1037,7 +1037,10 @@ def test_replacing_a_factor_signs_the_other_sessions_out(accounts):
 
         _, replaced = _replace(client, None, current=_next_code(old_secret))
         assert replaced.status_code == 204
-        assert len(client.portal.call(_live_sessions_for, user.id)) == 1
+        # The one that replaced the factor is the one still standing. Counting
+        # to one would pass just as well if it were the other way round.
+        live = client.portal.call(_live_sessions_for, user.id)
+        assert [row.token_hash for row in live] == [sessions.token_hash(here)]
 
 
 @pytest.mark.db
@@ -1056,6 +1059,40 @@ def test_the_other_realtime_sockets_are_closed_too(accounts, monkeypatch):
     with TestClient(app, base_url=ORIGIN) as client:
         user = client.portal.call(_make, "sockets@example.com")
         assert _login(client, "sockets@example.com").status_code == 204
+        kept = client.portal.call(sessions.resolve, _session_cookie(client)).session.id
         _enrol(client)
     assert [call[0] for call in closed] == [user.id], closed
-    assert closed[0][2] is not None, "the enrolling session is kept"
+    # Named, not merely present: keeping the wrong session would close the
+    # browser doing the enrolling and leave the one being evicted drawing.
+    assert closed[0][2] == kept, closed
+
+
+@pytest.mark.db
+def test_enrolling_leaves_a_reset_link_alone(accounts):
+    """A password change spends outstanding reset links, because the link and
+    the password are the same credential. A factor is not: the link proves
+    control of a mailbox, which is not what changed, and spending it would
+    take a way back in from somebody who has just secured their account."""
+    with TestClient(app, base_url=ORIGIN) as client:
+        user = client.portal.call(_make, "keepsreset@example.com")
+        assert _login(client, "keepsreset@example.com").status_code == 204
+
+        async def mint_reset() -> None:
+            async with db.session_factory() as session:
+                session.add(AuthToken(user_id=user.id, purpose="reset",
+                                      token_hash=b"r" * 32,
+                                      expires_at=datetime.now(timezone.utc)
+                                      + timedelta(minutes=30)))
+                await session.commit()
+
+        async def live_resets() -> int:
+            async with db.session_factory() as session:
+                return len((await session.execute(
+                    select(AuthToken).where(AuthToken.purpose == "reset",
+                                            AuthToken.consumed_at.is_(None))
+                )).scalars().all())
+
+        client.portal.call(mint_reset)
+        assert client.portal.call(live_resets) == 1
+        _enrol(client)
+        assert client.portal.call(live_resets) == 1


### PR DESCRIPTION
# Description

Enrolling or replacing a second factor now revokes the account's other sessions and closes their realtime sockets. Closes #433.

# Motivation

`app/factors.py` revoked nothing. `app/credentials.py` has done the opposite in four places since it was written: changing a password, changing the primary address, and linking or unlinking a provider each end every session but the one making the change. The normative specification puts factor changes in that same list.

The argument is stronger here than for any of them. Turning on a second factor is what somebody does when they think their account is at risk, and it is the moment where "and sign everything else out" is most obviously what they meant. A factor gates the next sign-in and says nothing about a session already open, so an intruder holding one was untouched by the strongest action the product offers, with no indication anything had happened.

# Functionality

- `confirm_enrolment` revokes the account's other sessions, and closes their realtime sockets after the change is durable.
- `revoke_others` and `close_other_sockets` move from `app/credentials.py` to `app/sessions.py`, which is where helpers about sessions belong rather than being imported out of credentials by a second caller.
- `revoke_others` takes a flag for whether to spend outstanding reset and recovery links.

# Details

**Reset and recovery links are deliberately left alone here.** A password change spends them, and the reason is written beside it: changing a credential after a mailbox is compromised should end what that mailbox can still do. That reason does not apply to a factor. Those links prove control of a mailbox, which is not what changed, and spending them would take a way back in from somebody who has just secured their account.

**One bug in this change would have shipped silently, and one existing test caught it.** The revocation was first placed before the guarded flush. Any statement issued while the new factor is still pending autoflushes it, and that flush happens outside the `try`, so the unique-constraint violation the racing-enrolment path expects escaped as a `500` instead of the `409` it is supposed to answer. Nothing else in 915 tests would have noticed; the one that did was written two PRs ago to pin exactly that status on exactly that race.

**Three traps walked into while writing the tests**, all of them already recorded and all of them worth the reminder:

- Nested `TestClient`s. The inner lifespan disposes the engine the outer one is using, and the symptom is a `503` where a `401` belongs. Rewritten with one client wearing different cookies, the `_wearing` shape `test_account_states.py` already uses.
- A helper named `_live_sessions` that collided with an existing one in the same file and broke an unrelated test.
- Logging in twice on one client gives one session, not two: login retires the cookie it is presented, which is session-fixation protection doing its job. The second session is a clean start, and after enrolment it has to be earned by answering a challenge, since a login then answers with one of those rather than a session.

**Neuter-checked.** Removing the revocation fails both session tests; removing the socket close fails the socket test; nothing else moves.

`make verify` from the worktree with `PYTHONPATH` forced to it: 915 backend, 247 worker, frontend and CSP, `MAKE_EXIT=0`.

**Not addressed.** Whether the enrolling session should also rotate its own token, which the specification's "revoke or rotate" leaves open, and whether removal should revoke as well. The second belongs with #426.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enrolling or replacing a TOTP factor now signs out other active sessions while preserving the current session.
  * Realtime connections for signed-out sessions are closed automatically.
  * Password-reset links remain available after TOTP enrollment.

* **Bug Fixes**
  * Session invalidation is now handled consistently when changing passwords, email addresses, or unlinking identities.

* **Tests**
  * Added coverage for session revocation and realtime connection handling during TOTP enrollment and replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

**Review round.** Five findings: three test weaknesses taken, two code findings filed rather than bolted on.

All three test findings were mine, and the worst was a decision with nothing behind it. Not spending reset links on a factor change was a deliberate choice with its reasoning written into the commit, and flipping the flag would have spent them while every test still passed. A decision made on purpose and held by nothing is a comment, so it has a test now. The other two: counting to one after a replacement passes equally well if the wrong session is the one left standing, and the socket assertion accepted any non-null `keep`, including a value that is not a session id at all. Both name what they mean now, and both were neuter-checked.

**#435, filed:** a login already in flight can read no factor, and mint its session after enrolment has committed and revoked everything that existed. That session was never revoked and is inside an account whose owner has just turned on a second factor. The window is small and it is exactly the case this feature exists to close, but the fix belongs in the login path rather than here.

**#436, filed:** no credential change in this codebase rotates the token of the session making it, so a copy of that token survives a password change made specifically to evict whoever holds it. The reviewer raised it against this PR, and it is equally true of password, address and identity changes. Rotating for factor changes alone would leave the codebase inconsistent, and a password change is the stronger case, so the decision belongs to all five call sites at once rather than to whichever one is under review.

**The question I could not settle myself, answered.** Leaving reset and recovery links alone is defensible: a live link still works after enrolment, but it changes the password and revokes sessions without removing the factor or issuing a session, so its holder can cause a lockout rather than gain an entry.

**Confirmed clean:** the move preserves the exact SQL and socket behaviour for all four existing credential routes, which still spend capabilities by default; the revocation runs for both a first enrolment and a replacement, after the guarded flush, and no longer autoflushes into the wrong except path; and socket closure happens only after commit.

Final gate: 916 backend, 247 worker, frontend and CSP, `MAKE_EXIT=0`.
