### PR TITLE
One database for every make target that talks to one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,15 @@ verify-guards: ## prove setup refuses a too-old Python and recreates a pip-less 
 		echo 'error: ensure-env.sh left FLEET_SECRET empty.' >&2; \
 		exit 1; \
 	fi; \
-	echo 'setup guards ok: no 3.11+ interpreter is refused; pip-less venvs are recreated; empty FLEET_SECRET is filled'
+	exported=$$(awk '/: export DATABASE_URL/{print} /^[a-z].*\\$$/{line=line" "$$0}' "$(CURDIR)/Makefile" | tr -d '\\\\'); \
+	for t in $$(grep -oE '^auth-[a-z-]+:' "$(CURDIR)/Makefile" | tr -d ':'); do \
+		if ! awk '/export DATABASE_URL/{found=1} found&&/^auth-|^api /{print}' "$(CURDIR)/Makefile" | grep -qw "$$t" && \
+		   ! sed -n '/^api dev-start/,/export DATABASE_URL/p' "$(CURDIR)/Makefile" | grep -qw "$$t"; then \
+			echo "error: $$t is not in the DATABASE_URL export list, so it acts on a different database than make api (issue #450)." >&2; \
+			exit 1; \
+		fi; \
+	done; \
+	echo 'setup guards ok: no 3.11+ interpreter is refused; pip-less venvs are recreated; empty FLEET_SECRET is filled; every auth target shares the API database'
 
 verify-compose: ## validate every compose file and profile (no containers started)
 	cd deploy/compose && ENV_FILE=$$([ -f .env ] && echo .env || echo .env.example) && \
@@ -354,7 +362,14 @@ override DB_SUFFIX := $(patsubst DB_SUFFIX=%,%,$(filter DB_SUFFIX=%,$(CHECKOUT_P
 # would then run against it.
 DEV_DB_SUPPLIED := $(if $(strip $(value DATABASE_URL)),1,)
 ifeq (,$(DEV_DB_SUPPLIED))
-api dev-start dev-restart cleanup-failed: export DATABASE_URL := \
+# Every target that talks to the database, or the auth-* commands silently
+# act on a different one: they fell through to the application default while
+# the API used this checkout's, so `auth-enable` wrote the flag somewhere the
+# API never reads and `auth-clear-factor` reported no such account while the
+# row sat in the other database (issue #450).
+api dev-start dev-restart cleanup-failed \
+auth-recover auth-enable auth-reclaim auth-rotate-keys auth-clear-factor \
+auth-configure auth-collapse: export DATABASE_URL := \
 	postgresql://potocolom:potocolom@localhost:5432/potocolom$(DB_SUFFIX)
 endif
 # Empty by default so scripts/dev-stack.sh detects the GPU this machine has.


### PR DESCRIPTION
# Description

Every `auth-*` target now exports the same `DATABASE_URL` that `make api` does, and a guard keeps it that way. Closes #450.

# Motivation

The Makefile exported this checkout's database for a named list of targets, and the `auth-*` commands were not on it, so they fell through to the application default while the API used the suffixed one.

Hit while smoke-testing accounts mode on merged main. `make auth-enable` reported success and the API then refused to start with "accounts mode requires explicit installation enable", because the flag had gone to a database it never reads. Later `make auth-clear-factor EMAIL=admin@example.com` answered "no account holds admin@example.com" while that account's factor row sat in the other database. Both messages are correct about the database they were handed and neither says which one that was, so the failure mode is somebody debugging their install rather than their invocation.

`DB_SUFFIX` is empty on the main checkout, so this only bites in the worktrees the contributor instructions ask people to use.

# Functionality

No behaviour change on the main checkout. In a worktree, `auth-recover`, `auth-enable`, `auth-reclaim`, `auth-rotate-keys`, `auth-clear-factor`, `auth-configure` and `auth-collapse` now act on the same database the API serves.

# Details

**Demonstrated rather than asserted.** With the fix, `make auth-enable` in a fresh worktree leaves `installation_auth_state.auth_mode = accounts` in `potocolom_d298e07e`, this checkout's database, and `deploy/compose/.env` carries no `DATABASE_URL`, so it came from the Makefile alone. With the target list reverted, the same command leaves that database without even the table:

```
ERROR:  relation "installation_auth_state" does not exist
```

**The guard is the point.** This is a wiring bug: the mechanism was fine and one line decided which database it pointed at. `verify-guards` already proves Makefile behaviour, so it now also asserts every `auth-*` target appears in that export list. Dropping `auth-clear-factor` from the list fails it by name:

```
error: auth-clear-factor is not in the DATABASE_URL export list, so it acts on
a different database than make api (issue #450).
```

so the next `auth-*` target added cannot quietly repeat this.

**Not addressed here.** The operator commands still do not say which database they acted on. `clear-factor` reporting "no account holds X" is much easier to act on when it also says where it looked, but that is a change to the command output rather than to the wiring, and it belongs with whoever next touches `operator.py`.

The self-hosted runner is stopped, so there is no CI on this push. `make verify-guards` passes locally, and the before/after above is the evidence for the fix itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Authentication administration commands now consistently use the checkout’s database.
  - Added validation to detect missing database configuration for authentication commands, helping prevent misconfigured operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->