### PR TITLE
refactor: give the live drawing session one owner

### DIFF
--- a/frontend/src/lib/components/realtime-canvas-panel.svelte
+++ b/frontend/src/lib/components/realtime-canvas-panel.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
 	// The live realtime drawing surface (issue #3). One 512 by 512 bitmap, CSS
 	// scaled for display, sent as complete WebP frames over the realtime
-	// protocol. The framing, the send predicate, the cadence and the opening
-	// message live in $lib/realtime-canvas so they carry tests. What stays here
-	// is not only the DOM: the timer, the changed and encoding flags, the
-	// latest-wins drop policy, the decode loop and the session lifecycle live in
-	// this file. The happy path is covered by a browser run; the failure and
-	// teardown paths (refused sessions, invalid session ids, overlapping
-	// sockets, stale asynchronous work) are not covered by any automated test.
+	// protocol. The session lifecycle lives in $lib/realtime-canvas; this panel
+	// keeps the bitmap DOM and drawing controls.
 	//
 	// Out of scope here, by their own issues: the replayable stroke journal and
 	// undo (#54), frame-diff skip and finer cadence adaptation (#42), and
@@ -31,17 +26,9 @@
 	} from '$lib/model-params';
 	import { fallbackModelId, modelIsRemoved, studio, type Model } from '$lib/studio.svelte';
 	import {
-		FAST_INTERVAL_MS,
-		IDLE_TICKS_BEFORE_STOP,
-		afterParamsUpdated,
-		canvasFrame,
-		nextDelayMs,
-		openMessage,
-		parseGeneratedFrame,
-		shouldSendFrame,
-		stateForCloseCode,
-		updateParamsMessage,
-		type ConnectionState
+		createRealtimeCanvasSession,
+		type ConnectionState,
+		type RealtimeCanvasNotice
 	} from '$lib/realtime-canvas';
 
 	/** The wire dimensions. CSS scales the display without changing these. */
@@ -49,9 +36,6 @@
 	const STROKE_WIDTH = 6;
 	const INK = '#111827';
 	const PAPER = '#ffffff';
-	// The shape uuidBytes requires: 32 hex digits with optional hyphens in the
-	// 8-4-4-4-12 positions.
-	const UUID_RE = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
 
 	let drawCanvas = $state<HTMLCanvasElement | undefined>();
 	let outputCanvas = $state<HTMLCanvasElement | undefined>();
@@ -59,6 +43,15 @@
 	/** A message is held as its key, not its text, so switching language
 	 * retranslates it instead of leaving the previous locale on screen. */
 	type NoticeKey = Parameters<typeof t>[0];
+	const NOTICE_KEYS: Record<Exclude<RealtimeCanvasNotice, ''>, NoticeKey> = {
+		encode_failed: 'app.realtime_canvas.encode_failed',
+		decode_failed: 'app.realtime_canvas.decode_failed',
+		socket_error: 'app.realtime_canvas.socket_error',
+		refused_protocol: 'app.realtime_canvas.refused_protocol',
+		refused_version: 'app.realtime_canvas.refused_version',
+		refused_capacity: 'app.realtime_canvas.refused_capacity',
+		refused_model: 'app.realtime_canvas.refused_model'
+	};
 
 	let prompt = $state('');
 	let connection = $state<ConnectionState>('idle');
@@ -74,24 +67,12 @@
 	let appliedStructure = $state(0);
 	let appliedSteps = $state(0);
 
-	let socket: WebSocket | null = null;
-	let sessionId: string | null = null;
 	let paint: CanvasRenderingContext2D | null = null;
 
-	let changed = false; // paint not yet on the wire
-	let encoding = false; // one encode in flight
-	let decoding = false; // one decode in flight
-	// Latest generated frame, older ones dropped. The buffer is named in the
-	// type so the Blob constructor accepts these bytes without a cast.
-	let pendingFrame: Uint8Array<ArrayBuffer> | null = null;
-	let timer: ReturnType<typeof setTimeout> | null = null;
-	let idleTicks = 0;
-	let lastFrameCostMs = 0;
 	let blank = true; // nothing drawn since the last clear
 	let drawing = false;
 	let strokePointer: number | null = null;
 	let lastPoint: { x: number; y: number } | null = null;
-	let userClosing = false;
 	// Slider updates are debounced so a drag does not send one message per
 	// pixel: the timer is re-armed on every movement and fires once the slider
 	// has settled, mirroring how armCapture/stopTimer time the capture loop.
@@ -135,15 +116,32 @@
 	const stepsValue = $derived(normToValue(stepsNorm, stepsRange));
 	const structureValue = $derived(normToValue(structureNorm, structureRange));
 	const connected = $derived(connection === 'active' || connection === 'resuming');
-	// Frames only go out while a worker is actually attached. During a reassign
-	// the socket is open and the session is alive, but the API has no worker to
-	// relay to and silently drops whatever arrives.
-	const sending = $derived(connection === 'active');
 	const busy = $derived(connection === 'connecting' || connected);
 	const canConnect = $derived(!busy && modelId !== '' && prompt.trim() !== '');
 	// The prompt differs from the last one the API confirmed; whitespace around
 	// it does not count, because openMessage and updateParamsMessage both trim.
 	const promptDirty = $derived(connected && prompt.trim() !== appliedPrompt);
+
+	const realtimeSession = createRealtimeCanvasSession({
+		getDrawCanvas: () => drawCanvas,
+		getOutputCanvas: () => outputCanvas,
+		isCanvasBlank: () => blank,
+		onState: (state) => {
+			connection = state;
+		},
+		onNotice: (key: RealtimeCanvasNotice) => {
+			notice = key === '' ? '' : NOTICE_KEYS[key];
+		},
+		onCounters: (sent, rendered) => {
+			sentFrames = sent;
+			renderedFrames = rendered;
+		},
+		onAppliedParams: (params) => {
+			if (params.prompt !== undefined) appliedPrompt = params.prompt;
+			if (params.structure_strength !== undefined) appliedStructure = params.structure_strength;
+			if (params.steps !== undefined) appliedSteps = params.steps;
+		}
+	});
 
 	const STATUS_KEYS = {
 		idle: 'app.realtime_canvas.status_idle',
@@ -192,7 +190,7 @@
 		if (!connected || structureValue === appliedStructure) return;
 		structureTimer = setTimeout(() => {
 			structureTimer = null;
-			sendUpdate({ structure_strength: structureValue });
+			realtimeSession.updateParams({ structure_strength: structureValue });
 		}, SLIDER_UPDATE_MS);
 	});
 
@@ -204,7 +202,7 @@
 		if (!connected || stepsValue === appliedSteps) return;
 		stepsTimer = setTimeout(() => {
 			stepsTimer = null;
-			sendUpdate({ steps: stepsValue });
+			realtimeSession.updateParams({ steps: stepsValue });
 		}, SLIDER_UPDATE_MS);
 	});
 
@@ -225,12 +223,9 @@
 	// Tear the socket and the timer down with the panel, so leaving the view
 	// does not leave a session open on a worker.
 	$effect(() => () => {
-		userClosing = true;
-		stopTimer();
+		realtimeSession.destroy();
 		if (structureTimer !== null) clearTimeout(structureTimer);
 		if (stepsTimer !== null) clearTimeout(stepsTimer);
-		socket?.close(1000);
-		socket = null;
 	});
 
 	function canvasPoint(event: PointerEvent): { x: number; y: number } {
@@ -243,12 +238,8 @@
 	}
 
 	function markChanged(): void {
-		changed = true;
 		blank = false;
-		idleTicks = 0;
-		// The loop stops arming itself once the canvas goes quiet, so new paint
-		// has to restart it.
-		if (sending && timer === null) armCapture(FAST_INTERVAL_MS);
+		realtimeSession.markChanged();
 	}
 
 	/** One segment per move, so a long stroke does not restroke its whole path. */
@@ -320,233 +311,7 @@
 		blank = true;
 		// Still a revision worth sending: the model should stop drawing what is
 		// no longer on the canvas.
-		changed = true;
-		idleTicks = 0;
-		if (sending && timer === null) armCapture(FAST_INTERVAL_MS);
-	}
-
-	function stopTimer(): void {
-		if (timer !== null) clearTimeout(timer);
-		timer = null;
-	}
-
-	/**
-	 * Send an update_params message for a subset of the session's params.
-	 * Only while the session is live and the socket is open: everything else
-	 * silently drops, and the params_updated confirmation records what the
-	 * API actually merged rather than what was sent.
-	 */
-	function sendUpdate(params: Record<string, string | number>): void {
-		if (!connected || !socket || socket.readyState !== WebSocket.OPEN) return;
-		socket.send(updateParamsMessage(params));
-	}
-
-	function applyPrompt(): void {
-		if (!promptDirty) return;
-		// updateParamsMessage trims, so the untrimmed text is sent.
-		sendUpdate({ prompt });
-	}
-
-	function armCapture(delay: number): void {
-		stopTimer();
-		timer = setTimeout(() => void captureTick(), delay);
-	}
-
-	function encodeCanvas(canvas: HTMLCanvasElement): Promise<Uint8Array> {
-		return new Promise((resolve, reject) => {
-			// WebP is what docs/connection-handling.md specifies. A browser that
-			// cannot encode WebP silently returns PNG instead, which the worker's
-			// decoder happens to open too, so this leans on that rather than
-			// failing: an extension to the documented wire, not conformance.
-			canvas.toBlob((blob) => {
-				if (!blob) {
-					reject(new Error('the canvas produced no image'));
-					return;
-				}
-				blob.arrayBuffer().then((buffer) => resolve(new Uint8Array(buffer)), reject);
-			}, 'image/webp');
-		});
-	}
-
-	async function captureTick(): Promise<void> {
-		timer = null;
-		if (!socket || socket.readyState !== WebSocket.OPEN || !sessionId || !drawCanvas) return;
-		if (!sending) return; // a reassign is in flight; resumed re-arms
-
-		if (!shouldSendFrame({ changed, encoding, buffered: socket.bufferedAmount })) {
-			idleTicks += 1;
-			// Nothing to send for a while: stop arming rather than hold a timer
-			// open on an untouched canvas. Paint, a clear, or a resume restarts it.
-			if (idleTicks >= IDLE_TICKS_BEFORE_STOP && !changed) return;
-			armCapture(nextDelayMs(lastFrameCostMs));
-			return;
-		}
-
-		// The session this frame belongs to. Encoding is asynchronous, so by the
-		// time it finishes the user may have disconnected, cleared and
-		// reconnected; sending then would frame a stale bitmap as the new
-		// session and hand the replacement worker input the canvas no longer has.
-		const forSocket = socket;
-		const forSession = sessionId;
-		const started = performance.now();
-		// Cleared before the encode, so paint arriving during it marks the canvas
-		// changed again rather than being swallowed by this frame.
-		changed = false;
-		encoding = true;
-		try {
-			const image = await encodeCanvas(drawCanvas);
-			if (
-				socket === forSocket &&
-				sessionId === forSession &&
-				forSocket.readyState === WebSocket.OPEN
-			) {
-				if (sending) {
-					forSocket.send(canvasFrame(forSession, image));
-					sentFrames += 1;
-				} else {
-					// An interrupted arrived while this encode was in flight: the
-					// API has no worker to relay to and would drop the frame. Keep
-					// the revision pending so the resumed handler re-sends it.
-					changed = true;
-				}
-			}
-		} catch {
-			// A failed encode must not end the session silently: keep the
-			// revision pending and let the next tick try again. A rejection
-			// that outlived its session belongs to a session that is gone and
-			// must not write into the one that replaced it.
-			if (socket === forSocket && sessionId === forSession) {
-				changed = true;
-				notice = 'app.realtime_canvas.encode_failed';
-			}
-		} finally {
-			encoding = false;
-			lastFrameCostMs = performance.now() - started;
-		}
-		// Not after the session went away: re-arming there would resurrect a
-		// timer the teardown had already stopped.
-		if (socket === forSocket && sessionId === forSession) armCapture(nextDelayMs(lastFrameCostMs));
-	}
-
-	async function drainGenerated(): Promise<void> {
-		if (decoding) return;
-		decoding = true;
-		try {
-			while (pendingFrame !== null) {
-				const image = pendingFrame;
-				pendingFrame = null;
-				const forSession = sessionId;
-				// Per frame, so one that fails to decode does not strand the frame
-				// waiting behind it: without this the loop exits and nothing runs
-				// again until a further frame happens to arrive.
-				try {
-					// The Blob copies the bytes, so the socket's buffer is free to go.
-					const bitmap = await createImageBitmap(new Blob([image], { type: 'image/webp' }));
-					try {
-						// A decode that outlived its session must not paint over the
-						// output of the one that replaced it.
-						const target = sessionId === forSession ? outputCanvas?.getContext('2d') : null;
-						if (target) {
-							target.drawImage(bitmap, 0, 0, CANVAS_SIZE, CANVAS_SIZE);
-							renderedFrames += 1;
-						}
-					} finally {
-						bitmap.close();
-					}
-				} catch {
-					// A decode that failed for a session that is gone must not
-					// write its notice into the session that replaced it.
-					if (sessionId === forSession) {
-						notice = 'app.realtime_canvas.decode_failed';
-					}
-				}
-			}
-		} catch {
-			notice = 'app.realtime_canvas.decode_failed';
-		} finally {
-			decoding = false;
-		}
-	}
-
-	function handleControl(text: string): void {
-		let control: {
-			type?: string;
-			session_id?: string;
-			code?: number;
-			params?: unknown;
-		};
-		try {
-			control = JSON.parse(text) as typeof control;
-		} catch {
-			return;
-		}
-		if (control.type === 'ready' && control.session_id) {
-			// A server that sends a session id this client cannot frame is a
-			// server this client cannot talk to. Failing visibly beats throwing
-			// once per frame behind an Active badge.
-			if (!UUID_RE.test(control.session_id)) {
-				notice = 'app.realtime_canvas.socket_error';
-				connection = 'failed';
-				// Close the refused socket the way disconnect does, so no handler
-				// of the refused session survives. onclose ignores a socket that is
-				// no longer the module's, so clearing socket here keeps the
-				// failure state just set above instead of letting onclose
-				// overwrite it.
-				stopTimer();
-				socket?.close(1000);
-				socket = null;
-				sessionId = null;
-				pendingFrame = null;
-				return;
-			}
-			sessionId = control.session_id;
-			connection = 'active';
-			notice = '';
-			// Anything already drawn belongs on the first frame.
-			changed = !blank;
-			armCapture(FAST_INTERVAL_MS);
-		} else if (control.type === 'interrupted') {
-			// The worker vanished and the API is already picking a replacement;
-			// the socket and the session id both survive it.
-			connection = 'resuming';
-		} else if (control.type === 'resumed') {
-			connection = 'active';
-			// The browser is the recovery source of truth: the replacement worker
-			// has never seen this canvas, so resend all of it.
-			changed = true;
-			idleTicks = 0;
-			armCapture(FAST_INTERVAL_MS);
-		} else if (control.type === 'params_updated' && control.params) {
-			// Record what the API confirmed. A rejected update leaves these
-			// untouched, so the Update button and the slider debounce keep
-			// comparing against the last confirmed params rather than optimism.
-			const params = control.params as {
-				prompt?: unknown;
-				structure_strength?: unknown;
-				steps?: unknown;
-			};
-			if (typeof params.prompt === 'string') appliedPrompt = params.prompt;
-			if (typeof params.structure_strength === 'number') {
-				appliedStructure = params.structure_strength;
-			}
-			if (typeof params.steps === 'number') appliedSteps = params.steps;
-			const wake = afterParamsUpdated();
-			changed = wake.changed;
-			idleTicks = wake.idleTicks;
-			if (sending) armCapture(FAST_INTERVAL_MS);
-		} else if (control.type === 'error') {
-			// A rejected update reports through the notice and leaves the
-			// session alone; the socket stays open either way.
-			notice = refusalNotice(control.code ?? 0);
-		}
-	}
-
-	function refusalNotice(code: number): NoticeKey {
-		if (code === 4004) return 'app.realtime_canvas.refused_model';
-		if (code === 4003) return 'app.realtime_canvas.refused_capacity';
-		if (code === 4002) return 'app.realtime_canvas.refused_version';
-		if (code === 4000) return 'app.realtime_canvas.refused_protocol';
-		return 'app.realtime_canvas.socket_error';
+		realtimeSession.markChanged();
 	}
 
 	/** The picker's option label: the model's measured frame cost when its
@@ -558,88 +323,26 @@
 			: model.name;
 	}
 
-	function onMessage(event: MessageEvent): void {
-		if (typeof event.data === 'string') {
-			handleControl(event.data);
-			return;
-		}
-		if (!sessionId || !(event.data instanceof ArrayBuffer)) return;
-		const image = parseGeneratedFrame(new Uint8Array(event.data), sessionId);
-		if (image === null || image.length === 0) return;
-		// Latest wins: a frame still waiting to be decoded is dropped rather
-		// than queued, so the output cannot fall behind the canvas.
-		pendingFrame = image;
-		void drainGenerated();
-	}
-
 	function connect(): void {
 		if (!canConnect) return;
-		notice = '';
-		userClosing = false;
-		connection = 'connecting';
-		// A new session must not show the previous one's output.
-		sentFrames = 0;
-		renderedFrames = 0;
-		pendingFrame = null;
 		const output = outputCanvas?.getContext('2d');
 		if (output) {
 			output.fillStyle = PAPER;
 			output.fillRect(0, 0, CANVAS_SIZE, CANVAS_SIZE);
 		}
-		// The open message must carry what the user chose when they pressed
-		// Connect, not whatever the reactive state holds by the time the socket
-		// completes: an effect can rewrite modelId if the model list changes in
-		// between.
-		const sessionModelId = modelId;
-		const sessionPrompt = prompt;
-		const sessionStructure = structureValue;
-		const sessionSteps = stepsValue;
-		const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
-		const opening = new WebSocket(`${scheme}//${location.host}/api/v1/realtime`);
-		opening.binaryType = 'arraybuffer';
-		socket = opening;
-		opening.onopen = () => {
-			// openMessage carries the params every shipped realtime model
-			// declares: the prompt is required (an open without it is refused
-			// 4000 before a worker is assigned), and structure_strength and
-			// steps are declared by every shipped realtime model too. The
-			// simulated manifest declares only the prompt and accepts the other
-			// two as extra properties, which JSON Schema allows. It is built in
-			// $lib/realtime-canvas so a test holds it. What opens is what is
-			// applied, so the same values seed the applied state that the
-			// Update button and the slider debounce compare against.
-			appliedPrompt = sessionPrompt.trim();
-			appliedStructure = sessionStructure;
-			appliedSteps = sessionSteps;
-			opening.send(
-				openMessage(sessionModelId, sessionPrompt, {
-					structure_strength: sessionStructure,
-					steps: sessionSteps
-				})
-			);
-		};
-		opening.onmessage = onMessage;
-		opening.onerror = () => {
-			if (!notice) notice = 'app.realtime_canvas.socket_error';
-		};
-		opening.onclose = (event) => {
-			// A late close from a socket that was replaced must not touch live
-			// state: its session is gone and the current one is owned by the
-			// socket that replaced it.
-			if (opening !== socket) return;
-			stopTimer();
-			socket = null;
-			sessionId = null;
-			pendingFrame = null;
-			connection = userClosing ? 'idle' : stateForCloseCode(event.code);
-			if (connection === 'failed' && !notice) notice = refusalNotice(event.code);
-		};
+		realtimeSession.connect({
+			modelId,
+			prompt,
+			params: { structure_strength: structureValue, steps: stepsValue }
+		});
+	}
+
+	function applyPrompt(): void {
+		if (promptDirty) realtimeSession.updateParams({ prompt });
 	}
 
 	function disconnect(): void {
-		userClosing = true;
-		stopTimer();
-		socket?.close(1000);
+		realtimeSession.disconnect();
 	}
 </script>
 

--- a/frontend/src/lib/realtime-canvas.test.ts
+++ b/frontend/src/lib/realtime-canvas.test.ts
@@ -11,8 +11,8 @@ import {
 	FAST_INTERVAL_MS,
 	FRAME_HEADER_BYTES,
 	GENERATED_FRAME,
+	IDLE_TICKS_BEFORE_STOP,
 	SLOW_INTERVAL_MS,
-	afterParamsUpdated,
 	canvasFrame,
 	nextDelayMs,
 	nextIntervalMs,
@@ -21,7 +21,10 @@ import {
 	shouldSendFrame,
 	stateForCloseCode,
 	updateParamsMessage,
-	uuidBytes
+	uuidBytes,
+	createRealtimeCanvasSession,
+	type ConnectionState,
+	type RealtimeCanvasSession
 } from './realtime-canvas.ts';
 
 const SESSION = '3f2504e0-4f89-11d3-9a0c-0305e82c3301';
@@ -117,14 +120,6 @@ test('a frame is sent only when there is a change, no encode, and an empty socke
 	assert.ok(!shouldSendFrame({ changed: true, encoding: false, buffered: 1 }));
 });
 
-test('a confirmed param update must resend the same canvas', () => {
-	const idle = { changed: false, encoding: false, buffered: 0 };
-	assert.ok(!shouldSendFrame(idle));
-	const wake = afterParamsUpdated();
-	assert.equal(wake.idleTicks, 0);
-	assert.ok(shouldSendFrame({ ...idle, changed: wake.changed }));
-});
-
 test('the cadence stays inside the two to four fps band', () => {
 	assert.equal(nextIntervalMs(10), FAST_INTERVAL_MS);
 	assert.equal(nextIntervalMs(FAST_INTERVAL_MS), FAST_INTERVAL_MS);
@@ -190,4 +185,358 @@ test('a refusal fails the session and anything else invites a reconnect', () => 
 	// A normal close, or a dropped connection, keeps the canvas recoverable.
 	assert.equal(stateForCloseCode(1000), 'interrupted');
 	assert.equal(stateForCloseCode(1006), 'interrupted');
+});
+
+class TestSocket {
+	readyState = 0;
+	emitClose = true;
+	bufferedAmount = 0;
+	binaryType: BinaryType = 'arraybuffer';
+	sent: Array<string | ArrayBuffer | ArrayBufferView> = [];
+	onopen: ((event: Event) => void) | null = null;
+	onmessage: ((event: MessageEvent<string | ArrayBuffer>) => void) | null = null;
+	onerror: ((event: Event) => void) | null = null;
+	onclose: ((event: CloseEvent) => void) | null = null;
+
+	send(data: string | ArrayBuffer | ArrayBufferView): void {
+		this.sent.push(data);
+	}
+
+	open(): void {
+		this.readyState = 1;
+		this.onopen?.(new Event('open'));
+	}
+
+	message(data: string | ArrayBuffer): void {
+		this.onmessage?.({ data } as MessageEvent<string | ArrayBuffer>);
+	}
+
+	close(code = 1000): void {
+		this.readyState = 3;
+		if (this.emitClose) this.onclose?.({ code } as CloseEvent);
+	}
+}
+
+function sessionHarness(
+	options: {
+		encode?: (canvas: HTMLCanvasElement) => Promise<Uint8Array<ArrayBuffer>>;
+		decode?: (image: Uint8Array<ArrayBuffer>) => Promise<{ close(): void }>;
+		isCanvasBlank?: () => boolean;
+	} = {}
+): {
+	session: RealtimeCanvasSession;
+	sockets: TestSocket[];
+	states: ConnectionState[];
+	notices: string[];
+	applied: Array<Record<string, unknown>>;
+	counters: Array<[number, number]>;
+	draws: number[];
+	tick(): void;
+	timerCount(): number;
+} {
+	const sockets: TestSocket[] = [];
+	const timers = new Map<number, () => void>();
+	let nextTimer = 0;
+	const schedule = ((callback: () => void) => {
+		const id = ++nextTimer;
+		timers.set(id, callback);
+		return id;
+	}) as typeof globalThis.setTimeout;
+	const cancel = ((id: ReturnType<typeof setTimeout>) => {
+		timers.delete(id as unknown as number);
+	}) as typeof globalThis.clearTimeout;
+	const states: ConnectionState[] = [];
+	const notices: string[] = [];
+	const applied: Array<Record<string, unknown>> = [];
+	const counters: Array<[number, number]> = [];
+	const draws: number[] = [];
+	const session = createRealtimeCanvasSession({
+		getDrawCanvas: () => ({}) as HTMLCanvasElement,
+		getOutputCanvas: () => ({}) as HTMLCanvasElement,
+		isCanvasBlank: options.isCanvasBlank ?? (() => false),
+		onState: (state) => states.push(state),
+		onNotice: (notice) => notices.push(notice),
+		onCounters: (sent, rendered) => counters.push([sent, rendered]),
+		onAppliedParams: (params) => applied.push(params),
+		webSocketFactory: () => {
+			const socket = new TestSocket();
+			sockets.push(socket);
+			return socket;
+		},
+		encode: options.encode ?? (async () => new Uint8Array([1, 2, 3])),
+		decode: options.decode ?? (async () => ({ close() {} })),
+		drawDecoded: () => draws.push(1),
+		setTimeout: schedule,
+		clearTimeout: cancel
+	});
+	return {
+		session,
+		sockets,
+		states,
+		notices,
+		applied,
+		counters,
+		draws,
+		tick() {
+			const entry = timers.entries().next().value as [number, () => void] | undefined;
+			if (!entry) throw new Error('no timer');
+			timers.delete(entry[0]);
+			entry[1]();
+		},
+		timerCount: () => timers.size
+	};
+}
+
+function ready(socket: TestSocket, id = SESSION): void {
+	socket.open();
+	socket.message(JSON.stringify({ type: 'ready', session_id: id }));
+}
+
+function generated(id = SESSION): ArrayBuffer {
+	const frame = new Uint8Array(FRAME_HEADER_BYTES + 2);
+	frame[0] = GENERATED_FRAME;
+	frame.set(uuidBytes(id), 1);
+	frame.set([9, 8], FRAME_HEADER_BYTES);
+	return frame.buffer;
+}
+
+function emptyGenerated(id = SESSION): ArrayBuffer {
+	const frame = new Uint8Array(FRAME_HEADER_BYTES);
+	frame[0] = GENERATED_FRAME;
+	frame.set(uuidBytes(id), 1);
+	return frame.buffer;
+}
+
+test('an interruption during encode keeps the canvas pending for resume', async () => {
+	let resolveEncode!: (image: Uint8Array<ArrayBuffer>) => void;
+	const harness = sessionHarness({
+		encode: () =>
+			new Promise((resolve) => {
+				resolveEncode = resolve;
+			})
+	});
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	ready(harness.sockets[0]);
+	harness.tick();
+	harness.session.markChanged();
+	assert.equal(harness.timerCount(), 0);
+	harness.sockets[0].message(JSON.stringify({ type: 'interrupted' }));
+	resolveEncode(new Uint8Array([4]));
+	await Promise.resolve();
+	assert.equal(harness.sockets[0].sent.filter((data) => typeof data !== 'string').length, 0);
+	assert.equal(harness.timerCount(), 1);
+	harness.sockets[0].message(JSON.stringify({ type: 'resumed' }));
+	assert.equal(harness.timerCount(), 1);
+});
+
+test('resume resend encodes and sends the complete current frame', async () => {
+	let encodes = 0;
+	const harness = sessionHarness({
+		encode: async () => {
+			encodes += 1;
+			return new Uint8Array([encodes]);
+		}
+	});
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	ready(harness.sockets[0]);
+	harness.sockets[0].message(JSON.stringify({ type: 'interrupted' }));
+	harness.sockets[0].message(JSON.stringify({ type: 'resumed' }));
+	harness.tick();
+	await Promise.resolve();
+	const frames = harness.sockets[0].sent.filter((data) => typeof data !== 'string');
+	assert.equal(frames.length, 1);
+	assert.deepEqual(
+		new Uint8Array(frames[0] as ArrayBuffer).subarray(FRAME_HEADER_BYTES),
+		new Uint8Array([1])
+	);
+});
+
+test('late socket, encode, and decode work cannot affect a replacement session', async () => {
+	let resolveEncode!: (image: Uint8Array<ArrayBuffer>) => void;
+	let resolveDecode!: (bitmap: { close(): void }) => void;
+	const harness = sessionHarness({
+		encode: () =>
+			new Promise((resolve) => {
+				resolveEncode = resolve;
+			}),
+		decode: () =>
+			new Promise((resolve) => {
+				resolveDecode = resolve;
+			})
+	});
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'old',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	const oldSocket = harness.sockets[0];
+	ready(oldSocket);
+	harness.tick();
+	oldSocket.message(generated());
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'new',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	const newSocket = harness.sockets[1];
+	oldSocket.close(1006);
+	oldSocket.message(JSON.stringify({ type: 'ready', session_id: SESSION }));
+	resolveEncode(new Uint8Array([7]));
+	resolveDecode({ close() {} });
+	await Promise.resolve();
+	assert.deepEqual(harness.states.slice(-1), ['connecting']);
+	assert.equal(harness.draws.length, 0);
+	ready(newSocket, NEARLY);
+	assert.equal(harness.states.at(-1), 'active');
+});
+
+test('an invalid ready id fails and closes without leaving a capture timer', () => {
+	const harness = sessionHarness();
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	harness.sockets[0].open();
+	harness.sockets[0].message(JSON.stringify({ type: 'ready', session_id: 'not-a-uuid' }));
+	assert.equal(harness.states.at(-1), 'failed');
+	assert.equal(harness.sockets[0].readyState, 3);
+	assert.equal(harness.timerCount(), 0);
+});
+
+test('encode and decode failures notify while preserving the session', async () => {
+	const harness = sessionHarness({
+		encode: async () => {
+			throw new Error('encode');
+		},
+		decode: async () => {
+			throw new Error('decode');
+		}
+	});
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	ready(harness.sockets[0]);
+	harness.tick();
+	await Promise.resolve();
+	assert.equal(harness.notices.at(-1), 'encode_failed');
+	harness.sockets[0].message(generated());
+	await Promise.resolve();
+	assert.equal(harness.notices.at(-1), 'decode_failed');
+	assert.equal(harness.states.at(-1), 'active');
+});
+
+test('params acknowledgement updates controls and wakes capture', () => {
+	const harness = sessionHarness({ isCanvasBlank: () => true });
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	ready(harness.sockets[0]);
+	for (let tick = 0; tick < IDLE_TICKS_BEFORE_STOP; tick += 1) harness.tick();
+	assert.equal(harness.timerCount(), 0);
+	harness.sockets[0].message(
+		JSON.stringify({
+			type: 'params_updated',
+			params: { prompt: 'a dog', structure_strength: 0.7, steps: 12 }
+		})
+	);
+	assert.deepEqual(harness.applied.at(-1), { prompt: 'a dog', structure_strength: 0.7, steps: 12 });
+	assert.equal(harness.timerCount(), 1);
+	harness.tick();
+	return Promise.resolve().then(() => {
+		const frames = harness.sockets[0].sent.filter((data) => typeof data !== 'string');
+		assert.equal(frames.length, 1);
+	});
+});
+
+test('destroy cancels capture timers and stale async completion cannot re-arm one', async () => {
+	let resolveEncode!: (image: Uint8Array<ArrayBuffer>) => void;
+	const harness = sessionHarness({
+		encode: () =>
+			new Promise((resolve) => {
+				resolveEncode = resolve;
+			})
+	});
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	ready(harness.sockets[0]);
+	harness.tick();
+	harness.session.destroy();
+	assert.equal(harness.timerCount(), 0);
+	resolveEncode(new Uint8Array([2]));
+	await Promise.resolve();
+	assert.equal(harness.timerCount(), 0);
+});
+
+test('disconnect fences pending encode and decode work before close arrives', async () => {
+	let resolveEncode!: (image: Uint8Array<ArrayBuffer>) => void;
+	let resolveDecode!: (bitmap: { close(): void }) => void;
+	const harness = sessionHarness({
+		encode: () =>
+			new Promise((resolve) => {
+				resolveEncode = resolve;
+			}),
+		decode: () =>
+			new Promise((resolve) => {
+				resolveDecode = resolve;
+			})
+	});
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	const socket = harness.sockets[0];
+	ready(socket);
+	harness.tick();
+	socket.emitClose = false;
+	harness.session.disconnect();
+	resolveEncode(new Uint8Array([5]));
+	await Promise.resolve();
+	assert.equal(harness.timerCount(), 0);
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	const replacement = harness.sockets[1];
+	ready(replacement);
+	replacement.message(generated());
+	replacement.emitClose = false;
+	harness.session.disconnect();
+	resolveDecode({ close() {} });
+	await Promise.resolve();
+	assert.equal(harness.draws.length, 0);
+});
+
+test('binary frames before ready and empty generated frames are ignored', async () => {
+	const harness = sessionHarness();
+	harness.session.connect({
+		modelId: 'vega-rt',
+		prompt: 'a cat',
+		params: { structure_strength: 0.5, steps: 10 }
+	});
+	const socket = harness.sockets[0];
+	socket.open();
+	socket.message(generated());
+	socket.message(JSON.stringify({ type: 'ready', session_id: SESSION }));
+	socket.message(emptyGenerated());
+	await Promise.resolve();
+	assert.equal(harness.draws.length, 0);
+	assert.equal(harness.counters.at(-1)?.[1], 0);
 });

--- a/frontend/src/lib/realtime-canvas.ts
+++ b/frontend/src/lib/realtime-canvas.ts
@@ -1,8 +1,6 @@
 // Wire framing and send policy for the realtime drawing canvas (issue #3).
-// Kept apart from the panel so the rules the canvas depends on are reachable
-// from node --test: this module holds the framing, the send predicate, the
-// cadence and the opening message. The panel owns the DOM and the session
-// lifecycle.
+// Kept apart from the panel so node --test can exercise framing and the live
+// session lifecycle without loading Svelte. The panel owns the DOM and controls.
 //
 // The wire is docs/connection-handling.md: a 17 byte header of one kind byte
 // and the 16 byte session UUID, then a complete WebP image. That header
@@ -81,16 +79,6 @@ export function shouldSendFrame(state: {
 	buffered: number;
 }): boolean {
 	return state.changed && !state.encoding && state.buffered === 0;
-}
-
-/**
- * After params_updated, the same canvas must go out again. Capture stops
- * once IDLE_TICKS_BEFORE_STOP ticks have had nothing to send, and a prompt
- * or slider change does not paint, so without this the new params wait
- * until the next stroke or a reconnect.
- */
-export function afterParamsUpdated(): { changed: true; idleTicks: 0 } {
-	return { changed: true, idleTicks: 0 };
 }
 
 /**
@@ -176,4 +164,433 @@ export type ConnectionState =
  */
 export function stateForCloseCode(code: number): ConnectionState {
 	return code >= 4000 && code <= 4004 ? 'failed' : 'interrupted';
+}
+
+const OPEN = 1;
+const UUID_RE = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+
+interface CanvasSocket {
+	readyState: number;
+	bufferedAmount: number;
+	binaryType: BinaryType;
+	send(data: string | ArrayBuffer | ArrayBufferView): void;
+	close(code?: number): void;
+	onopen: ((event: Event) => void) | null;
+	onmessage: ((event: MessageEvent<string | ArrayBuffer>) => void) | null;
+	onerror: ((event: Event) => void) | null;
+	onclose: ((event: CloseEvent) => void) | null;
+}
+
+type DecodedFrame = { close(): void };
+
+interface SessionGeneration {
+	readonly socket: CanvasSocket;
+	readonly modelId: string;
+	readonly prompt: string;
+	readonly params: RealtimeCanvasParams;
+	sessionId: string | null;
+	state: ConnectionState;
+	changed: boolean;
+	encoding: boolean;
+	decoding: boolean;
+	pendingFrame: Uint8Array<ArrayBuffer> | null;
+	timer: ReturnType<typeof setTimeout> | null;
+	idleTicks: number;
+	lastFrameCostMs: number;
+	userClosing: boolean;
+}
+
+export interface RealtimeCanvasParams {
+	structure_strength: number;
+	steps: number;
+}
+
+export type RealtimeCanvasNotice =
+	| ''
+	| 'encode_failed'
+	| 'decode_failed'
+	| 'socket_error'
+	| 'refused_protocol'
+	| 'refused_version'
+	| 'refused_capacity'
+	| 'refused_model';
+
+export interface RealtimeCanvasSessionOptions {
+	getDrawCanvas: () => HTMLCanvasElement | undefined;
+	getOutputCanvas: () => HTMLCanvasElement | undefined;
+	isCanvasBlank: () => boolean;
+	onState: (state: ConnectionState) => void;
+	onNotice: (notice: RealtimeCanvasNotice) => void;
+	onCounters: (sent: number, rendered: number) => void;
+	onAppliedParams: (
+		params: Partial<{ prompt: string; structure_strength: number; steps: number }>
+	) => void;
+	webSocketFactory?: () => CanvasSocket;
+	encode?: (canvas: HTMLCanvasElement) => Promise<Uint8Array<ArrayBuffer>>;
+	decode?: (image: Uint8Array<ArrayBuffer>) => Promise<DecodedFrame>;
+	drawDecoded?: (bitmap: DecodedFrame, canvas: HTMLCanvasElement) => void;
+	setTimeout?: typeof globalThis.setTimeout;
+	clearTimeout?: typeof globalThis.clearTimeout;
+}
+
+export interface RealtimeCanvasSession {
+	connect(input: { modelId: string; prompt: string; params: RealtimeCanvasParams }): void;
+	disconnect(): void;
+	updateParams(params: Record<string, string | number>): void;
+	markChanged(): void;
+	destroy(): void;
+}
+
+function encodeCanvas(canvas: HTMLCanvasElement): Promise<Uint8Array<ArrayBuffer>> {
+	return new Promise((resolve, reject) => {
+		canvas.toBlob((blob) => {
+			if (!blob) {
+				reject(new Error('the canvas produced no image'));
+				return;
+			}
+			blob.arrayBuffer().then((buffer) => resolve(new Uint8Array(buffer)), reject);
+		}, 'image/webp');
+	});
+}
+
+async function decodeCanvas(image: Uint8Array<ArrayBuffer>): Promise<DecodedFrame> {
+	return createImageBitmap(new Blob([image], { type: 'image/webp' }));
+}
+
+function drawDecodedFrame(bitmap: DecodedFrame, canvas: HTMLCanvasElement): void {
+	const context = canvas.getContext('2d');
+	if (!context) return;
+	context.drawImage(bitmap as CanvasImageSource, 0, 0, 512, 512);
+}
+
+function defaultSocketFactory(): CanvasSocket {
+	const scheme = location.protocol === 'https:' ? 'wss:' : 'ws:';
+	return new WebSocket(`${scheme}//${location.host}/api/v1/realtime`) as CanvasSocket;
+}
+
+function refusalNotice(code: number): RealtimeCanvasNotice {
+	if (code === 4004) return 'refused_model';
+	if (code === 4003) return 'refused_capacity';
+	if (code === 4002) return 'refused_version';
+	if (code === 4000) return 'refused_protocol';
+	return 'socket_error';
+}
+
+export function createRealtimeCanvasSession(
+	options: RealtimeCanvasSessionOptions
+): RealtimeCanvasSession {
+	const makeSocket = options.webSocketFactory ?? defaultSocketFactory;
+	const encode = options.encode ?? encodeCanvas;
+	const decode = options.decode ?? decodeCanvas;
+	const draw = options.drawDecoded ?? drawDecodedFrame;
+	const schedule = options.setTimeout ?? globalThis.setTimeout;
+	const cancel = options.clearTimeout ?? globalThis.clearTimeout;
+	let current: SessionGeneration | null = null;
+	let sent = 0;
+	let rendered = 0;
+	let destroyed = false;
+	let notice: RealtimeCanvasNotice = '';
+
+	function isCurrent(generation: SessionGeneration): boolean {
+		return !destroyed && current === generation;
+	}
+
+	function setNotice(value: RealtimeCanvasNotice): void {
+		notice = value;
+		options.onNotice(value);
+	}
+
+	function stopTimer(generation: SessionGeneration): void {
+		if (generation.timer !== null) cancel(generation.timer);
+		generation.timer = null;
+	}
+
+	function armCapture(generation: SessionGeneration, delay: number): void {
+		stopTimer(generation);
+		generation.timer = schedule(() => void captureTick(generation), delay);
+	}
+
+	function retire(generation: SessionGeneration): void {
+		stopTimer(generation);
+		generation.pendingFrame = null;
+		generation.userClosing = true;
+		generation.socket.close(1000);
+	}
+
+	function setState(generation: SessionGeneration, state: ConnectionState): void {
+		if (!isCurrent(generation)) return;
+		generation.state = state;
+		options.onState(state);
+	}
+
+	function sending(generation: SessionGeneration): boolean {
+		return generation.state === 'active';
+	}
+
+	function canContinue(generation: SessionGeneration): boolean {
+		return isCurrent(generation) && !generation.userClosing;
+	}
+
+	function sendUpdate(
+		generation: SessionGeneration,
+		params: Record<string, string | number>
+	): void {
+		if (
+			!isCurrent(generation) ||
+			generation.userClosing ||
+			!generation.sessionId ||
+			generation.socket.readyState !== OPEN ||
+			(generation.state !== 'active' && generation.state !== 'resuming')
+		)
+			return;
+		generation.socket.send(updateParamsMessage(params));
+	}
+
+	async function captureTick(generation: SessionGeneration): Promise<void> {
+		generation.timer = null;
+		const canvas = options.getDrawCanvas();
+		if (
+			!isCurrent(generation) ||
+			generation.userClosing ||
+			!generation.sessionId ||
+			generation.socket.readyState !== OPEN ||
+			!canvas ||
+			!sending(generation)
+		)
+			return;
+
+		if (
+			!shouldSendFrame({
+				changed: generation.changed,
+				encoding: generation.encoding,
+				buffered: generation.socket.bufferedAmount
+			})
+		) {
+			generation.idleTicks += 1;
+			if (generation.idleTicks >= IDLE_TICKS_BEFORE_STOP && !generation.changed) return;
+			armCapture(generation, nextDelayMs(generation.lastFrameCostMs));
+			return;
+		}
+
+		const forSession = generation.sessionId;
+		const started = performance.now();
+		generation.changed = false;
+		generation.encoding = true;
+		try {
+			const image = await encode(canvas);
+			if (canContinue(generation) && generation.socket.readyState === OPEN) {
+				if (sending(generation)) {
+					generation.socket.send(canvasFrame(forSession, image));
+					sent += 1;
+					options.onCounters(sent, rendered);
+				} else {
+					generation.changed = true;
+				}
+			}
+		} catch {
+			if (canContinue(generation)) {
+				generation.changed = true;
+				setNotice('encode_failed');
+			}
+		} finally {
+			generation.encoding = false;
+			generation.lastFrameCostMs = performance.now() - started;
+		}
+		if (canContinue(generation)) armCapture(generation, nextDelayMs(generation.lastFrameCostMs));
+	}
+
+	async function drainGenerated(generation: SessionGeneration): Promise<void> {
+		if (generation.decoding) return;
+		generation.decoding = true;
+		try {
+			while (canContinue(generation) && generation.pendingFrame !== null) {
+				const image = generation.pendingFrame;
+				generation.pendingFrame = null;
+				try {
+					const bitmap = await decode(image);
+					try {
+						if (canContinue(generation)) {
+							const canvas = options.getOutputCanvas();
+							if (canvas) {
+								draw(bitmap, canvas);
+								rendered += 1;
+								options.onCounters(sent, rendered);
+							}
+						}
+					} finally {
+						bitmap.close();
+					}
+				} catch {
+					if (canContinue(generation)) setNotice('decode_failed');
+				}
+			}
+		} finally {
+			generation.decoding = false;
+		}
+	}
+
+	function handleControl(generation: SessionGeneration, text: string): void {
+		let control: {
+			type?: string;
+			session_id?: string;
+			code?: number;
+			params?: unknown;
+		};
+		try {
+			control = JSON.parse(text) as typeof control;
+		} catch {
+			return;
+		}
+		if (!canContinue(generation)) return;
+		if (control.type === 'ready') {
+			if (!control.session_id || !UUID_RE.test(control.session_id)) {
+				setNotice('socket_error');
+				setState(generation, 'failed');
+				stopTimer(generation);
+				generation.pendingFrame = null;
+				current = null;
+				generation.socket.close(1000);
+				return;
+			}
+			generation.sessionId = control.session_id;
+			setState(generation, 'active');
+			setNotice('');
+			generation.changed = !options.isCanvasBlank();
+			armCapture(generation, FAST_INTERVAL_MS);
+			return;
+		}
+		if (control.type === 'interrupted') {
+			setState(generation, 'resuming');
+			return;
+		}
+		if (control.type === 'resumed') {
+			setState(generation, 'active');
+			generation.changed = true;
+			generation.idleTicks = 0;
+			armCapture(generation, FAST_INTERVAL_MS);
+			return;
+		}
+		if (control.type === 'params_updated' && control.params) {
+			const params = control.params as {
+				prompt?: unknown;
+				structure_strength?: unknown;
+				steps?: unknown;
+			};
+			const applied: Partial<{ prompt: string; structure_strength: number; steps: number }> = {};
+			if (typeof params.prompt === 'string') applied.prompt = params.prompt;
+			if (typeof params.structure_strength === 'number') {
+				applied.structure_strength = params.structure_strength;
+			}
+			if (typeof params.steps === 'number') applied.steps = params.steps;
+			options.onAppliedParams(applied);
+			generation.changed = true;
+			generation.idleTicks = 0;
+			if (sending(generation)) armCapture(generation, FAST_INTERVAL_MS);
+			return;
+		}
+		if (control.type === 'error') setNotice(refusalNotice(control.code ?? 0));
+	}
+
+	function attach(generation: SessionGeneration): void {
+		const socket = generation.socket;
+		socket.binaryType = 'arraybuffer';
+		socket.onopen = () => {
+			if (!canContinue(generation)) return;
+			socket.send(
+				openMessage(generation.modelId, generation.prompt, {
+					structure_strength: generation.params.structure_strength,
+					steps: generation.params.steps
+				})
+			);
+			options.onAppliedParams({
+				prompt: generation.prompt.trim(),
+				structure_strength: generation.params.structure_strength,
+				steps: generation.params.steps
+			});
+		};
+		socket.onmessage = (event) => {
+			if (!canContinue(generation)) return;
+			if (typeof event.data === 'string') {
+				handleControl(generation, event.data);
+				return;
+			}
+			if (!generation.sessionId || !(event.data instanceof ArrayBuffer)) return;
+			const image = parseGeneratedFrame(new Uint8Array(event.data), generation.sessionId);
+			if (image === null || image.length === 0) return;
+			generation.pendingFrame = image;
+			void drainGenerated(generation);
+		};
+		socket.onerror = () => {
+			if (canContinue(generation)) setNotice('socket_error');
+		};
+		socket.onclose = (event) => {
+			if (!isCurrent(generation)) return;
+			stopTimer(generation);
+			generation.sessionId = null;
+			generation.pendingFrame = null;
+			const state = generation.userClosing ? 'idle' : stateForCloseCode(event.code);
+			generation.state = state;
+			options.onState(state);
+			current = null;
+			if (generation.state === 'failed' && !notice) setNotice(refusalNotice(event.code));
+		};
+	}
+
+	return {
+		connect(input) {
+			if (destroyed) return;
+			if (current) retire(current);
+			const socket = makeSocket();
+			const generation: SessionGeneration = {
+				socket,
+				modelId: input.modelId,
+				prompt: input.prompt,
+				params: input.params,
+				sessionId: null,
+				state: 'connecting',
+				changed: false,
+				encoding: false,
+				decoding: false,
+				pendingFrame: null,
+				timer: null,
+				idleTicks: 0,
+				lastFrameCostMs: 0,
+				userClosing: false
+			};
+			current = generation;
+			sent = 0;
+			rendered = 0;
+			options.onCounters(sent, rendered);
+			setNotice('');
+			options.onState('connecting');
+			attach(generation);
+		},
+		disconnect() {
+			if (!current) return;
+			current.userClosing = true;
+			stopTimer(current);
+			current.socket.close(1000);
+		},
+		updateParams(params) {
+			if (current) sendUpdate(current, params);
+		},
+		markChanged() {
+			if (!current) return;
+			current.changed = true;
+			current.idleTicks = 0;
+			if (sending(current) && current.timer === null && !current.encoding) {
+				armCapture(current, FAST_INTERVAL_MS);
+			}
+		},
+		destroy() {
+			if (destroyed) return;
+			destroyed = true;
+			if (current) {
+				stopTimer(current);
+				current.pendingFrame = null;
+				current.socket.close(1000);
+				current = null;
+			}
+		}
+	};
 }


### PR DESCRIPTION
# Description

Move live drawing session rules into the existing realtime canvas module. The panel keeps drawing controls and the canvas DOM.

Closes #473.

# Motivation

Socket state, frame capture and pending image work lived in the panel. Helper tests could not test a full session or its failure paths.

# Functionality

The session module owns connect, parameter updates, resume, frame capture and teardown. Work from an old session cannot change its replacement. The panel maps short notice names to translated text and keeps slider debounce timers.

# Details

Review the session methods first, then the tests for stale socket events, pending encode/decode work, interrupted sessions and timer cleanup. The frame format, canvas dimensions and user controls stay the same.

Checks: full make verify passes with the branch PYTHONPATH: 1008 backend tests, 297 worker tests and 114 frontend tests. Type, lint, production build and CSP checks pass.

The built /app route also passed a Chrome test with real drawing and WebP encode/decode. It covered output pixels, prompt updates, resume, disconnect/reconnect and navigation teardown. HTTP and WebSocket test adapters replaced the backend. No GPU inference was run.
