### PR TITLE
One lock order for both routes, not one route

### DIFF
--- a/backend/app/factors.py
+++ b/backend/app/factors.py
@@ -203,16 +203,6 @@ async def answer_challenge(body: CodeRequest, request: Request) -> Response:
         raise REFUSED
     async with db.session_factory() as session:
         async with session.begin():
-            # auth_factors before recovery_codes, the one order every route
-            # that touches both has to take. Spending a recovery proof writes
-            # recovery_codes and the budget reset below writes auth_factors,
-            # so without this the pair runs backwards from confirm_enrolment
-            # and a recovery-code login racing a replacement deadlocks: two
-            # transactions each holding what the other wants, resolved by
-            # PostgreSQL killing one, which the caller sees as a 500 on a
-            # sign-in (issue #438).
-            await session.execute(
-                select(AuthFactor.id).where(AuthFactor.id == factor.id).with_for_update())
             # The session is contingent on winning this. The attempt was
             # counted and committed before the code was checked, so a second
             # request carrying the same challenge reaches here too, and only
@@ -223,10 +213,27 @@ async def answer_challenge(body: CodeRequest, request: Request) -> Response:
                 .values(consumed_at=func.now())
                 .returning(AuthToken.id)
             )).first()
+            if won is None:
+                raise REFUSED
+            # auth_factors before recovery_codes, the one order every route
+            # that touches both has to take. Spending a recovery proof writes
+            # recovery_codes and the budget reset below writes auth_factors,
+            # so without this the pair runs backwards from confirm_enrolment
+            # and a recovery-code login racing a replacement deadlocks: two
+            # transactions each holding what the other wants, resolved by
+            # PostgreSQL killing one, which the caller sees as a 500 on a
+            # sign-in (issue #438).
+            #
+            # After the token claim, not before it: operator.collapse deletes
+            # auth_tokens before auth_factors, so locking the factor first
+            # would trade the cycle this closes for one against a collapse run
+            # while the API is still up.
+            await session.execute(
+                select(AuthFactor.id).where(AuthFactor.id == factor.id).with_for_update())
             # The proof is spent here rather than when it was checked, so the
             # request that loses the race rolls back and gives the code or the
             # step back with it (#424).
-            if won is None or not await _spend(session, factor, proof):
+            if not await _spend(session, factor, proof):
                 raise REFUSED
             # Answering a challenge proves the authenticator is in the right
             # hands, which is what the replacement budget waits for. An
@@ -478,9 +485,6 @@ async def confirm_enrolment(
                 )).first()
                 if gone is None:
                     raise REFUSED
-            # Replacing an enrolment replaces its codes with it: a code minted
-            # for a secret nobody holds any more is a way in nobody expects.
-            await session.execute(delete(RecoveryCode).where(RecoveryCode.user_id == user_id))
             # A first enrolment deletes nothing at all. Deleting by account
             # here is what let two of them race: both read no factor, the
             # first installed one, and the second removed it and installed
@@ -495,8 +499,6 @@ async def confirm_enrolment(
                 # live for another ninety seconds otherwise.
                 last_step=step,
             ))
-            for code in codes:
-                session.add(RecoveryCode(user_id=user_id, code_hash=_hash(code)))
             try:
                 await session.flush()
             except IntegrityError as raced:
@@ -514,6 +516,19 @@ async def confirm_enrolment(
                 raise HTTPException(
                     status_code=409,
                     detail="a second factor was enrolled already") from raced
+            # Replacing an enrolment replaces its codes with it: a code minted
+            # for a secret nobody holds any more is a way in nobody expects.
+            #
+            # After the factor insert, never before it, and this is the whole
+            # of the first enrolment's share of the one lock order. An insert
+            # whose unique key collides with a row some other transaction has
+            # deleted and not yet committed waits for that transaction, so a
+            # first enrolment that ran the delete first would be holding
+            # recovery_codes while waiting on auth_factors, which is the cycle
+            # every other route here is arranged to avoid (issue #438).
+            await session.execute(delete(RecoveryCode).where(RecoveryCode.user_id == user_id))
+            for code in codes:
+                session.add(RecoveryCode(user_id=user_id, code_hash=_hash(code)))
             # After the guarded flush, not before it. Any statement issued
             # while the new factor is still pending autoflushes it, and that
             # flush happens outside the try, so the constraint violation this

--- a/backend/app/factors.py
+++ b/backend/app/factors.py
@@ -203,6 +203,16 @@ async def answer_challenge(body: CodeRequest, request: Request) -> Response:
         raise REFUSED
     async with db.session_factory() as session:
         async with session.begin():
+            # auth_factors before recovery_codes, the one order every route
+            # that touches both has to take. Spending a recovery proof writes
+            # recovery_codes and the budget reset below writes auth_factors,
+            # so without this the pair runs backwards from confirm_enrolment
+            # and a recovery-code login racing a replacement deadlocks: two
+            # transactions each holding what the other wants, resolved by
+            # PostgreSQL killing one, which the caller sees as a 500 on a
+            # sign-in (issue #438).
+            await session.execute(
+                select(AuthFactor.id).where(AuthFactor.id == factor.id).with_for_update())
             # The session is contingent on winning this. The attempt was
             # counted and committed before the code was checked, so a second
             # request carrying the same challenge reaches here too, and only
@@ -437,7 +447,9 @@ async def confirm_enrolment(
         async with session.begin():
             if replacing is not None:
                 # The factor row first, always, whichever kind of proof this
-                # is. Spending a recovery code touches recovery_codes and then
+                # is, and answer_challenge takes it first too: auth_factors
+                # before recovery_codes is the order every route that touches
+                # both must take (issue #438). Spending a recovery code touches recovery_codes and then
                 # auth_factors, and spending a step touches auth_factors and
                 # then the code sweep touches recovery_codes: two replacements
                 # of different kinds would take the two tables in opposite

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -1096,3 +1096,75 @@ def test_enrolling_leaves_a_reset_link_alone(accounts):
         assert client.portal.call(live_resets) == 1
         _enrol(client)
         assert client.portal.call(live_resets) == 1
+
+
+def _locks_taken(statements: list[str]) -> list[str]:
+    """The order the two tables that can deadlock were first LOCKED.
+
+    Only statements that take a row lock count: an UPDATE, a DELETE, or a
+    SELECT ... FOR UPDATE. A plain SELECT reads without locking and cannot be
+    half of a cycle, and counting one made an earlier version of this test
+    pass with the fix removed, because enrolled_factor reads auth_factors
+    before the transaction either way.
+    """
+    order: list[str] = []
+    for statement in statements:
+        lowered = " ".join(statement.lower().split())
+        locking = (lowered.startswith(("update", "delete"))
+                   or (lowered.startswith("select") and "for update" in lowered))
+        if not locking:
+            continue
+        # The attempt counter runs in a transaction of its own and commits, so
+        # its lock is gone before the one that matters begins. Counting it hid
+        # the replacement half of this test: auth_factors looked locked first
+        # whether or not the route that has to lock it did.
+        if "replace_attempts" in lowered:
+            continue
+        for table in ("auth_factors", "recovery_codes"):
+            if table in lowered and table not in order:
+                order.append(table)
+    return order
+
+
+@pytest.mark.db
+@pytest.mark.parametrize("route", ["challenge", "replacement"])
+def test_both_routes_take_the_factor_before_the_codes(accounts, route):
+    """One lock order, or the two deadlock against each other.
+
+    Spending a recovery code writes recovery_codes and the budget reset writes
+    auth_factors, so a challenge answered with a code touches both, and so
+    does a replacement. Taken in opposite orders they are a cycle, and
+    PostgreSQL breaks a cycle by killing one of them, which reaches a caller
+    as a 500 on a sign-in (issue #438).
+
+    Asserted on the order the statements go out rather than by staging a real
+    deadlock: making one happen means holding a transaction open inside the
+    spend while another starts, which is how a suite hangs instead of failing.
+    """
+    from sqlalchemy import event
+
+    seen: list[str] = []
+
+    with TestClient(app, base_url=ORIGIN) as client:
+        client.portal.call(_make, "ordered@example.com")
+        assert _login(client, "ordered@example.com").status_code == 204
+        secret, codes = _enrol(client)
+
+        def record(conn, cursor, statement, parameters, context, executemany):
+            seen.append(statement)
+
+        event.listen(db.engine.sync_engine, "before_cursor_execute", record)
+        try:
+            if route == "challenge":
+                _signed_out(client)
+                assert _login(client, "ordered@example.com").status_code == 200
+                assert client.post("/api/v1/auth/totp", headers={"Origin": ORIGIN},
+                                   json={"code": codes[0]}).status_code == 204
+            else:
+                _, replaced = _replace(client, None, current=codes[0])
+                assert replaced.status_code == 204
+        finally:
+            event.remove(db.engine.sync_engine, "before_cursor_execute", record)
+
+    taken = _locks_taken(seen)
+    assert taken[:2] == ["auth_factors", "recovery_codes"], taken

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -1098,27 +1098,23 @@ def test_enrolling_leaves_a_reset_link_alone(accounts):
         assert client.portal.call(live_resets) == 1
 
 
-def _locks_taken(statements: list[str]) -> list[str]:
-    """The order the two tables that can deadlock were first LOCKED.
+def _order_within(statements: list[str]) -> list[str]:
+    """The order one transaction first took a lock on each of the two tables.
 
-    Only statements that take a row lock count: an UPDATE, a DELETE, or a
-    SELECT ... FOR UPDATE. A plain SELECT reads without locking and cannot be
-    half of a cycle, and counting one made an earlier version of this test
-    pass with the fix removed, because enrolled_factor reads auth_factors
-    before the transaction either way.
+    Only statements that take a lock another transaction can wait behind
+    count. An UPDATE, a DELETE and a SELECT ... FOR UPDATE lock the rows they
+    match; an INSERT locks the unique key it claims, which is enough to wait
+    on a conflicting row some other transaction has deleted and not committed.
+    A plain SELECT locks nothing and cannot be half of a cycle: counting one
+    made an earlier version of this test pass with the fix removed, because
+    enrolled_factor reads auth_factors before the transaction either way.
     """
     order: list[str] = []
     for statement in statements:
         lowered = " ".join(statement.lower().split())
-        locking = (lowered.startswith(("update", "delete"))
+        locking = (lowered.startswith(("update", "delete", "insert"))
                    or (lowered.startswith("select") and "for update" in lowered))
         if not locking:
-            continue
-        # The attempt counter runs in a transaction of its own and commits, so
-        # its lock is gone before the one that matters begins. Counting it hid
-        # the replacement half of this test: auth_factors looked locked first
-        # whether or not the route that has to lock it did.
-        if "replace_attempts" in lowered:
             continue
         for table in ("auth_factors", "recovery_codes"):
             if table in lowered and table not in order:
@@ -1126,45 +1122,81 @@ def _locks_taken(statements: list[str]) -> list[str]:
     return order
 
 
+def _lock_orders(transactions: list[list[str]]) -> list[list[str]]:
+    """Per transaction that locked BOTH tables, the order it took them.
+
+    Grouped by transaction, because only locks held at the same time can be
+    half of a cycle, and a transaction that commits releases everything it
+    held. Counting across the whole request instead let the replacement
+    attempt counter, which runs in a transaction of its own and commits before
+    the one that matters begins, stand in for the lock the route under test is
+    supposed to take.
+
+    A transaction touching one table cannot deadlock against anything on this
+    pair, so only those touching both are judged.
+    """
+    orders = [_order_within(statements) for statements in transactions]
+    return [order for order in orders if len(order) == 2]
+
+
 @pytest.mark.db
-@pytest.mark.parametrize("route", ["challenge", "replacement"])
-def test_both_routes_take_the_factor_before_the_codes(accounts, route):
-    """One lock order, or the two deadlock against each other.
+@pytest.mark.parametrize("route", ["challenge", "replacement", "first enrolment"])
+def test_every_route_takes_the_factor_before_the_codes(accounts, route):
+    """One lock order, or these deadlock against each other.
 
     Spending a recovery code writes recovery_codes and the budget reset writes
-    auth_factors, so a challenge answered with a code touches both, and so
-    does a replacement. Taken in opposite orders they are a cycle, and
-    PostgreSQL breaks a cycle by killing one of them, which reaches a caller
-    as a 500 on a sign-in (issue #438).
+    auth_factors, so a challenge answered with a code touches both; so does a
+    replacement; and a first enrolment inserts a factor and clears the account
+    codes. Taken in opposite orders they are a cycle, and PostgreSQL breaks a
+    cycle by killing one of them, which reaches a caller as a 500 on a sign-in
+    (issue #438).
 
-    Asserted on the order the statements go out rather than by staging a real
+    Asserted on the order the locks go out rather than by staging a real
     deadlock: making one happen means holding a transaction open inside the
     spend while another starts, which is how a suite hangs instead of failing.
     """
     from sqlalchemy import event
 
-    seen: list[str] = []
+    transactions: list[list[str]] = []
+    current: list[str] = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        current.append(statement)
+
+    def close(conn):
+        nonlocal current
+        transactions.append(current)
+        current = []
 
     with TestClient(app, base_url=ORIGIN) as client:
+        # Inside the lifespan, never before it: startup connects and builds a
+        # new engine, so a listener attached to the one that is here now
+        # records nothing and the assertions below all pass on no evidence.
+        engine = db.engine.sync_engine
         client.portal.call(_make, "ordered@example.com")
         assert _login(client, "ordered@example.com").status_code == 204
-        secret, codes = _enrol(client)
+        if route != "first enrolment":
+            secret, codes = _enrol(client)
 
-        def record(conn, cursor, statement, parameters, context, executemany):
-            seen.append(statement)
-
-        event.listen(db.engine.sync_engine, "before_cursor_execute", record)
+        for name, handler in (("before_cursor_execute", record),
+                              ("commit", close), ("rollback", close)):
+            event.listen(engine, name, handler)
         try:
             if route == "challenge":
                 _signed_out(client)
                 assert _login(client, "ordered@example.com").status_code == 200
                 assert client.post("/api/v1/auth/totp", headers={"Origin": ORIGIN},
                                    json={"code": codes[0]}).status_code == 204
-            else:
+            elif route == "replacement":
                 _, replaced = _replace(client, None, current=codes[0])
                 assert replaced.status_code == 204
+            else:
+                _enrol(client)
         finally:
-            event.remove(db.engine.sync_engine, "before_cursor_execute", record)
+            for name, handler in (("before_cursor_execute", record),
+                                  ("commit", close), ("rollback", close)):
+                event.remove(engine, name, handler)
 
-    taken = _locks_taken(seen)
-    assert taken[:2] == ["auth_factors", "recovery_codes"], taken
+    orders = _lock_orders(transactions + [current])
+    assert orders, "no transaction locked both tables, so this proved nothing"
+    assert all(order == ["auth_factors", "recovery_codes"] for order in orders), orders

--- a/backend/tests/test_totp_flow.py
+++ b/backend/tests/test_totp_flow.py
@@ -833,9 +833,11 @@ def test_a_first_enrolment_that_races_a_factor_is_refused_not_a_crash(accounts, 
                                json={"enrolment": started["enrolment"],
                                      "code": totp.code_at(started["secret"], int(_now()))})
         assert answered.status_code == 409
-        # The sweep ran before the insert that failed, so the account's
-        # recovery codes were deleted inside the transaction that then rolled
-        # back. Losing this race must not cost them.
+        # The sweep never runs: it sits after the insert that failed. Losing
+        # this race cost the codes nothing when the sweep ran first either,
+        # because the transaction rolled back, so this assertion holds under
+        # both orders and is not what keeps the sweep where it is. That is
+        # test_every_route_takes_the_factor_before_the_codes.
         assert len(client.portal.call(_unspent_codes)) == totp.RECOVERY_CODES
         # The factor that was already there is the one still there.
         stored = client.portal.call(_factors)
@@ -1158,15 +1160,16 @@ def test_every_route_takes_the_factor_before_the_codes(accounts, route):
     from sqlalchemy import event
 
     transactions: list[list[str]] = []
-    current: list[str] = []
+    # Keyed by connection, because two of them interleaving would otherwise
+    # read as one transaction taking both tables, and a reversal on either
+    # could hide inside the merge.
+    open_now: dict[int, list[str]] = {}
 
     def record(conn, cursor, statement, parameters, context, executemany):
-        current.append(statement)
+        open_now.setdefault(id(conn), []).append(statement)
 
     def close(conn):
-        nonlocal current
-        transactions.append(current)
-        current = []
+        transactions.append(open_now.pop(id(conn), []))
 
     with TestClient(app, base_url=ORIGIN) as client:
         # Inside the lifespan, never before it: startup connects and builds a
@@ -1197,6 +1200,6 @@ def test_every_route_takes_the_factor_before_the_codes(accounts, route):
                                   ("commit", close), ("rollback", close)):
                 event.remove(engine, name, handler)
 
-    orders = _lock_orders(transactions + [current])
+    orders = _lock_orders(transactions + list(open_now.values()))
     assert orders, "no transaction locked both tables, so this proved nothing"
     assert all(order == ["auth_factors", "recovery_codes"] for order in orders), orders


### PR DESCRIPTION
# Description

Every route that touches both `auth_factors` and `recovery_codes` now takes them in that order. Closes #438.

# Motivation

This is on main. It ships today.

A challenge answered with a recovery code writes `recovery_codes` to spend the code, then writes `auth_factors` to reset the replacement budget. A replacement takes the factor row `FOR UPDATE` first and sweeps `recovery_codes` afterwards. Two transactions taking the same two tables in opposite orders is a cycle, and PostgreSQL breaks a cycle by aborting one of them, which the caller sees as a `500` on a sign-in.

It is also my own half-done fix. The review of #432 found a version of this within `confirm_enrolment` and said to use one lock order for both routes. I read that as being about the route I had open, applied it there, and left the other one pointing the other way.

# Functionality

`auth_factors` before `recovery_codes`, on all three paths that reach both, with the invariant named where each takes it.

# Details

**A third path had the same bug, found in review.** A first enrolment has no factor to lock, so it fell outside the fix: it deleted the account recovery codes and then inserted the factor, which is the banned order.

That only matters if an insert can wait, so it was measured before anything was changed:

```
insert still blocked after 3.00s -> IT WAITS
```

An insert whose unique key collides with a row another transaction has deleted and not yet committed blocks on that transaction until it ends. So a stale first enrolment concurrent with a replacement is the same deadlock from a third direction: the enrolment holds recovery codes and waits on the factor delete, the replacement holds the factor and waits on the codes. The factor insert goes first now.

**The challenge lock moved after the token claim**, also from review. Taken before it, `auth_factors` came ahead of `auth_tokens`, and `operator.collapse` deletes `auth_tokens` ahead of `auth_factors`, so the first version traded this cycle for one against an operator collapse run while the API is up. The claim orders nothing that follows, so both orders hold at once.

**Getting the test to mean anything took three goes, and the first two failures were the same mistake in different clothes.**

Counting every statement mentioning either table passed with the fix removed: `enrolled_factor` reads `auth_factors` before the transaction either way, and a plain `SELECT` takes no lock. Counting the `replace_attempts` update passed too: it runs in a transaction of its own that commits, so its lock is gone before the one that matters begins.

Both are the same error, which is why the third version fixes the scope rather than the filter. Statements are grouped by transaction, using the `commit` and `rollback` events, and only transactions that lock both tables are judged. The attempt counter then drops out on its own, because its transaction touches one table, instead of being excluded by name.

**The rebuilt test caught a bug in itself first.** It attached its listener to the engine that existed before `TestClient` started, and startup connects and builds another, so it recorded nothing at all. `assert orders, "no transaction locked both tables, so this proved nothing"` is what turned that silence into a failure instead of three green tests resting on no evidence.

**Asserted on lock order rather than by staging a deadlock**, deliberately. Producing one means holding a transaction open inside the spend while another starts, which is how a suite hangs instead of failing, and a real deadlock surfaces as an opaque driver error where a statement-order assertion names both tables.

Each of the three properties was neuter-checked: removing either `FOR UPDATE`, or putting the code delete back before the factor insert, fails exactly its own parametrisation and nothing else.

`make verify` from the worktree with `PYTHONPATH` forced to it: 919 backend, 247 worker, frontend and CSP, `MAKE_EXIT=0`.

**Unblocks #437**, whose removal route takes the same `auth_factors`-first order and therefore inherits this cycle against `answer_challenge` as it stands on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when completing authentication challenges and replacing authentication factors by preventing transaction deadlocks.
  - Ensured recovery-code and authentication-factor updates are processed in a consistent order.
  - Authentication challenges now fail safely when required verification information is no longer available.

- **Tests**
  - Added regression coverage for locking behavior during TOTP verification, factor replacement, and first-time enrolment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->