### PR TITLE
refactor: share file cleanup for jobs and accounts

### DIFF
--- a/backend/app/deletion.py
+++ b/backend/app/deletion.py
@@ -282,8 +282,7 @@ async def _purge(user_id: uuid.UUID, cutoff: datetime) -> None:
             select(Asset.storage_key).where(Asset.user_id == user_id))).scalars().all())
     # Before the rows: a key nothing names any more is an object nobody will
     # ever find, and the row is the only thing that names it.
-    for key in keys:
-        await _forget_object(key)
+    await jobs.purge_keys(keys, what=f"purged account {user_id}")
     async with db.session_factory() as session:
         async with session.begin():
             await hold_the_account(session, user_id)
@@ -298,17 +297,6 @@ async def _purge(user_id: uuid.UUID, cutoff: datetime) -> None:
             # key, so what an administrator did survives the account.
             await session.execute(delete(User).where(User.id == user_id))
     logger.info("purged account %s and the %d objects it owned", user_id, len(keys))
-
-
-async def _forget_object(storage_key: str) -> None:
-    """Bounded, and never fatal. A wedged mount answers never, and an object
-    that will not go is recorded for the sweep that owns retries rather than
-    stopping the account from being finished."""
-    try:
-        await jobs._bounded_delete(storage_key)
-    except Exception as error:
-        logger.warning("could not remove %s for a purged account", storage_key, exc_info=True)
-        await jobs.record_pending_delete(storage_key, jobs._trim_error(error))
 
 
 async def purge_loop() -> None:

--- a/backend/app/jobs.py
+++ b/backend/app/jobs.py
@@ -1594,7 +1594,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             # A requeue replaced this attempt after the copy. No asset row
             # names these dests, and the winner's keys are a later attempt.
             schedule_blob_cleanup(
-                _purge_keys(promoted, job_id),
+                purge_keys(promoted, what=f"superseded library copies for job {job_id}"),
                 what=f"superseded library copies for job {job_id}",
             )
             return
@@ -1611,7 +1611,9 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
                     if promoted and (job is None or job.attempt > current.attempt
                                      or job.state != "succeeded"):
                         schedule_blob_cleanup(
-                            _purge_keys(promoted, job_id),
+                            purge_keys(
+                                promoted, what=f"uncommitted library copies for job {job_id}"
+                            ),
                             what=f"uncommitted library copies for job {job_id}",
                         )
                     cancelled_here = (job is not None and job.state == "cancelled"
@@ -1673,7 +1675,7 @@ async def on_worker_message(worker: realtime.Worker, control: dict) -> None:
             if attempt < current.attempt:
                 orphans.extend(storage_keys_for_attempt(current.user_id, job_id, attempt))
         schedule_blob_cleanup(
-            _purge_keys(orphans, job_id),
+            purge_keys(orphans, what=f"dispatch orphans for job {job_id}"),
             what=f"dispatch orphans for job {job_id}",
         )
         publish(job_id, {"state": "succeeded", "url": asset_url(full.id)})
@@ -1733,7 +1735,8 @@ async def drain_blob_cleanup() -> None:
             await task
 
 
-async def _purge_keys(keys: list[str], job_id: uuid.UUID) -> None:
+async def purge_keys(keys: list[str], *, what: str) -> None:
+    """Delete keys and record failures before their database rows disappear."""
     pending = list(keys)
     try:
         while pending:
@@ -1741,11 +1744,7 @@ async def _purge_keys(keys: list[str], job_id: uuid.UUID) -> None:
             try:
                 await _bounded_delete(key)
             except Exception as error:
-                # The same leak purge_attempt_blobs had, one function away: the
-                # success path collects the earlier attempts and an unreported
-                # thumbnail, and nothing else ever names those keys.
-                logger.warning("could not remove blob %s for job %s", key,
-                               job_id, exc_info=True)
+                logger.warning("could not remove blob %s (%s)", key, what, exc_info=True)
                 await record_pending_delete(key, _trim_error(error))
             pending.pop(0)
     except asyncio.CancelledError:
@@ -1769,7 +1768,7 @@ async def purge_attempt_blobs(user_id: uuid.UUID, job_id: uuid.UUID, attempt: in
     for earlier in range(1, attempt + 1):
         keys.extend(dispatch_keys_for_attempt(user_id, job_id, earlier))
         keys.extend(storage_keys_for_attempt(user_id, job_id, earlier))
-    await _purge_keys(keys, job_id)
+    await purge_keys(keys, what=f"attempt cleanup for job {job_id}")
 
 
 async def _bounded_delete(storage_key: str) -> None:

--- a/backend/tests/test_account_deletion.py
+++ b/backend/tests/test_account_deletion.py
@@ -5,6 +5,7 @@ request with a waiting period behind it, reversible until the purge runs, and
 a purge leaves no user row at all.
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -15,7 +16,7 @@ from sqlalchemy import text
 
 from app import db
 from app.main import app
-from app.tables import Asset, Job, User
+from app.tables import Asset, Job, PendingDelete, User
 from tests.test_account_states import _admin, _session_cookie, _set_state, _state_of, _wearing
 from tests.test_totp_flow import ORIGIN, _csrf, _login, _make, accounts
 
@@ -50,6 +51,19 @@ async def _rows(table: str, user_id: uuid.UUID) -> int:
             text(f"SELECT count(*) FROM {table} WHERE user_id = :id"), {"id": user_id}) or 0)
 
 
+async def _pending(storage_key: str) -> PendingDelete | None:
+    async with db.session_factory() as session:
+        return await session.get(PendingDelete, storage_key)
+
+
+async def _make_pending_due(storage_key: str) -> None:
+    async with db.session_factory() as session:
+        await session.execute(
+            text("UPDATE pending_deletes SET next_attempt_at = now() "
+                 "WHERE storage_key = :key"), {"key": storage_key})
+        await session.commit()
+
+
 async def _owned_work(user_id: uuid.UUID) -> Asset:
     """A job and an asset, which are the two tables a purge has to order."""
     from tests.test_shares import MODEL
@@ -64,8 +78,9 @@ async def _owned_work(user_id: uuid.UUID) -> Asset:
                   params={"prompt": "a boat"}, state="succeeded")
         session.add(job)
         await session.flush()
-        asset = Asset(id=uuid.uuid4(), user_id=user_id, job_id=job.id,
-                      storage_key=f"{user_id}/boat.png", mime="image/png",
+        asset_id = uuid.uuid4()
+        asset = Asset(id=asset_id, user_id=user_id, job_id=job.id,
+                      storage_key=f"{user_id}/{asset_id}.png", mime="image/png",
                       width=32, height=32)
         session.add(asset)
         await session.commit()
@@ -264,18 +279,115 @@ def test_the_objects_of_a_purged_account_are_taken_with_it(library):
         client.portal.call(request_deletion)
         client.portal.call(_age_request, user.id, deletion.RESTORE_WINDOW_DAYS + 1)
 
-        original = deletion._forget_object
+        from app import jobs
 
-        async def watch(key: str) -> None:
-            removed.append(key)
-            await original(key)
+        original = jobs.purge_keys
 
-        deletion._forget_object = watch
+        async def watch(keys: list[str], *, what: str) -> None:
+            removed.extend(keys)
+            await original(keys, what=what)
+
+        jobs.purge_keys = watch
         try:
             client.portal.call(deletion.purge_due)
         finally:
-            deletion._forget_object = original
+            jobs.purge_keys = original
     assert asset.storage_key in removed
+
+
+@pytest.mark.db
+def test_account_purge_records_a_failed_delete_and_the_sweep_recovers_it(
+    library, monkeypatch,
+):
+    from app import deletion, jobs
+
+    with TestClient(app, base_url=ORIGIN) as client:
+        user = client.portal.call(_make, "failed-object@example.com")
+        asset = client.portal.call(_owned_work, user.id)
+        storage = jobs.get_storage()
+        storage.path(asset.storage_key).parent.mkdir(parents=True, exist_ok=True)
+        storage.path(asset.storage_key).write_bytes(b"object")
+
+        async def request_deletion() -> None:
+            async with db.session_factory() as session:
+                await deletion.request(session, user.id)
+                await session.commit()
+
+        client.portal.call(request_deletion)
+        client.portal.call(_age_request, user.id, deletion.RESTORE_WINDOW_DAYS + 1)
+
+        class RefusingDelete:
+            def __getattr__(self, name):
+                return getattr(storage, name)
+
+            async def delete(self, key):
+                raise PermissionError(f"denied {key}")
+
+        monkeypatch.setattr(jobs, "get_storage", lambda: RefusingDelete())
+        client.portal.call(deletion.purge_due)
+        row = client.portal.call(_pending, asset.storage_key)
+        assert row is not None
+        assert row.attempts == 0
+        assert client.portal.call(_user, user.id) is None
+
+        monkeypatch.undo()
+        client.portal.call(_make_pending_due, asset.storage_key)
+        client.portal.call(jobs.retry_pending_deletes)
+        assert client.portal.call(_pending, asset.storage_key) is None
+        assert not storage.path(asset.storage_key).exists()
+
+
+@pytest.mark.db
+def test_cancelled_account_purge_records_all_remaining_keys(library, monkeypatch):
+    from app import deletion, jobs
+
+    with TestClient(app, base_url=ORIGIN) as client:
+        user = client.portal.call(_make, "cancelled-purge@example.com")
+        first = client.portal.call(_owned_work, user.id)
+        second = client.portal.call(_owned_work, user.id)
+        assert first.storage_key != second.storage_key
+        storage = jobs.get_storage()
+        for asset in (first, second):
+            storage.path(asset.storage_key).parent.mkdir(parents=True, exist_ok=True)
+            storage.path(asset.storage_key).write_bytes(b"object")
+
+        async def request_deletion() -> None:
+            async with db.session_factory() as session:
+                await deletion.request(session, user.id)
+                await session.commit()
+
+        client.portal.call(request_deletion)
+        client.portal.call(_age_request, user.id, deletion.RESTORE_WINDOW_DAYS + 1)
+        started = asyncio.Event()
+
+        class HangingDelete:
+            def __getattr__(self, name):
+                return getattr(storage, name)
+
+            async def delete(self, key):
+                started.set()
+                await asyncio.Event().wait()
+
+        monkeypatch.setattr(jobs, "get_storage", lambda: HangingDelete())
+
+        async def cancel_purge() -> None:
+            task = asyncio.create_task(
+                deletion._purge(
+                    user.id,
+                    datetime.now(timezone.utc) - timedelta(
+                        days=deletion.RESTORE_WINDOW_DAYS
+                    ),
+                )
+            )
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        client.portal.call(cancel_purge)
+        assert client.portal.call(_pending, first.storage_key) is not None
+        assert client.portal.call(_pending, second.storage_key) is not None
+        assert client.portal.call(_user, user.id) is not None
 
 
 @pytest.mark.db


### PR DESCRIPTION
# Description

Use the existing blob purge function for account deletion and job cleanup.

Closes #474.

# Motivation

Account deletion called private job helpers and had its own object deletion loop. That loop did not record the remaining keys when cancellation stopped a purge.

# Functionality

A public purge function accepts the keys and a caller label. It handles bounded deletion, failed-delete records and cancellation. Account deletion now uses it, and its duplicate helper is gone.

# Details

Review the shared purge call and account row order, then the failed-storage and cancelled-purge tests. Retry tasks, tables, backoff and startup stay in place. Failed-delete recording remains best effort if the database is unavailable.

Checks: full make verify passes with the branch PYTHONPATH: 1010 backend tests, 297 worker tests and 106 frontend tests, plus type, lint, production build and CSP checks. Account deletion has 18 passing tests; job cleanup has 94.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account deletion reliability when storage items cannot be removed immediately.
  - Failed deletions are now tracked and retried automatically, helping ensure cleanup completes successfully.
  - Cancelled account purges now preserve outstanding cleanup work so it can be recovered later.
  - Improved cleanup reporting with clearer descriptions of the items being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->