### PR TITLE
Stop the batch collector when the worker stops

### DIFF
--- a/worker/tests/test_client.py
+++ b/worker/tests/test_client.py
@@ -1401,3 +1401,53 @@ def test_session_runner_ignores_resident_wording_on_other_errors():
     controls = [json.loads(m) for m in socket.sent if isinstance(m, str)]
     assert any(m.get("type") == "session_ready" for m in controls)
     assert not any(m.get("type") == "session_refused" for m in controls)
+
+
+def test_run_closes_the_engine_when_the_worker_stops(monkeypatch):
+    """Cancellation is how a worker stops, and build_runtime hands run() an
+    engine nothing else owns. Without a close on the way out the collector's
+    loop task outlives the loop that created it (issue #456)."""
+    engine = SimulatedEngine(0.0)
+
+    async def scenario():
+        serving = asyncio.Event()
+
+        class Connection:
+            def __init__(self, url, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return object()
+
+            async def __aexit__(self, *exc):
+                return None
+
+        async def fake_serve_connection(ws, settings, manifests, served):
+            await served.frame(SIMULATED_MANIFEST, {}, b"payload")
+            serving.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(
+            "worker.client.get_settings",
+            lambda: Settings(worker_id="w-stop", fleet_token="fleet-secret"))
+        monkeypatch.setattr("worker.client.build_runtime",
+                            lambda _settings: ([SIMULATED_MANIFEST], engine))
+        monkeypatch.setattr("worker.client.websockets.connect", Connection)
+        monkeypatch.setattr("worker.client.serve_connection", fake_serve_connection)
+
+        worker = asyncio.create_task(run())
+        await serving.wait()
+        collector_loop = engine._batch_collector._loop_task
+        assert collector_loop is not None and not collector_loop.done()
+        worker.cancel()
+        try:
+            await worker
+        except asyncio.CancelledError:
+            pass
+        # Read inside the loop: asyncio.run cancels every straggler on the way
+        # out, so a task checked after it returns looks stopped either way.
+        return collector_loop.cancelled(), engine._batch_collector._loop_task
+
+    cancelled, remaining = asyncio.run(scenario())
+    assert cancelled
+    assert remaining is None

--- a/worker/tests/test_engine.py
+++ b/worker/tests/test_engine.py
@@ -3061,3 +3061,37 @@ def test_a_missing_source_is_never_substituted_by_the_model_id():
     engine._from_pretrained(FakeRepo, manifest)
 
     assert asked == [""]
+
+
+def test_closing_the_engine_stops_the_batch_collector():
+    engine = SimulatedEngine(0.0)
+
+    async def scenario():
+        await engine.frame(SIMULATED_MANIFEST, {}, b"payload")
+        collector_loop = engine._batch_collector._loop_task
+        assert collector_loop is not None and not collector_loop.done()
+        await engine.close()
+        return collector_loop.cancelled(), engine._batch_collector._loop_task
+
+    cancelled, remaining = asyncio.run(scenario())
+    assert cancelled
+    assert remaining is None
+
+
+def test_closing_the_engine_twice_does_not_raise():
+    engine = SimulatedEngine(0.0)
+
+    async def scenario():
+        await engine.frame(SIMULATED_MANIFEST, {}, b"payload")
+        await engine.close()
+        await engine.close()
+
+    asyncio.run(scenario())
+
+
+def test_closing_an_engine_that_never_ran_a_frame_does_not_raise():
+    asyncio.run(SimulatedEngine(0.0).close())
+
+
+def test_closing_a_diffusers_engine_built_without_init_does_not_raise():
+    asyncio.run(DiffusersEngine.__new__(DiffusersEngine).close())

--- a/worker/tests/test_frame_profile.py
+++ b/worker/tests/test_frame_profile.py
@@ -210,16 +210,23 @@ def _decoder_modules():
     return diffusers
 
 
+async def _await_frame(engine, manifest, *, prompt_cache=None, profile=False):
+    """Every frame on one engine goes through that engine's batch collector,
+    whose work Event binds to the first loop that waits on it. A test needing
+    two frames must await both in one loop; a second asyncio.run leaves the
+    collector's new task raising on the first loop's Event (issue #456)."""
+    return await engine.frame(
+        manifest,
+        {"prompt": "w0 w1"},
+        _payload(),
+        prompt_cache=prompt_cache,
+        profile=profile,
+    )
+
+
 def _frame(engine, manifest, *, prompt_cache=None, profile=False):
     return asyncio.run(
-        engine.frame(
-            manifest,
-            {"prompt": "w0 w1"},
-            _payload(),
-            prompt_cache=prompt_cache,
-            profile=profile,
-        )
-    )
+        _await_frame(engine, manifest, prompt_cache=prompt_cache, profile=profile))
 
 
 def test_default_frame_has_no_stages():
@@ -251,19 +258,30 @@ def test_prompt_cache_miss_then_hit():
     pipeline = _ProfilePipeline()
     engine = _engine(pipeline)
     cache = PromptCache()
+
+    async def scenario():
+        first = await _await_frame(
+            engine, _manifest(), prompt_cache=cache, profile=True)
+        second = await _await_frame(
+            engine, _manifest(), prompt_cache=cache, profile=True)
+        return first, second
+
     with patch.dict("sys.modules", {"diffusers": _decoder_modules()}):
-        first = _frame(engine, _manifest(), prompt_cache=cache, profile=True)
-        second = _frame(engine, _manifest(), prompt_cache=cache, profile=True)
+        first, second = asyncio.run(scenario())
     assert first.stages["text_encode_cache_hit"] == 0
     assert second.stages["text_encode_cache_hit"] == 1
 
 
 def test_simulated_engine_honors_profile():
     engine = SimulatedEngine(0.0)
-    default = asyncio.run(engine.frame(SIMULATED_MANIFEST, {}, _payload()))
-    profiled = asyncio.run(
-        engine.frame(SIMULATED_MANIFEST, {}, _payload(), profile=True)
-    )
+
+    async def scenario():
+        default = await engine.frame(SIMULATED_MANIFEST, {}, _payload())
+        profiled = await engine.frame(
+            SIMULATED_MANIFEST, {}, _payload(), profile=True)
+        return default, profiled
+
+    default, profiled = asyncio.run(scenario())
     assert default.stages is None
     assert set(profiled.stages) == PROFILE_KEYS
     assert all(type(value) is int for value in profiled.stages.values())

--- a/worker/worker/client.py
+++ b/worker/worker/client.py
@@ -837,20 +837,25 @@ async def run() -> None:
     settings = get_settings()
     manifests, engine = build_runtime(settings)
     delay = BACKOFF_INITIAL
-    while True:
-        try:
-            async with websockets.connect(
-                settings.api_url,
-                # Lowercase: header names are case-insensitive, but not every
-                # ASGI stack normalises them before the application looks.
-                additional_headers={"x-fleet-token": settings.fleet_token},
-            ) as ws:
-                delay = BACKOFF_INITIAL
-                await serve_connection(ws, settings, manifests, engine)
-        except RegistrationRejected as error:
-            logger.error("registration rejected (%s); update this worker, not retrying", error)
-            return
-        except (OSError, websockets.WebSocketException) as error:
-            logger.warning("connection lost (%s), retrying in %.0fs", error, delay)
-        await asyncio.sleep(delay * (1 + random.random() * BACKOFF_JITTER))
-        delay = min(delay * 2, BACKOFF_CAP)
+    try:
+        while True:
+            try:
+                async with websockets.connect(
+                    settings.api_url,
+                    # Lowercase: header names are case-insensitive, but not every
+                    # ASGI stack normalises them before the application looks.
+                    additional_headers={"x-fleet-token": settings.fleet_token},
+                ) as ws:
+                    delay = BACKOFF_INITIAL
+                    await serve_connection(ws, settings, manifests, engine)
+            except RegistrationRejected as error:
+                logger.error("registration rejected (%s); update this worker, not retrying", error)
+                return
+            except (OSError, websockets.WebSocketException) as error:
+                logger.warning("connection lost (%s), retrying in %.0fs", error, delay)
+            await asyncio.sleep(delay * (1 + random.random() * BACKOFF_JITTER))
+            delay = min(delay * 2, BACKOFF_CAP)
+    finally:
+        # build_runtime is called once, so the engine outlives every reconnect:
+        # it is stopped when the process is, never inside the retry loop.
+        await engine.close()

--- a/worker/worker/engine.py
+++ b/worker/worker/engine.py
@@ -207,6 +207,8 @@ class Engine(Protocol):
 
     async def unload_all(self) -> None: ...
 
+    async def close(self) -> None: ...
+
 
 def decode_input_image(data: bytes) -> Image.Image:
     """Decode a job's source image; a clear ValueError beats a Pillow OSError."""
@@ -361,6 +363,9 @@ class SimulatedEngine:
 
     async def unload_all(self) -> None:
         self._loaded.clear()
+
+    async def close(self) -> None:
+        await self._batch_collector.close()
 
     async def generate(
         self, manifest: Manifest, params: dict, progress: ProgressFn,
@@ -1612,6 +1617,9 @@ class DiffusersEngine:
     async def unload_all(self) -> None:
         async with self._gpu:
             await self._run_to_completion(self._evict_all)
+
+    async def close(self) -> None:
+        await self._batch_collector_or_create().close()
 
     def _pipeline_class(self, manifest: Manifest, mode: str) -> Any:
         import diffusers


### PR DESCRIPTION
# Description

The frame batch collector's loop task was started on the first frame and never cancelled, because `close()` had no production caller. The engine gains a shutdown path and the worker calls it. Closes #456.

# Motivation

`FrameBatchCollector` already had a correct `start()` / `close()` pair. `start()` is called lazily from `submit()`; `close()` was called from exactly one place in the repository, a test. `DiffusersEngine` had no `close`, `shutdown` or `aclose` at all, and `build_runtime` builds the engine once and nothing tore it down.

So a worker had no way to stop the collector, and the suite showed it as a task outliving the loop that made it.

# Functionality

`Engine` gains `close()`. `run()` calls it in a `finally`.

# Details

**The shape suits both implementations without either inventing anything.** `SimulatedEngine` and `DiffusersEngine` each already own a collector, so `close()` is a one-liner on each. `DiffusersEngine` routes through the existing `_batch_collector_or_create()`, which is what keeps engines built with `__new__` in tests working without a new guard.

`run()` closes in a `finally` because cancellation is the normal way a worker stops, and outside the reconnect loop because the engine outlives any one connection.

**The wiring test is the point.** `close()` was already correct; it was never called. A test that closes the collector by hand proves the mechanism and would have passed before this change. So the test drives `run()` with a real engine, pushes a frame through so `submit()` starts the loop task for real, cancels the task, and asserts the collector stopped. Neuter: emptying the `finally` body while leaving `close()` intact fails it.

One trap worth recording: `asyncio.run` cancels every straggler on its way out, so a task inspected after it returns looks stopped whether or not anything closed it. The assertions are read inside the coroutine.

**The stderr noise had a different cause, and my first reading of it was wrong.** The issue attributed it to the missing shutdown call. It is not. With the engine fix alone the noise was unchanged: present in 4 of 5 full runs, same as baseline.

Instrumenting `start()` traced it to two tests in `test_frame_profile.py` calling `asyncio.run` twice on the same engine. The first loop starts the collector and binds `_work` to that loop; `asyncio.run` cancels the task on exit; in the second loop `start()` sees a done task and makes a fresh one, but `_work` still belongs to the dead loop, so it dies at once and is reported at collection time. A test defect, not a worker one: production builds one engine and runs it on one loop. Both frames are awaited in one loop now.

With both changes: **8 of 8 runs clean**, and the gate log is clean too.

Rebinding `_work` inside `start()` was rejected: it adds production code for a state production cannot reach, and it would silently drop a pending `_work.set()` if `start()` were ever called from outside `submit()`.

**Neuter evidence.** Four of the five tests fail against their own neuter with the failure text recorded. The fifth, closing twice does not raise, has no failing neuter: the `suppress(CancelledError)` already in `close()` covers it and predates this change. It is a regression guard rather than a proof, and it is kept as one rather than dressed up.

Verified in both environments, which is the lesson from #457: **297 passed** with the inference extra installed, **281 passed and 16 skipped** in a CI-shaped venv built from `".[dev]"`. Backend 983. Ruff and mypy clean.

**Found, not fixed.** `scripts/compile_ab.py`, `scripts/profile-candidates.py` and `scripts/profile-realtime-frame.py` build a `DiffusersEngine` directly and never close it. They are one-shot GPU scripts outside CI, and `profile-realtime-frame.py` creates a fresh engine inside each `asyncio.run`, so it does not hit the cross-loop trap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker shutdown to reliably close processing engines and stop background batch collection.
  * Prevented lingering background tasks when worker execution is cancelled or ends.
  * Made engine shutdown safe when repeated, performed before processing starts, or used with an uninitialized engine.

* **Tests**
  * Added regression coverage for cancellation and engine cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->