### PR TITLE
A parameter reads as a number rather than as a float

### DIFF
--- a/frontend/src/lib/components/lineage-canvas.svelte
+++ b/frontend/src/lib/components/lineage-canvas.svelte
@@ -1095,6 +1095,13 @@
 
 	function paramValue(value: unknown): string {
 		if (typeof value === 'string') return value;
+		// A strength of 0.7 that has been through one arithmetic step arrives
+		// as 0.7000000000000001, and String() prints every digit of it. Twelve
+		// significant figures is far more than any parameter here carries and
+		// still collapses the binary-float tail.
+		if (typeof value === 'number' && Number.isFinite(value)) {
+			return String(Number(value.toPrecision(12)));
+		}
 		if (value === null || typeof value !== 'object') return String(value);
 		return JSON.stringify(value);
 	}


### PR DESCRIPTION
# Description

The lineage detail panel printed `strength 0.7000000000000001`. Found by driving the studio in a browser.

# Motivation

`paramValue` returns `String(value)` for anything that is not a string or an object, so a number reaches the screen in full. A strength of 0.7 that has been through one arithmetic step is `0.7000000000000001` in binary floating point, and the panel showed the representation rather than the value.

The slider labels never had this problem because they go through `formatParamValue`, which takes the parameter's range spec. The lineage panel dumps `Object.entries` generically and has no spec per key, so it needs a formatter that works without one.

# Functionality

Numbers are printed to twelve significant figures, which is far more than any parameter here carries and still collapses the floating-point tail. Everything else is unchanged.

| value | before | after |
|---|---|---|
| 0.7000000000000001 | 0.7000000000000001 | 0.7 |
| 0.30000000000000004 | 0.30000000000000004 | 0.3 |
| 0.7 | 0.7 | 0.7 |
| 1 | 1 | 1 |
| 1.5 | 1.5 | 1.5 |
| 1234 | 1234 | 1234 |
| 0.123456789012345 | 0.123456789012345 | 0.123456789012 |

Integers are untouched, genuine precision survives to twelve figures, and a non-finite number still falls through to `String()` because the guard is `Number.isFinite`.

`npm run check` 0 errors 0 warnings across 1251 files, `npm run lint` clean.