### PR TITLE
A typed seed no longer stops Generate from doing anything

### DIFF
--- a/frontend/src/lib/components/generate-panel.svelte
+++ b/frontend/src/lib/components/generate-panel.svelte
@@ -70,7 +70,7 @@
 	let sizeContext = $state({ modelId: '', optionCount: 0 });
 	let count = $state('1');
 	let normsReady = $state(false);
-	let seed = $state('');
+	let seed = $state<number | null>(null);
 	let sourceAssetId = $state<string | null>(null);
 	let branchParams = $state<Record<string, unknown>>({});
 	// Which mode raised the branch that set the two above. One panel instance
@@ -248,7 +248,7 @@
 		studio.generationPrefill = null;
 		studio.prompt = prefill.prompt;
 		sourceAssetId = prefill.sourceAssetId;
-		seed = '';
+		seed = null;
 		branchParams = { ...prefill.params };
 		delete branchParams.seed;
 		branchMode = mode;
@@ -371,7 +371,7 @@
 				height: sizeValue
 			};
 			if (mode === 'image_to_image') params.strength = strengthValue;
-			if (seed.trim() !== '') params.seed = Number(seed) + index;
+			if (typeof seed === 'number' && Number.isFinite(seed)) params.seed = seed + index;
 			const response = await fetch('/api/v1/generations', {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
# Description

Typing a Seed silently stopped Generate from working until the page was reloaded. Found by driving the studio in a browser.

# Motivation

The Seed field is `type="number"`, so `bind:value` hands back a number, or `null` once the field is emptied. The state behind it was a string, and the submit path called `seed.trim()`.

So the moment somebody typed a digit into a field whose placeholder invites it ("Random if empty"), Generate threw:

```
TypeError: $.get(...).trim is not a function
```

Nothing was posted, nothing appeared on screen, and the button stayed enabled. The only symptom was that the product's primary action had quietly stopped working. Clearing the field did not recover it, because the binding then writes `null` and `null` has no `.trim()` either; only a reload did.

# Functionality

Typing a seed generates, and the seed is used. An empty seed generates without one, as before.

# Details

Three places treated the seed as a string against a numeric input: the initial state, the reset, and the guard. It is a `number | null` now, which is what the field was always going to give it, and the guard asks whether there is a finite number rather than whether a string is non-empty.

**Verified in the browser, before and after.** Before: `POSTs sent: 0`, `page errors: ["$.get(...).trim is not a function"]`. After, driving the real form:

```
seed typed (1234)      POSTs=1 errors=0 seedInBody=1234
seed typed then empty  POSTs=1 errors=0 seedInBody=77
no seed                POSTs=1 errors=0 seedInBody=absent
```

The middle row is the point: it is not enough for the error to be gone, the seed has to reach the request. It does, and an absent seed is still absent rather than being sent as `0` or `null`.

`npm run check` 0 errors 0 warnings across 1251 files, `npm run lint` clean.

**Why this was not caught before.** Nothing exercised the field. The earlier browser pass drove a generation with the prompt only, and the suite has no test for the seed path. This is a one-line type mismatch that TypeScript could not see through the binding, and only clicking the control reveals it.

Nine further findings from the same sweep are being triaged separately; this one is on its own because it breaks the primary action.
