### PR TITLE
Give CI its own database so simulation cannot touch the developer one

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -35,5 +35,6 @@ jobs:
       - run: .ci-venv/bin/python scripts/simulate.py
         timeout-minutes: 3
         env:
+          DATABASE_URL: postgresql://potocolom:potocolom@localhost:5432/potocolom_ci
           FLEET_TOKEN_KEY: test-fleet-token
           FLEET_TOKEN: test-fleet-token

--- a/backend/tests/test_simulation_ci_database.py
+++ b/backend/tests/test_simulation_ci_database.py
@@ -1,0 +1,56 @@
+"""Simulation must not share the developer database with local auth-enable."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _ci_database():
+    path = ROOT / "scripts" / "ci_database.py"
+    spec = importlib.util.spec_from_file_location("ci_database", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ci_database = _ci_database()
+DEVELOPER_DATABASE = ci_database.DEVELOPER_DATABASE
+CI_DATABASE = ci_database.CI_DATABASE
+DEVELOPER_URL = f"postgresql://potocolom:potocolom@localhost:5432/{DEVELOPER_DATABASE}"
+CI_URL = f"postgresql://potocolom:potocolom@localhost:5432/{CI_DATABASE}"
+
+
+def test_database_name_reads_the_path():
+    assert ci_database.database_name(DEVELOPER_URL) == DEVELOPER_DATABASE
+    assert ci_database.database_name(CI_URL) == CI_DATABASE
+    assert ci_database.database_name(CI_URL + "?sslmode=disable") == CI_DATABASE
+
+
+def test_ci_refuses_the_developer_database():
+    with pytest.raises(SystemExit, match="must not use the developer database"):
+        ci_database.refuse_developer_database(url=DEVELOPER_URL, ci=True)
+
+
+def test_ci_accepts_the_ci_database():
+    ci_database.refuse_developer_database(url=CI_URL, ci=True)
+
+
+def test_a_local_run_may_use_the_developer_database():
+    ci_database.refuse_developer_database(url=DEVELOPER_URL, ci=False)
+
+
+def test_simulate_calls_the_developer_database_guard():
+    source = (ROOT / "scripts" / "simulate.py").read_text()
+    assert "refuse_developer_database" in source
+    assert "prepare_ci_database" in source
+
+
+def test_simulation_workflow_sets_the_ci_database():
+    source = (ROOT / ".github" / "workflows" / "simulation.yml").read_text()
+    assert "DATABASE_URL" in source
+    assert CI_URL in source

--- a/backend/tests/test_simulation_ci_database.py
+++ b/backend/tests/test_simulation_ci_database.py
@@ -1,8 +1,10 @@
 """Simulation must not share the developer database with local auth-enable."""
 
+import asyncio
 import importlib.util
 from pathlib import Path
 
+import asyncpg
 import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -54,3 +56,71 @@ def test_simulation_workflow_sets_the_ci_database():
     source = (ROOT / ".github" / "workflows" / "simulation.yml").read_text()
     assert "DATABASE_URL" in source
     assert CI_URL in source
+
+
+class _Catalog:
+    def __init__(self, *, exists=None, create_error=None):
+        self._exists = exists
+        self._create_error = create_error
+        self.executed = []
+
+    async def fetchval(self, query, *args):
+        assert "pg_database" in query
+        return self._exists
+
+    async def execute(self, query):
+        self.executed.append(query)
+        if self._create_error is not None:
+            raise self._create_error
+
+    async def close(self):
+        return None
+
+
+class _Target:
+    def __init__(self):
+        self.executed = []
+
+    async def fetchval(self, query, *args):
+        assert "to_regclass" in query
+        return "installation_auth_state"
+
+    async def execute(self, query):
+        self.executed.append(query)
+
+    async def close(self):
+        return None
+
+
+def _stub_connect(monkeypatch, catalog, target):
+    async def connect(**kwargs):
+        if kwargs.get("database") == "postgres":
+            return catalog
+        return target
+
+    monkeypatch.setattr(asyncpg, "connect", connect)
+
+
+def test_prepare_treats_a_duplicate_create_as_already_there(monkeypatch):
+    catalog = _Catalog(
+        exists=None,
+        create_error=asyncpg.DuplicateDatabaseError(
+            'database "potocolom_ci" already exists'
+        ),
+    )
+    target = _Target()
+    _stub_connect(monkeypatch, catalog, target)
+    asyncio.run(ci_database._prepare(CI_URL))
+    assert target.executed == [
+        "UPDATE installation_auth_state SET auth_mode = 'none', "
+        "root_key_version = NULL WHERE id = 1"
+    ]
+
+
+def test_prepare_still_fails_on_an_unrelated_create_error(monkeypatch):
+    catalog = _Catalog(exists=None, create_error=asyncpg.CannotConnectNowError("starting"))
+    target = _Target()
+    _stub_connect(monkeypatch, catalog, target)
+    with pytest.raises(asyncpg.CannotConnectNowError):
+        asyncio.run(ci_database._prepare(CI_URL))
+    assert target.executed == []

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1417,6 +1417,19 @@ materially larger change than the discrepancy justifies.
 
 
 
+## Simulation CI uses a dedicated database name
+
+The self-hosted runner and local development share one PostgreSQL server. Backend CI already starts its own postgres container. The simulation job did not. It used the Settings default, which is the developer database `potocolom`. A local `make auth-enable` then made `main` red, because `validate_startup_auth_mode` correctly refuses `AUTH_MODE=none` against an accounts installation (issue #459).
+
+Simulation in CI now uses `potocolom_ci` on the same server. The job creates that database if it is missing and sets `installation_auth_state` to `none` before the API starts, so leftover accounts mode cannot fail the run.
+
+`scripts/simulate.py` refuses to start when `CI` is set and the database name is `potocolom`. Removing `DATABASE_URL` from the workflow therefore fails the job instead of hitting the developer database.
+
+Local `make auth-enable` and `make simulate` still use `potocolom` or `potocolom$(DB_SUFFIX)`. That is unchanged.
+
+Rejected alternatives: a second PostgreSQL container for the runner (a clean boundary and one more service to keep running); exporting `DATABASE_URL` only in the runner environment (every workflow must honour it, and a missed one is silent).
+
+
 Chosen as conventional defaults rather than debated decisions:
 
 - PostgreSQL with SQLAlchemy and Alembic migrations. One database engine in every mode; docker compose makes it trivial for self-hosters.

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -31,7 +31,7 @@ python3.11 --version
 node --version   # 24.x
 ```
 
-Keep Docker running (`systemctl enable --now docker`). The backend workflow uses postgres on host port **15432** so it does not clash with `make deps` on :5432.
+Keep Docker running (`systemctl enable --now docker`). The backend workflow maps postgres to a free host port so two backend jobs do not collide, and so it does not clash with `make deps` on :5432.
 
 ### 2. Register and start the runners
 
@@ -50,7 +50,7 @@ Every target installs and controls `CI_RUNNERS` runner instances (default **4**)
 
 Change the count with `make ci-runner-install CI_RUNNERS=6`, and pass the same value to the start, stop, and status targets. The reference desktop has 32 CPUs and 61 GB of RAM, so 4 concurrent jobs are comfortable.
 
-Two workflows bind host ports (backend postgres via Docker on a free port, simulation on a free API port), so both declare a `concurrency` group. Runs of the same workflow still queue one at a time; different workflows run in parallel. Add a `concurrency` group to any new workflow that binds a host port.
+Two workflows bind host resources (backend postgres via Docker on a free port, simulation on a free API port and the shared `potocolom_ci` database), so both declare a `concurrency` group. Runs of the same workflow still queue one at a time. Different workflows run in parallel. Add a `concurrency` group to any new workflow that binds a host port or the CI database.
 
 Simulation talks to the host PostgreSQL, not the backend job's Docker postgres. It uses the database `potocolom_ci`, created on first run, and never the developer database `potocolom`. A local `make auth-enable` therefore cannot redden `main`. The script refuses to start in CI if `DATABASE_URL` still names `potocolom`.
 

--- a/docs/self-hosted-runner.md
+++ b/docs/self-hosted-runner.md
@@ -11,7 +11,7 @@ The four path-filtered workflows in `.github/workflows/`:
 | backend | Docker (postgres service container), Python 3.11 |
 | worker | Python 3.11 |
 | frontend | Node 24 |
-| simulation | Python 3.11 |
+| simulation | Python 3.11, host postgres database `potocolom_ci` |
 
 GPU inference is not in CI. `make verify` locally matches what these jobs run.
 
@@ -50,7 +50,9 @@ Every target installs and controls `CI_RUNNERS` runner instances (default **4**)
 
 Change the count with `make ci-runner-install CI_RUNNERS=6`, and pass the same value to the start, stop, and status targets. The reference desktop has 32 CPUs and 61 GB of RAM, so 4 concurrent jobs are comfortable.
 
-Two workflows bind fixed host ports (backend on 15432, simulation on 8901), so both declare a `concurrency` group. Runs of the same workflow still queue one at a time; different workflows run in parallel. Add a `concurrency` group to any new workflow that binds a host port.
+Two workflows bind host ports (backend postgres via Docker on a free port, simulation on a free API port), so both declare a `concurrency` group. Runs of the same workflow still queue one at a time; different workflows run in parallel. Add a `concurrency` group to any new workflow that binds a host port.
+
+Simulation talks to the host PostgreSQL, not the backend job's Docker postgres. It uses the database `potocolom_ci`, created on first run, and never the developer database `potocolom`. A local `make auth-enable` therefore cannot redden `main`. The script refuses to start in CI if `DATABASE_URL` still names `potocolom`.
 
 To add instances later, run `make ci-runner-install` again: it skips the directories that are already configured.
 

--- a/scripts/ci_database.py
+++ b/scripts/ci_database.py
@@ -65,7 +65,11 @@ async def _prepare(url: str) -> None:
             "SELECT 1 FROM pg_database WHERE datname = $1", name
         )
         if not exists:
-            await conn.execute(f'CREATE DATABASE "{name}"')
+            try:
+                await conn.execute(f'CREATE DATABASE "{name}"')
+            except asyncpg.DuplicateDatabaseError:
+                # Another job created it between the catalog check and here.
+                pass
     finally:
         await conn.close()
     target = await asyncpg.connect(

--- a/scripts/ci_database.py
+++ b/scripts/ci_database.py
@@ -1,0 +1,93 @@
+"""Which PostgreSQL database a URL names, and the CI rule for simulation.
+
+The self-hosted runner shares one PostgreSQL with local development. Backend
+CI already starts its own container. Simulation did not, so a local
+`make auth-enable` could redden main (issue #459).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from urllib.parse import urlsplit
+
+DEVELOPER_DATABASE = "potocolom"
+CI_DATABASE = "potocolom_ci"
+DEFAULT_URL = "postgresql://potocolom:potocolom@localhost:5432/potocolom"
+_NAME = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def database_name(url: str) -> str:
+    return urlsplit(url).path.lstrip("/").split("?")[0]
+
+
+def refuse_developer_database(*, url: str, ci: bool) -> None:
+    """Exit if CI would otherwise use the developer database.
+
+    The workflow sets DATABASE_URL to potocolom_ci. This is the backstop:
+    deleting that env var must fail the job, not hit `potocolom`.
+    """
+    if ci and database_name(url) == DEVELOPER_DATABASE:
+        raise SystemExit(
+            "simulation in CI must not use the developer database; "
+            f"set DATABASE_URL to a database named {CI_DATABASE}"
+        )
+
+
+def prepare_ci_database(url: str) -> None:
+    """Create the named database if needed, then clear installation auth state.
+
+    A leftover `accounts` row is what made simulation fail after a local
+    auth-enable. Clearing it here is safe because CI never shares this name
+    with a developer checkout.
+    """
+    asyncio.run(_prepare(url))
+
+
+async def _prepare(url: str) -> None:
+    import asyncpg
+
+    parsed = urlsplit(url)
+    name = database_name(url)
+    if not _NAME.fullmatch(name):
+        raise SystemExit(f"database name {name!r} is not usable")
+    conn = await asyncpg.connect(
+        host=parsed.hostname,
+        port=parsed.port or 5432,
+        user=parsed.username,
+        password=parsed.password,
+        database="postgres",
+        timeout=10,
+    )
+    try:
+        exists = await conn.fetchval(
+            "SELECT 1 FROM pg_database WHERE datname = $1", name
+        )
+        if not exists:
+            await conn.execute(f'CREATE DATABASE "{name}"')
+    finally:
+        await conn.close()
+    target = await asyncpg.connect(
+        host=parsed.hostname,
+        port=parsed.port or 5432,
+        user=parsed.username,
+        password=parsed.password,
+        database=name,
+        timeout=10,
+    )
+    try:
+        if await target.fetchval(
+            "SELECT to_regclass($1)", "public.installation_auth_state"
+        ) is None:
+            return
+        await target.execute(
+            "UPDATE installation_auth_state SET auth_mode = 'none', "
+            "root_key_version = NULL WHERE id = 1"
+        )
+    finally:
+        await target.close()
+
+
+def ci_from_environ(environ: dict[str, str] | os._Environ[str] = os.environ) -> bool:
+    return environ.get("CI", "") != ""

--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -25,8 +25,16 @@ import websockets
 
 # Importable because this script runs in an environment where the app package
 # is installed (backend/.venv locally, one shared env in CI); the wire
-# constants stay single-sourced.
+# constants stay single-sourced. `ci_database` sits beside this file; Python
+# puts the script directory on sys.path, so the import resolves when the
+# Makefile or the workflow runs `python scripts/simulate.py`.
 from app.realtime import CANVAS_FRAME, FRAME_HEADER_BYTES
+from ci_database import (
+    DEFAULT_URL,
+    ci_from_environ,
+    prepare_ci_database,
+    refuse_developer_database,
+)
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -210,4 +218,11 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
+    # CI is set by Actions. A missing DATABASE_URL would otherwise fall through
+    # to the developer database and the next local auth-enable would redden main.
+    database_url = os.environ.get("DATABASE_URL", DEFAULT_URL)
+    running_in_ci = ci_from_environ()
+    refuse_developer_database(url=database_url, ci=running_in_ci)
+    if running_in_ci:
+        prepare_ci_database(database_url)
     asyncio.run(main())


### PR DESCRIPTION
# Description

Closes #459.

The simulation job now uses `potocolom_ci`. If CI is set and the URL still names `potocolom`, the job refuses to start. `installation_auth_state` is reset on that database at job start. `make auth-enable` and local `make simulate` still use `potocolom`.

# Motivation

CI and this desktop share Postgres. Resetting auth state on the developer database races a live session.

# Functionality

- Workflow `DATABASE_URL` points at `potocolom_ci`.
- `prepare_ci_database` creates the database if needed.
- The developer database name is refused when `CI` is set.

# Details

Merge this first. The other branches also append to `docs/decisions.md` at the same anchor, so they will need a rebase after this lands.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulation CI now uses a dedicated PostgreSQL database and creates it automatically when needed.
  * CI simulations reset authentication state before running.
  * Safety checks prevent CI simulations from using the developer database.

* **Documentation**
  * Updated self-hosted runner requirements and simulation database guidance.
  * Documented the database and authentication decisions.

* **Tests**
  * Added coverage for database selection, safety checks, initialization, and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->