### PR TITLE
Give the result image a height on anything narrower than a desktop

### DIFF
--- a/frontend/src/lib/components/generate-panel.svelte
+++ b/frontend/src/lib/components/generate-panel.svelte
@@ -820,7 +820,7 @@
 
 	<!-- min-w-0: the thumbnail strip's intrinsic width must not widen the grid track -->
 	<div class="flex min-h-0 min-w-0 flex-col gap-3">
-		<Card.Root class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+		<Card.Root class="flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto lg:overflow-hidden">
 			<Card.Content class="flex min-h-0 flex-1 flex-col gap-2 p-4">
 				{#if shown !== null}
 					{#if lineage !== null}
@@ -882,7 +882,7 @@
 						</div>
 					{/if}
 					{#if shown.assets.length > 0}
-						<div class="relative min-h-0 flex-1">
+						<div class="relative min-h-64 flex-1 lg:min-h-0">
 							<a
 								href={shown.assets[0].url}
 								target="_blank"
@@ -908,7 +908,7 @@
 						</div>
 					{:else}
 						<div
-							class="border-border text-muted-foreground grid min-h-0 flex-1 place-items-center rounded-lg border border-dashed text-sm"
+							class="border-border text-muted-foreground grid min-h-64 flex-1 place-items-center rounded-lg border border-dashed text-sm lg:min-h-0"
 						>
 							{t('app.lineage.missing')}
 						</div>


### PR DESCRIPTION
# Description

The generated image rendered at zero height on anything narrower than a desktop, so a phone user generated a picture and never saw one. Found by driving the running studio in a real browser.

# Motivation

`/app` at 390x844 shows the ancestry thumbnail and the DERIVATIVES block and no picture. The image element is there and has loaded (`naturalWidth 512`, `complete: true`); it is laid out at zero height. The card is `overflow-hidden`, and the app shell is `h-svh overflow-hidden`, so there is nothing to scroll to reveal it either.

Measured across widths, everything else equal:

| viewport width | image height |
|---|---|
| 390 | 0 |
| 768 | 0 |
| 1023 | 0 |
| 1024 | 394 |
| 1280 | 394 |

It fixes exactly at the `lg` breakpoint, which is where the layout becomes two columns.

# Functionality

Below `lg` the picture gets a height and the result card scrolls. At `lg` and above nothing changes.

# Details

The image wrapper asks for `flex-1` inside a `min-h-0` chain. That only resolves against a definite height. The two-column grid gives the right-hand column one; the single-column stack below `lg` does not, so the wrapper collapsed to zero and took the picture with it.

The download button is `absolute top-2 right-2` inside that same wrapper, so when the wrapper collapsed the button landed on the caption and the DERIVATIVES heading below it. That was reported separately as an overlap, but it is the same bug wearing different clothes and it goes with the same fix, which is why there is one change here and not two.

Three classes:

- the result card scrolls below `lg` (`overflow-y-auto lg:overflow-hidden`), because the shell is `h-svh overflow-hidden` and nothing outside the card can scroll to reveal what does not fit
- the image wrapper gets a floor below `lg` (`min-h-64 lg:min-h-0`)
- the empty-state placeholder gets the same floor, since it collapses the same way

**Verified in the browser, before and after.** After the change: 256 at 390, 768 and 1023, and still 394 at 1024 and 1280, so the desktop layout is untouched. `document.elementsFromPoint` at the download button's centre now returns the button over the `IMG` at every width, where before it returned the caption and the derivatives text.

`npm run check` 0 errors 0 warnings across 1251 files, `npm run lint` clean, `npm run build` succeeds and `verify-csp` passes on all 17 HTML files.

**Also checked and clean during the same browser pass**, so not part of this change: every route (`/`, `/app`, `/whitepaper`, `/benchmark`, `/legal`, `/privacy`) has zero console errors, zero page exceptions and zero failed requests; the 404 route answers 404 and renders its page; a generation returns an image in 369 ms; the realtime WebSocket opens, round-trips a frame and stays open; and there is no document-level horizontal overflow at 390 px anywhere.

**One thing observed and deliberately not changed:** two fast clicks on Generate produce two generations, with no de-duplication and no in-flight lock. Nothing breaks and both succeed, so it is behaviour rather than a defect, but it is worth a decision on its own rather than being folded into a layout fix.

The self-hosted runner is stopped, so there is no CI on this push; the measurements above and the frontend gates are the evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the result viewer layout on large screens with vertical scrolling.
  * Added consistent minimum heights for populated and empty result areas.
  * Enhanced responsive behavior for image and placeholder panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->