### PR TITLE
Bound canvas retries while the socket is busy

### DIFF
--- a/docs/connection-handling.md
+++ b/docs/connection-handling.md
@@ -145,6 +145,13 @@ slot calibration in [decisions.md](decisions.md) is measured against.
 
 TCP-level disconnects are acted on immediately; the heartbeat timeout only matters when a connection dies silently, which load balancers make possible. Browser keepalive is an application-level control message because browser WebSocket APIs cannot send protocol pings.
 
+Browser capture targets 250 or 500 ms between frame starts, based on the
+last encode and send cost. After an encode, only the unused part of that
+period is delayed. A tick that does no work waits a full period: it must not
+subtract the old encode cost again. This bounds retries while the socket is
+busy and keeps the latest drawing pending until the socket can send it.
+It does not change the wire format or prove a GPU cost saving.
+
 ## Session states
 
 > Shipped status (2026-08-19): **partially implemented.** Protocol 4 ships named states `assigning` / `live` / `ending` / `ended`, `control_generation` fencing, and `session_refused` as an attempt failure (issue #270). `queued` and `idle` still wait on the admission queue and idle release. Checkpoints, durable outbox, and per-session mailboxes do not ship. The governing design is decisions.md, "The realtime session has states, a fencing generation, and one durable accounting owner".

--- a/frontend/src/lib/realtime-canvas.test.ts
+++ b/frontend/src/lib/realtime-canvas.test.ts
@@ -231,15 +231,18 @@ function sessionHarness(
 	applied: Array<Record<string, unknown>>;
 	counters: Array<[number, number]>;
 	draws: number[];
+	timerDelays: number[];
 	tick(): void;
 	timerCount(): number;
 } {
 	const sockets: TestSocket[] = [];
 	const timers = new Map<number, () => void>();
 	let nextTimer = 0;
-	const schedule = ((callback: () => void) => {
+	const timerDelays: number[] = [];
+	const schedule = ((callback: () => void, delay = 0) => {
 		const id = ++nextTimer;
 		timers.set(id, callback);
+		timerDelays.push(delay);
 		return id;
 	}) as typeof globalThis.setTimeout;
 	const cancel = ((id: ReturnType<typeof setTimeout>) => {
@@ -277,6 +280,7 @@ function sessionHarness(
 		applied,
 		counters,
 		draws,
+		timerDelays,
 		tick() {
 			const entry = timers.entries().next().value as [number, () => void] | undefined;
 			if (!entry) throw new Error('no timer');
@@ -306,6 +310,139 @@ function emptyGenerated(id = SESSION): ArrayBuffer {
 	frame.set(uuidBytes(id), 1);
 	return frame.buffer;
 }
+
+test('a busy socket retries at a bounded rate after a slow encode and keeps the latest drawing', async (context) => {
+	let now = 0;
+	context.mock.method(performance, 'now', () => now);
+	let resolveEncode!: (image: Uint8Array<ArrayBuffer>) => void;
+	let encodes = 0;
+	let latest = 1;
+	const harness = sessionHarness({
+		encode: () => {
+			encodes += 1;
+			return encodes === 1
+				? new Promise((resolve) => {
+						resolveEncode = resolve;
+					})
+				: Promise.resolve(new Uint8Array([latest]));
+		}
+	});
+	try {
+		harness.session.connect({
+			modelId: 'vega-rt',
+			prompt: 'a cat',
+			params: { structure_strength: 0.5, steps: 10 }
+		});
+		const socket = harness.sockets[0];
+		ready(socket);
+		harness.tick();
+		latest = 2;
+		harness.session.markChanged();
+		socket.bufferedAmount = 1;
+		now = 600;
+		resolveEncode(new Uint8Array([1]));
+		await Promise.resolve();
+		assert.equal(harness.timerDelays.at(-1), 0, 'the first retry can start after an overrun');
+		for (let index = 0; index < 20; index += 1) {
+			harness.tick();
+			const delay = harness.timerDelays.at(-1)!;
+			assert.ok(delay >= 250 && delay <= 500, `blocked retry waited ${delay} ms`);
+			assert.equal(harness.timerCount(), 1);
+		}
+		assert.equal(encodes, 1, 'a busy socket must not trigger another encode');
+		assert.equal(socket.sent.filter((data) => typeof data !== 'string').length, 1);
+		latest = 3;
+		harness.session.markChanged();
+		socket.bufferedAmount = 0;
+		harness.tick();
+		await Promise.resolve();
+		const frames = socket.sent.filter((data) => typeof data !== 'string');
+		assert.equal(frames.length, 2);
+		assert.deepEqual(frames.at(-1), canvasFrame(SESSION, new Uint8Array([3])));
+		assert.equal(harness.timerCount(), 1);
+	} finally {
+		harness.session.destroy();
+	}
+	assert.equal(harness.timerCount(), 0);
+});
+
+test('a slow encode backs off idle ticks, stops, and wakes for a new edit', async (context) => {
+	let now = 0;
+	context.mock.method(performance, 'now', () => now);
+	let encodes = 0;
+	const harness = sessionHarness({
+		encode: async () => {
+			encodes += 1;
+			now = 600;
+			return new Uint8Array([encodes]);
+		}
+	});
+	try {
+		harness.session.connect({
+			modelId: 'vega-rt',
+			prompt: 'a cat',
+			params: { structure_strength: 0.5, steps: 10 }
+		});
+		const socket = harness.sockets[0];
+		ready(socket);
+		harness.tick();
+		await Promise.resolve();
+		assert.equal(harness.timerDelays.at(-1), 0);
+
+		for (let index = 0; index < IDLE_TICKS_BEFORE_STOP - 1; index += 1) {
+			harness.tick();
+			const delay = harness.timerDelays.at(-1)!;
+			assert.ok(delay >= 250 && delay <= 500, `idle retry waited ${delay} ms`);
+			assert.equal(harness.timerCount(), 1);
+		}
+		harness.tick();
+		assert.equal(harness.timerCount(), 0);
+
+		harness.session.markChanged();
+		assert.equal(harness.timerCount(), 1);
+		assert.equal(harness.timerDelays.at(-1), FAST_INTERVAL_MS);
+		harness.tick();
+		await Promise.resolve();
+		assert.equal(encodes, 2);
+		assert.equal(socket.sent.filter((data) => typeof data !== 'string').length, 2);
+	} finally {
+		harness.session.destroy();
+	}
+});
+
+test('an encode failure keeps the drawing pending for a successful retry', async () => {
+	let encodes = 0;
+	const harness = sessionHarness({
+		encode: async () => {
+			encodes += 1;
+			if (encodes === 1) throw new Error('encode');
+			return new Uint8Array([2]);
+		}
+	});
+	try {
+		harness.session.connect({
+			modelId: 'vega-rt',
+			prompt: 'a cat',
+			params: { structure_strength: 0.5, steps: 10 }
+		});
+		const socket = harness.sockets[0];
+		ready(socket);
+		harness.tick();
+		await Promise.resolve();
+		assert.equal(harness.notices.at(-1), 'encode_failed');
+		assert.equal(socket.sent.filter((data) => typeof data !== 'string').length, 0);
+		assert.equal(harness.timerCount(), 1);
+
+		harness.tick();
+		await Promise.resolve();
+		assert.equal(encodes, 2);
+		const frames = socket.sent.filter((data) => typeof data !== 'string');
+		assert.equal(frames.length, 1);
+		assert.deepEqual(frames[0], canvasFrame(SESSION, new Uint8Array([2])));
+	} finally {
+		harness.session.destroy();
+	}
+});
 
 test('an interruption during encode keeps the canvas pending for resume', async () => {
 	let resolveEncode!: (image: Uint8Array<ArrayBuffer>) => void;

--- a/frontend/src/lib/realtime-canvas.ts
+++ b/frontend/src/lib/realtime-canvas.ts
@@ -368,7 +368,7 @@ export function createRealtimeCanvasSession(
 		) {
 			generation.idleTicks += 1;
 			if (generation.idleTicks >= IDLE_TICKS_BEFORE_STOP && !generation.changed) return;
-			armCapture(generation, nextDelayMs(generation.lastFrameCostMs));
+			armCapture(generation, nextIntervalMs(generation.lastFrameCostMs));
 			return;
 		}
 


### PR DESCRIPTION
## Summary

A slow image encode could make the browser retry a busy socket with no delay. A tick that does no work now waits the full capture period instead of subtracting the previous encode cost again.

The latest drawing still sends after the socket clears. The active frame cadence, one-encode limit and wire format stay the same. This is a small part of #42, not the full revision-driven stream or a GPU cost claim.

## Checks

Full local `make verify` passed: 1010 backend tests, 300 worker tests, 117 frontend unit tests and 20 browser tests.

A separate timing probe changed from twenty consecutive 0 ms retries to twenty 500 ms waits after a slow encode. Both traces sent the latest drawing after the socket cleared. Restoring the old line makes the new busy and idle tests fail.

## How to review

1. Check the distinction between a completed encode and a tick that did no work.
2. Check bounded retries, one pending timer, idle stop/wake and failed-encode recovery.
3. Confirm that no wire, worker or billing behavior was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved real-time canvas capture retries when connections are busy, helping preserve the latest drawing.
  - Capture attempts now retry at a bounded pace after slow encoding and recover from temporary encoding failures.
  - Idle capture backs off appropriately and resumes when the drawing is edited.

- **Documentation**
  - Clarified browser capture timing, retry behavior, and the limits of performance-related conclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->