### PR TITLE
Record window 2 SDS-end ratings

### DIFF
--- a/docs/illusion-reliability-60h.md
+++ b/docs/illusion-reliability-60h.md
@@ -1,5 +1,11 @@
 # Illusion Reliability: Author-Reference Campaign
 
+**Not run as the primary window.** The 36-cell `reference60h` plan was
+replaced by the measured yield window in
+[illusion-window.md](illusion-window.md). Keep this file as the record of
+that decision. PR #150 merged the later programme into the optimizer
+branch. PR #118 stays draft. `IllusionConfig` defaults are unchanged.
+
 This is an experiment-only reliability program. It does not change
 `IllusionConfig` defaults, select a new product default, or alter the PR #118
 acceptance gate.

--- a/docs/illusion-reliability-handoff.md
+++ b/docs/illusion-reliability-handoff.md
@@ -4,7 +4,10 @@ This temporary handoff note is superseded by the durable protocol:
 
 [illusion-reliability.md](illusion-reliability.md)
 
-Latest done/tested snapshot for the next agent:
+Results through 2026-09-10: [illusion-window.md](illusion-window.md).
+PR #150 merged into `issue-115-illusion-optimizer`. PR #118 stays draft.
+
+The 2026-07-29 snapshot:
 [illusion-reliability-status.md](illusion-reliability-status.md)
 
 Do not use ad-hoc `/tmp` agent notes as the source of truth for commands.

--- a/docs/illusion-reliability-status.md
+++ b/docs/illusion-reliability-status.md
@@ -1,17 +1,22 @@
 # Illusion reliability - status for next agent
 
-> **SUPERSEDED, last accurate 2026-07-29.** This file predates windows 2, 3, 4 and
-> 5 and its status is five windows out of date. The current state lives in
-> `.local/illusion-reliability/HANDOFF.md` (gitignored, primary checkout), and the
-> results write-up is [illusion-window.md](illusion-window.md). Read those first.
-> What stays useful here is the branch and PR discipline below.
+> **SUPERSEDED as a live status file, last fully accurate 2026-07-29.**
+> This file predates windows 2-7, P0 and P1. Measured results live in
+> [illusion-window.md](illusion-window.md). Pickup for the next agent is
+> `.local/illusion-reliability/HANDOFF.md` (gitignored, primary checkout).
+>
+> **PR #150 merged 2026-09-10** into `issue-115-illusion-optimizer`
+> (merge `019e962`). PR #118 stays draft on `main`. Product defaults stay
+> `legacy`. The cheap-first ladder is complete. P4 is off.
 
 Full protocol: [illusion-reliability.md](illusion-reliability.md).
 
 ## Branch
 
-- Branch: `illusion-reliability-program` (worktree may be used for GPU work)
-- Do **not** cherry-pick into PR #118 or change optimizer defaults yet.
+- Live stack after the merge: `issue-115-illusion-optimizer` (PR #118, still draft).
+- A worktree may still sit on `illusion-reliability-program`. Those commits
+  are in the merge. New work on this stack starts from the optimizer branch.
+- Do **not** merge #118 or change optimizer defaults yet.
 - Authorship: `leonfullxr` / DCO `-s` / no Co-authored-by.
 
 ## Durable local layout (gitignored)

--- a/docs/illusion-reliability.md
+++ b/docs/illusion-reliability.md
@@ -12,7 +12,12 @@ loss curves, and gradient conflict stats are diagnostic until calibrated.
 - DeepFloyd / Visual Anagrams remain research-only (gated non-commercial).
 - Defaults stay `sds_objective=legacy` until the acceptance gate passes.
 
-Progress snapshot (what already passed on the reliability branch):
+Measured results (windows 1-7, P0, P1) are in
+[illusion-window.md](illusion-window.md). PR #150 merged that programme into
+the optimizer branch on 2026-09-10. PR #118 stays draft. This file is the
+harness how-to. The Wave 1 campaign below is historical.
+
+The 2026-07-29 snapshot file is
 [illusion-reliability-status.md](illusion-reliability-status.md).
 
 ## Environment

--- a/docs/illusion-window.md
+++ b/docs/illusion-window.md
@@ -356,7 +356,8 @@ orientations and the printable prime.
 ## Window 2: results
 
 Phase `window2`, 98 entries producing 206 final-stage observations, finished in
-about 44 hours with zero failed cells. Its plan is
+about 44 hours with zero failed cells. SDS-end on the same 98 cells was rated
+2026-09-11 (score only, no frame). Its plan is
 `.local/illusion-reliability/campaigns/window2/PLAN.md`; the decision rules
 below were fixed in writing before any image was seen.
 
@@ -521,17 +522,49 @@ WITHDRAWN, and recorded because it was load-bearing for a day. An earlier versio
 of this section claimed 72 cells across the two windows were reruns of one
 configuration, agreeing at r = 0.10 with keeper status disagreeing 44 percent of
 the time, and concluded that one observation is "close to uninformative". Those
-72 cells match only at the `final` stage, because window 2 rated no other stage,
-and window 1's final is after EIGHT Dream rounds against window 2's one. The
-schedule is the largest effect either window measured, and it appears here as a
-mean shift of 1.19 against 1.81. Matching window 1's `dream_d1` against window
-2's `final` is closer to like-for-like and gives r = 0.196 with 28 of 72
-disagreeing, still crossing two implementations. Neither is a rerun; no
-configuration was ever run twice in either window. The conclusion was also wrong
-in the other direction: run agreement is 85.6 percent, not near-random.
+72 cells match only at the `final` stage, because at write-up time window 2 had
+rated no other stage, and window 1's final is after EIGHT Dream rounds against
+window 2's one. The schedule is the largest effect either window measured, and
+it appears here as a mean shift of 1.19 against 1.81. Matching window 1's
+`dream_d1` against window 2's `final` is closer to like-for-like and gives r =
+0.196 with 28 of 72 disagreeing, still crossing two implementations. Neither is
+a rerun; no configuration was ever run twice in either window. The conclusion
+was also wrong in the other direction: run agreement is 85.6 percent, not
+near-random.
+
+Window 2 SDS-end is now rated, so that hole is filled. The 72-cell final
+comparison stays withdrawn. The SDS-end sitting did not reopen those tables.
 
 What survives is that ranking cells by a single small-n margin ranks noise, which
 is what retired the best-cell hypothesis.
+
+### Window 2 SDS-end, rated 2026-09-11
+
+Zero GPU. 98 of 98 cells, score only. Script:
+`.local/illusion-reliability/campaigns/window2/review/analyse-sds-end.py`.
+
+Unit: one cell. Dream score for a cell is the mean of its negative-OFF finals.
+Forked cells contribute two arms. Unforked cells contribute one. Negative-ON
+is not in the mean. Better-of is not the primary delta.
+
+| Measure | Value |
+|---|---|
+| SDS-end mean | 1.510 |
+| SDS-end keep >= 3 | 40/98 |
+| Dream-mean keep >= 3 | 27/98 |
+| mean paired delta (SDS minus Dream mean) | -0.138 |
+| mean abs paired delta | 1.362 |
+| falsifier, abs(mean delta) >= 0.3 | did not fire |
+
+Histogram: 0x55, 2x3, 3x24, 4x10, 5x6. No frame at this stage. Do not treat a
+missing frame as clean.
+
+Dream-1 on window 2 is a near-tie with SDS-end. That matches window 1 SDS-end
+versus dream_d1 (both mean 0.93). Settled final-stage tables stay closed.
+
+Report only, not a falsifier: window 1 SDS-end at 5,000 steps is 35/180 keep
+>= 3. The corpora differ. Unique (pair, seed) `reference_sketch` match n=36,
+r = 0.700, MAD = 0.838. Not a rerun. Two implementations.
 
 ### The colour rule measured the wrong endpoint
 
@@ -1145,9 +1178,10 @@ which are the pairs that FAILED the >= 3 bar and so are negatively selected.
    an eighth of the cost. Run it only if P2 fails and the failure needs sizing across
    a broad corpus.
 
-**Status, 2026-09-10.** P0, P1, P2, P3 and P3b are complete. P4 stays off:
-P2 did not fail. No GPU window is queued. A new window needs a new question
-and a falsifier.
+**Status, 2026-09-11.** P0, P1, P2, P3 and P3b are complete. P4 stays off:
+P2 did not fail. Window 2 SDS-end is rated: 40/98 keep >= 3, mean paired
+delta -0.138, falsifier did not fire. No GPU window is queued. A new window
+needs a new question and a falsifier.
 
 ## Running it
 

--- a/docs/illusions.md
+++ b/docs/illusions.md
@@ -176,9 +176,10 @@ A/B ratings, and the acceptance gate) are documented in
 [illusion-reliability.md](illusion-reliability.md). Defaults remain legacy
 until that gate passes. Failed experimental modes may stay behind flags for
 reproducibility; they do not become defaults merely because they exist.
-The 60-hour yield window that is the current primary axis is documented in
-[illusion-window.md](illusion-window.md); the author-reference
-campaign it replaced is in
+The measured yield windows and the cheap-first ladder (complete 2026-09-10)
+are in [illusion-window.md](illusion-window.md). That programme landed in
+PR #150, merged into the optimizer branch. PR #118 stays draft. The
+author-reference campaign the window replaced is in
 [illusion-reliability-60h.md](illusion-reliability-60h.md).
 
 ## Fabrication


### PR DESCRIPTION
## Summary

- Records the 2026-09-11 window 2 SDS-end sitting: 40/98 keep >= 3, mean paired delta -0.138. The 0.3 falsifier did not fire.
- Points the older reliability status files at PR 150 on the optimizer branch. PR 118 stays draft. Product defaults stay legacy.

## Test plan

- [x] Local `PYTHONPATH=<worktree>/backend:<worktree>/worker make verify` (lint, 62 backend, 169 worker, svelte-check 0, frontend build)
- [ ] CI on this PR (runners Idle at push)
- Numbers in `docs/illusion-window.md` match `campaigns/window2/review/analyse-sds-end.py` (gitignored script; re-run from `.local`)
