### PR TITLE
docs: record canvas, accounts, and CI database as shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -146,8 +146,8 @@ Still open:
 
 ### M4 Accounts
 
-- Still-open epics: #5 sessions and principal policy, #9 first-admin and adoption leftovers, and #10 account UI.
-- Shipped slices: invitations and roles (PR #364), realtime socket authentication (PR #365 / #383; #19 still owns admission queue, idle release, and other protocol work), mail outbox (PR #367 / #385), Google and GitHub OAuth sign-in and linking (PR #369 / #386; linking only, never enrolment by email), TOTP and recovery (PR #371 / #387), and credential changes (PR #374 / #388).
+- Still-open epics: leftover #5 session and principal policy work, leftover #9 first-admin and adoption work, and the rest of #10 account UI (settings, first-admin setup, export, deletion, restore, purge).
+- Shipped slices: invitations and roles (PR #364), realtime socket authentication (PR #365 / #383; #19 still owns admission queue, idle release, and other protocol work), mail outbox (PR #367 / #385), Google and GitHub OAuth sign-in and linking (PR #369 / #386; linking only, never enrolment by email), TOTP and recovery (PR #371 / #387), credential changes (PR #374 / #388), studio `/login` and `/join` (PR #470, first slice of #10), and the per-account advisory lock (PR #467 / #444).
 
 ### M5 Cloud readiness (largest)
 
@@ -155,8 +155,8 @@ Still open:
   safety screening, #28 in-app admin area, #29 usage metrics and opt-out telemetry,
   #48 relay load harness, #60 inference-speed baseline and optimization backlog,
   #95 CLIP output categorizer, #107 one-click benchmark pipeline, and the
-  lineage-canvas foundations #124 (persist favorites), #125 (PNG masters), #129
-  (lineage on the detail view).
+  lineage-canvas items still open: #124 (persist favorites) and #125 (PNG masters).
+  PR #210 shipped #129 (lineage on the detail view).
 - Inference backlog note (#60): torch.compile warmup and measured realtime slots
   are in-flight in PR #141. That PR recommends against enabling torch.compile by
   default (measured ROCm speedup only 0.8-7.4% against a large cold-load cost).
@@ -170,9 +170,11 @@ Still open:
 
 ### M6 Launch and beta
 
-- #40 landing pricing and previews, #49 invite-gated signup, #50 launch, and the
-  lineage canvas itself: #130 pannable derivation forest, #131 branch-from-node
-  with edge deltas, #132 search and filter overlays.
+- #40 landing pricing and previews, #49 invite-gated signup, #50 launch.
+- Lineage canvas is on main: #130 pannable derivation forest (PR #210), #131
+  branch-from-node with edge deltas (PR #468), #132 search overlay (PR #469),
+  #223 keyboard rover (PR #466), #224 cost measure (PR #471). Category chips
+  still wait on #95.
 
 ### M7 Developer API
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -333,6 +333,8 @@ Transitions are compare-and-set inside one transaction and idempotent, so a retr
 
 Leaving `active` revokes every session in the same transaction as the state, then reaches what a transaction cannot: the realtime sockets that bound their principal at the handshake, and the workers holding that account's jobs.
 
+Collapse and the credential routes do not share one table lock order (issue #444). Each overlapping transaction acquires the per-account advisory lock (`hold_the_account`) before anything else. HTTP callers wait three seconds, then receive 503. Collapse waits without a timeout. Role and state changes still use global `184468` for the last-administrator count. The account gate is extra and comes first. Reset-ask skips the gate, so a 503 cannot be used to enumerate accounts.
+
 Cancellation is cooperative and PostgreSQL is the authority. The row is marked `cancelled` first, and the worker is told afterwards, best effort and bounded, because an `await` cannot interrupt the thread holding the GPU. A worker takes the cancellation between diffusion steps or between upscale tiles. One that never hears it finishes its image and uploads it, and the terminal-state check that already guards every late verdict discards what it wrote. The GPU milliseconds it measured are recorded and charged either way, because the hardware really did run for that long.
 
 ### Upscale (post-generation)
@@ -353,7 +355,11 @@ How the images are pulled, and why it holds at scale:
 - History is never fetched as one account-wide response. Roots come from cursor-paged `GET /api/v1/generations?roots_only=true`. A chain-free root is laid out from that response without another request. When a branched root first enters the viewport, one `GET /api/v1/generations/{job_id}/subtree` request returns its renderable nodes and generation data; at most four subtree requests run concurrently, and the browser does not request lineage and generation detail per node. Each root includes `has_derivatives`, so the client reserves a tree row or a chain-free grid cell before that subtree loads. Subtrees are cached per root id for the session. A derivative that completes during the session prompts one revalidation; cached retained nodes and newly observed derivatives still revalidate when they change; and a capped cache remembers known omitted history so it does not repeatedly request the same omitted frontier.
 - The subtree endpoint executes one recursive database query. Its queue is bounded to 600 nodes, descendants stop at depth 100, visited job ids make it cycle safe, and all asset edges are user-owned non-thumbnail masters. A truncated response includes a conservative lower bound for omitted branches. The separate detail-view lineage endpoint remains: it uses a recursive ancestor query, a direct-child query, and a depth-100 recursive descendant count with an explicit truncation flag. The `jobs_source_asset` index serves both downward walks.
 - Bandwidth follows the zoom band. The constellation and tree bands render the WebP thumbnail rendition; the full master loads only at the card band, and never below it. Tiles outside the viewport unmount on a world coordinate test, keeping the mounted count bounded rather than growing with history.
-- Layout is deterministic from root ids, `created_at`, and `has_derivatives`. Derived trees receive separate rows and the chain-free grid occupies an independent fixed-height region, so loading a subtree cannot move a root between regions or re-index the grid. Older grid pages extend to the right. A loaded tree can increase its row height and push only later tree rows down. The viewport, its nearest root anchor and that anchor's world position, and additive per-root drag offsets are kept in browser local storage. On restore, the saved transform is translated by any change in the anchor's world position. Coordinates are clamped to plus or minus 1,000,000 world pixels, and offsets that do not match any root are discarded after root paging is exhausted. Default positions remain reproducible and nothing about the canvas is persisted server side. Root tiles are the drag handles, focused root tiles move with the arrow keys, and both one-tree and all-tree reset controls remove offsets.
+- Layout is deterministic from root ids, `created_at`, and `has_derivatives`. Derived trees receive separate rows and the chain-free grid occupies an independent fixed-height region, so loading a subtree cannot move a root between regions or re-index the grid. Older grid pages extend to the right. A loaded tree can increase its row height and push only later tree rows down. The viewport, its nearest root anchor and that anchor's world position, and additive per-root drag offsets are kept in browser local storage. On restore, the saved transform is translated by any change in the anchor's world position. Coordinates are clamped to plus or minus 1,000,000 world pixels, and offsets that do not match any root are discarded after root paging is exhausted. Default positions remain reproducible and nothing about the canvas is persisted server side. Root tiles are the drag handles. Alt plus the arrow keys move a focused root tree. One-tree and all-tree reset controls remove offsets.
+- The viewport is the keyboard surface (issue #223). The `role="application"` canvas is a single tab stop. Enter moves focus to the newest root. Escape returns focus to the viewport. Arrow keys pan when the viewport has focus. Arrow keys on a tile walk a roving tabindex (roots by recency, then tree order). A focused node off screen is force-mounted and the camera pans to it.
+- Search overlays the current forest (issue #132). `GET /api/v1/generations?q=` matches prompts. `fields=ids` returns those ids. Matches get a ring. Everything else dims. Roots are not reloaded and trees do not move. A match in an unloaded descendant stays dim until that tree loads.
+- A double-click on a tile starts a branch (issue #131). Image-to-image if the tile has bytes, else generate from the prompt, else upscale. The seed is dropped. At card zoom, each visible edge labels the delta: prompt word hunks, a shallow param compare, "new seed" when only the seed changed, and the action name.
+- Issue #224 measured per-frame cost at a few thousand nodes on this machine. Nested edge drawing and the nearest-root scan do not dominate a frame. Production canvas paint did not change.
 
 The same code path serves every deployment profile:
 
@@ -425,7 +431,7 @@ flowchart TB
     M -->|"accounts"| A["Email and password forms<br>provider buttons where configured<br>DB-backed session cookie"]
 ```
 
-The frontend never hardcodes this: it builds the login screen from the `auth_methods` field of `GET /api/v1/config`.
+The frontend never hardcodes this: it builds the login screen from the `auth_methods` field of `GET /api/v1/config`. Studio account UI starts at `/login` (password, OAuth, TOTP challenge) and `/join` (invitation accept). The invite token sits in the URL hash. An OAuth flow that still needs a second factor lands on `/login?totp=required`. The marketing build prerenders those routes and does not show working forms. Account settings and first-admin setup remain later slices of issue #10.
 
 ### Registration and login
 
@@ -999,6 +1005,8 @@ App shell with the drawing tool active (issues #3, #4):
 +---------------------------------------------------------------------------+
 ```
 
+Generate and Upscale ignore a second click while the POST that creates the job is still in flight (issue #455). The server still queues jobs after that POST lands.
+
 Generate tool, with controls rendered from the model's parameter schema (issues #2, #11):
 
 ```
@@ -1012,7 +1020,7 @@ Generate tool, with controls rendered from the model's parameter schema (issues 
 +--------------------------------------+------------------------------------+
 ```
 
-Account view (issue #10):
+Account view (issue #10). The first slice is `/login` and `/join`. Settings, sessions, and plan come later:
 
 ```
 +---------------------------------------------+

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -161,10 +161,10 @@ offline destructive reset, which is `make auth-collapse` and destroys every
 account on the installation.
 
 Sign-in is here: address and password, an optional second factor, and Google or
-GitHub when they are configured. After claiming the administrator account, sign
-in at `POST /api/v1/auth/login` and invite everybody else. The password policy
-is fifteen to one hundred and twenty-eight characters against a bundled
-blocklist.
+GitHub when they are configured. After the administrator account is claimed, open
+`/login` in the studio (or call `POST /api/v1/auth/login`) and invite everybody else.
+Accepting an invitation is `/join#{token}`. The password policy is fifteen to one
+hundred and twenty-eight characters against a bundled blocklist.
 
 ## Mail, and doing without it
 
@@ -255,7 +255,7 @@ Kept honest and short, this is the list staging exists for: Terraform itself, IA
 
 ## Continuous integration
 
-GitHub Actions runs lint and tests on every pull request (issue #13). By default workflows target a **self-hosted runner** on the reference desktop so CI keeps working when hosted minutes are exhausted; see [self-hosted-runner.md](self-hosted-runner.md). Switch workflows back to `ubuntu-latest` when hosted quota is available.
+GitHub Actions runs lint and tests on every pull request (issue #13). By default workflows target a **self-hosted runner** on the reference desktop so CI keeps working when hosted minutes are exhausted; see [self-hosted-runner.md](self-hosted-runner.md). Switch workflows back to `ubuntu-latest` when hosted quota is available. The simulation job talks to host database `potocolom_ci`. When `CI` is set it refuses the developer name `potocolom` (issue #459).
 
 Per component, no GPU:
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -188,8 +188,9 @@ The link lasts one hour, is good once, and is replaced if you run `make auth-ena
 again. Nothing durable holds it, only its hash, so a lost link means minting another.
 
 Sign-in is here: address and password, an optional second factor, and Google or
-GitHub when you configure them. A session is a cookie the browser never reads,
-and an administrator invites everybody else.
+GitHub when you configure them. After you claim the administrator account, open
+`/login` in the studio. Accepting an invitation is `/join#{token}`. A session is a
+cookie the browser never reads, and an administrator invites everybody else.
 
 ### When nobody can get in
 


### PR DESCRIPTION
## Summary

- Bring `docs/architecture.md`, `docs/local-development.md`, `docs/self-hosting.md`, and `ROADMAP.md` in line with PRs #464-#471.
- Record the Images canvas rover, overlay search, double-click branch, account gate, `/login` and `/join`, Generate-once, and simulation CI database `potocolom_ci`.
- Leave `docs/internals/` out of the commit. That tree is local-only.

## Test plan

- [ ] Skim the four files against the merge notes for PRs #464-#471.
- [ ] Confirm `docs/api.md` and `docs/decisions.md` already match (no change in this PR).
- [ ] Confirm CI is green or skipped on docs-only paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the roadmap to reflect shipped account, authentication, and lineage capabilities, with remaining work clearly identified.
  - Documented account protection behavior, including advisory locking and request handling during concurrent changes.
  - Added guidance for studio login and invitation flows, including `/login` and `/join#{token}`.
  - Expanded keyboard navigation guidance for lineage views.
  - Clarified Generate and Upscale behavior while requests are in progress.
  - Updated local development and self-hosting instructions for account setup and invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->