### PR TITLE
A link lands only while the account is still active

### DIFF
--- a/backend/app/oauth.py
+++ b/backend/app/oauth.py
@@ -364,12 +364,19 @@ async def _link(provider: str, identity: ProviderIdentity, user_id: uuid.UUID,
     died while it was away at the provider is refused: the link would add a
     way in and end nothing, which is the reverse of what revoking that session
     meant.
+
+    The account has to still be active, which is what start_link asked for
+    before sending the browser away. Ten minutes is long enough for an
+    administrator to suspend an account in, and suspension is the one state
+    that leaves its sessions alive, so without this the flow that started a
+    moment before the suspension lands a moment after it and adds a way into
+    an account somebody has just closed off.
     """
     if db.session_factory is None:
         raise HTTPException(status_code=503, detail="database unavailable")
     presented = request.cookies.get(sessions.cookie_names(settings.public_url)[0])
     linker = await sessions.resolve(presented) if presented else None
-    if linker is None or linker.user.id != user_id:
+    if linker is None or linker.user.id != user_id or linker.user.state != "active":
         raise REFUSED
     async with db.session_factory() as session:
         async with session.begin():

--- a/backend/tests/test_oauth.py
+++ b/backend/tests/test_oauth.py
@@ -407,6 +407,38 @@ def _linked_through(client, provider):
     return _callback(client, provider, state)
 
 
+async def _suspend(user_id: uuid.UUID) -> None:
+    """Suspension only, and directly, because it is the one state that leaves
+    the account's sessions alive. Every other state a link must not land on
+    revokes them, so the callback's live-session guard already refuses those
+    and this is the case that slips past it."""
+    async with db.session_factory() as session:
+        await session.execute(
+            text("UPDATE users SET prior_state = state, state = 'suspended' WHERE id = :id"),
+            {"id": user_id})
+        await session.commit()
+
+
+@pytest.mark.db
+def test_a_link_started_while_active_does_not_land_after_a_suspension(accounts, monkeypatch):
+    """start_link asks for an active account and then sends the browser away
+    for up to ten minutes, which is long enough for an administrator to close
+    the account in. Suspension keeps its sessions, so the callback's own guard
+    lets that browser back in (issue #448)."""
+    _fake_provider(monkeypatch, "github", subject="h-susp", email="susp@example.com")
+    with TestClient(app, base_url=ORIGIN) as client:
+        user = client.portal.call(_make, "susp@example.com")
+        _sign_in(client, "susp@example.com")
+        started = client.post("/api/v1/account/identities/github", headers=_csrf(client))
+        assert started.status_code == 200, started.text
+        state = parse_qs(urlsplit(started.json()["redirect"]).query)["state"][0]
+
+        client.portal.call(_suspend, user.id)
+
+        assert _callback(client, "github", state).status_code == 403
+        assert [row.provider for row in client.portal.call(_identities, user.id)] == ["password"]
+
+
 @pytest.mark.db
 def test_linking_a_provider_rotates_the_token_that_linked_it(accounts, monkeypatch):
     """A link adds a way into the account, which is the same kind of event as


### PR DESCRIPTION
# Description

The OAuth callback that finishes a link now requires the account to still be active, which is what the redirect that started the flow required. Closes #448.

# Motivation

`start_link` refuses an account that is not `active`, then sends the browser away to the provider for up to ten minutes. The callback checked that the linking session was still alive and never that the account still was, so a flow started a moment before a suspension landed a moment after it, adding a way into an account an administrator had just closed off.

Suspension is the case that mattered, and it is the one this slipped through by accident rather than by design: every other state a link must not land on revokes the account's sessions, so the live-session guard added in #445 already refused those. Suspension keeps its sessions.

# Functionality

`_link` refuses `403` unless the resolved session's account is `active`, alongside the checks that the session exists and belongs to the account the flow named.

# Details

The callback now asks for exactly what the redirect asked for, which is the property worth having: `start_link` requires `active`, so finishing requires `active`. That is stricter than `CANNOT_SIGN_IN`, which admits `suspended`, and the issue raised the choice between the two. Matching `start_link` is the simpler rule and the one that closes the reported gap; a link is not something a suspended account should be completing either way.

**Neuter-checked**: with the state check removed, `test_a_link_started_while_active_does_not_land_after_a_suspension` fails and the other 32 tests in the file pass, which is the point - nothing else in that file notices.

The test suspends the account directly rather than through the admin route, because the interesting property is that suspension leaves the sessions alive; going through the route would revoke them and the live-session guard would refuse the callback for the wrong reason, proving nothing about this change.

`make verify-backend` from the worktree with `PYTHONPATH` forced: **983 passed**, ruff and mypy clean. The self-hosted runner is stopped, so there is no CI on this push; the local run is the evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth account linking is now blocked when the initiating account becomes suspended during the linking process.
  * Suspended accounts receive an access-denied response, preventing unintended identity linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->